### PR TITLE
Compass: floating cardinals, uniform color, toggleable gradient bg

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -66,6 +66,8 @@
   "hud": {
     "compass_height_px": 60,
     "compass_bottom_margin_px": 20,
+    "compass_bg": false,
+    "compass_bg_opacity": 0.75,
     "panel_width_px": 320,
     "lora_message_history": 50,
     "show_secondary_cams": true,

--- a/src/app_state.h
+++ b/src/app_state.h
@@ -122,7 +122,8 @@ struct AppState {
     size_t                   max_messages = 50;
 
     // Heading used for the HUD compass. Updated by LoRa or IMU.
-    float compass_heading = 0.0f;
+    float compass_heading    = 0.0f;
+    bool  compass_bg_enabled = false;
 
     // Latest IMU pose (NWU coordinates). Updated by XRDisplay IMU callback.
     ImuPose imu_pose;

--- a/src/hud/hud_renderer.cpp
+++ b/src/hud/hud_renderer.cpp
@@ -465,7 +465,18 @@ void HudRenderer::draw_compass_tape(ImDrawList* dl, const AppState& s,
     constexpr ImU32 col_glow1  = IM_COL32(255, 160,  32,  70);
     constexpr ImU32 col_glow2  = IM_COL32(255, 160,  32,  28);
 
+    // Optional gradient background: transparent at top, opaque at bottom
+    if (s.compass_bg_enabled) {
+        const uint8_t a = static_cast<uint8_t>(cfg_.compass_bg_opacity * 255.f);
+        dl->AddRectFilledMultiColor(
+            {origin.x, origin.y}, {origin.x + tw, origin.y + th},
+            IM_COL32(8, 12, 18,  0), IM_COL32(8, 12, 18,  0),  // top: clear
+            IM_COL32(8, 12, 18,  a), IM_COL32(8, 12, 18,  a)); // bottom: solid
+    }
+
     if (font_mono_) ImGui::PushFont(font_mono_);
+
+    // Pass 1 — all tick lines so cardinal labels always render on top
     for (int deg = 0; deg < 360; deg++) {
         float offset = deg - heading;
         while (offset >  180.f) offset -= 360.f;
@@ -475,22 +486,32 @@ void HudRenderer::draw_compass_tape(ImDrawList* dl, const AppState& s,
         if (px < origin.x || px > origin.x + tw) continue;
 
         if (deg % 45 == 0) {
-            // Glow — wide dim halos behind the sharp tick
-            dl->AddLine({px, origin.y + 2.f}, {px, tick_y}, col_glow2, 9.f);
-            dl->AddLine({px, origin.y + 2.f}, {px, tick_y}, col_glow1, 4.f);
-            dl->AddLine({px, origin.y + 2.f}, {px, tick_y}, col_major, 1.5f);
-            dl->AddText({px - 8.f, origin.y + 4.f}, col_major,
-                        cardinal_str(static_cast<float>(deg)));
+            dl->AddLine({px, origin.y}, {px, tick_y}, col_glow2, 9.f);
+            dl->AddLine({px, origin.y}, {px, tick_y}, col_glow1, 4.f);
+            dl->AddLine({px, origin.y}, {px, tick_y}, col_major, 1.5f);
         } else if (deg % 10 == 0) {
             dl->AddLine({px, tick_y - 12.f}, {px, tick_y}, col_mid);
             char buf[8]; snprintf(buf, sizeof(buf), "%d", deg);
-            dl->AddText({px - 8.f, tick_y - 28.f}, col_.text_dim, buf);
+            dl->AddText({px - 8.f, tick_y - 28.f}, col_major, buf);
         } else if (deg % 5 == 0) {
             dl->AddLine({px, tick_y - 8.f}, {px, tick_y}, col_minor);
         }
     }
 
-    // Centre cursor triangle — glow then sharp fill
+    // Pass 2 — cardinal labels float above the tick area
+    for (int deg = 0; deg < 360; deg += 45) {
+        float offset = deg - heading;
+        while (offset >  180.f) offset -= 360.f;
+        while (offset < -180.f) offset += 360.f;
+
+        float px = center_x + offset * ppd;
+        if (px < origin.x || px > origin.x + tw) continue;
+
+        dl->AddText({px - 8.f, origin.y - 16.f}, col_major,
+                    cardinal_str(static_cast<float>(deg)));
+    }
+
+    // Centre cursor triangle — glow halo then sharp fill
     dl->AddTriangleFilled(
         {center_x,        origin.y       },
         {center_x - 12.f, origin.y + 18.f},

--- a/src/hud/hud_renderer.h
+++ b/src/hud/hud_renderer.h
@@ -33,6 +33,7 @@ struct HudColors {
 struct HudConfig {
     int   compass_height        = 72;
     int   compass_bottom_margin = 20;
+    float compass_bg_opacity    = 0.75f;
     int   panel_width           = 200;
     int   top_bar_height        = 52;
     float opacity               = 0.85f;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -340,6 +340,14 @@ static std::vector<MenuItem> build_menu(
         { "Size",         nullptr, make_size_items(android_cfg)     },
     };
 
+    // ── Compass ───────────────────────────────────────────────────────────────
+    std::vector<MenuItem> compass_menu = {
+        { "BG On",  [&state]{ std::lock_guard<std::mutex> lk(state.mtx);
+                               state.compass_bg_enabled = true;  }, {} },
+        { "BG Off", [&state]{ std::lock_guard<std::mutex> lk(state.mtx);
+                               state.compass_bg_enabled = false; }, {} },
+    };
+
     return {
         { "Face Effects",    nullptr, std::move(effects)            },
         { "Face Color",      nullptr, std::move(colors)             },
@@ -348,6 +356,7 @@ static std::vector<MenuItem> build_menu(
         { "Lens Brightness", nullptr, std::move(glasses_brightness) },
         { "Camera",          nullptr, std::move(camera_menu)        },
         { "USB Cameras",     nullptr, std::move(pip_menu)           },
+        { "Compass",         nullptr, std::move(compass_menu)       },
         { "Audio",           nullptr, std::move(audio_menu)         },
         { "Headset",         nullptr, std::move(headset_menu)       },
         { "Android Mirror",  nullptr, std::move(android_menu)       },
@@ -486,6 +495,7 @@ int main(int argc, char* argv[]) {
     HudConfig hud_cfg;
     hud_cfg.compass_height        = jval(jhud, "compass_height_px",        60);
     hud_cfg.compass_bottom_margin = jval(jhud, "compass_bottom_margin_px",  20);
+    hud_cfg.compass_bg_opacity    = jval(jhud, "compass_bg_opacity",        0.75f);
     hud_cfg.panel_width          = jval(jhud, "panel_width_px",       200);
     hud_cfg.health_panel_opacity = jval(jhud, "health_panel_opacity", 0.71f);
     hud_cfg.opacity              = jval(jdisp,"hud_opacity",          0.85f);
@@ -516,7 +526,8 @@ int main(int argc, char* argv[]) {
     // ── Shared state ──────────────────────────────────────────────────────────
 
     AppState state;
-    state.max_messages = jval(jhud, "lora_message_history", 50);
+    state.max_messages        = jval(jhud, "lora_message_history", 50);
+    state.compass_bg_enabled  = jhud.value("compass_bg", false);
 
     if (cfg.contains("night_vision")) {
         auto& jnv = cfg["night_vision"];
@@ -777,8 +788,9 @@ int main(int argc, char* argv[]) {
             snap.audio           = state.audio;
             snap.lora_nodes      = state.lora_nodes;
             snap.lora_messages   = state.lora_messages;
-            snap.compass_heading = state.compass_heading;
-            snap.imu_pose        = state.imu_pose;
+            snap.compass_heading    = state.compass_heading;
+            snap.compass_bg_enabled = state.compass_bg_enabled;
+            snap.imu_pose           = state.imu_pose;
         }
 
         // Record render-time pose for timewarp


### PR DESCRIPTION
- Two-pass rendering: tick lines drawn first, then cardinal labels in a second pass so they always render on top of every tick mark.
- Cardinal labels positioned 16 px above the tape top edge so they visually float clear of the tick area.
- Degree number labels now use col_major (yellow-orange) to match the cardinal label color; previously they used the dim teal color.
- Optional gradient background: transparent at the top edge, opaque at the bottom. Enabled/disabled via Menu → Compass → BG On / BG Off. Initial state and opacity come from config.json (compass_bg, compass_bg_opacity). Runtime toggle writes through state.mtx so it is safe from the menu callback thread.

https://claude.ai/code/session_01TxT4j1se1Vg9GmBmZTJSii