### PR TITLE
USB cameras: per-camera overlay, position, fix open blocking render t…

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -94,8 +94,8 @@
   },
   "pip": {
     "enabled": true,
-    "size": 0.25,
-    "anchor": "top_center",
+    "cam1": { "size": 0.25, "anchor": "top_left"  },
+    "cam2": { "size": 0.25, "anchor": "top_right" },
     "_anchor_values": "top_left | top_center | top_right | bottom_left | bottom_center | bottom_right"
   },
   "audio": {

--- a/src/hud/hud_renderer.cpp
+++ b/src/hud/hud_renderer.cpp
@@ -157,9 +157,9 @@ static ImVec2 overlay_origin(const OverlayConfig& cfg,
 
 // ── PiP ──────────────────────────────────────────────────────────────────────
 
-void HudRenderer::draw_pip(unsigned int tex_usb1, unsigned int tex_usb2,
+void HudRenderer::draw_pip(unsigned int tex, const char* label,
                             int w, int h, bool active, const OverlayConfig& cfg) {
-    if (!active || (!tex_usb1 && !tex_usb2)) return;
+    if (!active) return;
 
     ImGui::SetCurrentContext(ctx_);
     ImDrawList* dl = ImGui::GetForegroundDrawList();
@@ -179,15 +179,16 @@ void HudRenderer::draw_pip(unsigned int tex_usb1, unsigned int tex_usb2,
                       { pos.x + ov_w, pos.y + ov_h },
                       col_.background);
 
-    // Label (top-left corner of the box)
-    if (font_mono_) ImGui::PushFont(font_mono_);
-    dl->AddText({ pos.x + 4.f, pos.y + 4.f }, col_.primary, "USB CAM");
-    if (font_mono_) ImGui::PopFont();
+    // Camera image or dark placeholder
+    if (tex) {
+        dl->AddImage(reinterpret_cast<ImTextureID>(static_cast<uintptr_t>(tex)),
+                     { pos.x, pos.y }, { pos.x + ov_w, pos.y + ov_h });
+    }
 
-    // Camera image
-    GLuint tex = tex_usb1 ? tex_usb1 : tex_usb2;
-    dl->AddImage(reinterpret_cast<ImTextureID>(static_cast<uintptr_t>(tex)),
-                 { pos.x, pos.y }, { pos.x + ov_w, pos.y + ov_h });
+    // Label (always on top so it's visible even with no signal)
+    if (font_mono_) ImGui::PushFont(font_mono_);
+    dl->AddText({ pos.x + 4.f, pos.y + 4.f }, col_.primary, label);
+    if (font_mono_) ImGui::PopFont();
 }
 
 // ── Android mirror overlay ────────────────────────────────────────────────────

--- a/src/hud/hud_renderer.h
+++ b/src/hud/hud_renderer.h
@@ -59,10 +59,11 @@ public:
     // Build all HUD draw commands (pure ImGui DrawList — no GL calls).
     void draw_frame(const AppState& snap, int w, int h);
 
-    // Build PiP draw commands (USB camera overlay, 16:9 aspect).
-    // tex_usb1/tex_usb2: raw GLuint texture IDs. Pass 0 if unavailable.
+    // Build PiP draw commands for a single USB camera overlay (16:9 aspect).
+    // tex: raw GLuint texture ID (0 = no image, shows placeholder).
+    // label: short name shown in the overlay corner.
     // cfg controls anchor position and size as a fraction of screen height.
-    void draw_pip(unsigned int tex_usb1, unsigned int tex_usb2,
+    void draw_pip(unsigned int tex, const char* label,
                   int w, int h, bool active, const OverlayConfig& cfg);
 
     // Build Android mirror overlay (portrait 9:16 aspect).

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -76,7 +76,9 @@ static std::vector<MenuItem> build_menu(
         TeensyController* teensy, XRDisplay* xr, CameraManager* cameras,
         LoRaRadio* lora, SmartKnob* knob, AudioEngine* audio, AppState& state,
         AndroidMirror* android_mirror, bool* android_overlay,
-        OverlayConfig* pip_cfg, OverlayConfig* android_cfg)
+        OverlayConfig* pip_cfg1, OverlayConfig* pip_cfg2,
+        bool* pip_cam1_overlay, bool* pip_cam2_overlay,
+        OverlayConfig* android_cfg)
 {
     (void)lora; (void)knob;
 
@@ -314,18 +316,24 @@ static std::vector<MenuItem> build_menu(
 
     // ── USB camera PiP layout ─────────────────────────────────────────────────
     std::vector<MenuItem> cam1_menu = {
-        { "Open",  [cameras]{ cameras->open_usb1();  }, {} },
-        { "Close", [cameras]{ cameras->close_usb1(); }, {} },
+        { "Open",         [cameras]{ std::thread([cameras]{ cameras->open_usb1(); }).detach(); }, {} },
+        { "Close",        [cameras]{ cameras->close_usb1(); }, {} },
+        { "Show Overlay", [pip_cam1_overlay]{ *pip_cam1_overlay = true;  }, {} },
+        { "Hide Overlay", [pip_cam1_overlay]{ *pip_cam1_overlay = false; }, {} },
+        { "Position",     nullptr, make_position_items(pip_cfg1) },
+        { "Size",         nullptr, make_size_items(pip_cfg1)     },
     };
     std::vector<MenuItem> cam2_menu = {
-        { "Open",  [cameras]{ cameras->open_usb2();  }, {} },
-        { "Close", [cameras]{ cameras->close_usb2(); }, {} },
+        { "Open",         [cameras]{ std::thread([cameras]{ cameras->open_usb2(); }).detach(); }, {} },
+        { "Close",        [cameras]{ cameras->close_usb2(); }, {} },
+        { "Show Overlay", [pip_cam2_overlay]{ *pip_cam2_overlay = true;  }, {} },
+        { "Hide Overlay", [pip_cam2_overlay]{ *pip_cam2_overlay = false; }, {} },
+        { "Position",     nullptr, make_position_items(pip_cfg2) },
+        { "Size",         nullptr, make_size_items(pip_cfg2)     },
     };
     std::vector<MenuItem> pip_menu = {
-        { "Cam 1",    nullptr, std::move(cam1_menu)          },
-        { "Cam 2",    nullptr, std::move(cam2_menu)          },
-        { "Position", nullptr, make_position_items(pip_cfg)  },
-        { "Size",     nullptr, make_size_items(pip_cfg)      },
+        { "Cam 1", nullptr, std::move(cam1_menu) },
+        { "Cam 2", nullptr, std::move(cam2_menu) },
     };
 
     // ── Android mirror ────────────────────────────────────────────────────────
@@ -502,13 +510,23 @@ int main(int argc, char* argv[]) {
     hud_cfg.scale                = jval(jdisp,"hud_scale",            1.0f);
 
     AndroidMirrorConfig and_cfg;
-    OverlayConfig       pip_overlay_cfg;
+    OverlayConfig       pip_overlay_cfg1, pip_overlay_cfg2;
     OverlayConfig       android_overlay_cfg;
 
     if (cfg.contains("pip")) {
         auto& jpip = cfg["pip"];
-        pip_overlay_cfg.size   = jval(jpip, "size",   0.25f);
-        pip_overlay_cfg.anchor = parse_anchor(jpip.value("anchor", std::string("top_center")));
+        // Per-camera configs; fall back to top-level pip values
+        float def_size = jval(jpip, "size", 0.25f);
+        std::string def_anch = jpip.value("anchor", std::string("top_left"));
+
+        auto& jc1 = jpip.contains("cam1") ? jpip["cam1"] : jpip;
+        pip_overlay_cfg1.size   = jval(jc1, "size",   def_size);
+        pip_overlay_cfg1.anchor = parse_anchor(jc1.value("anchor", def_anch));
+
+        std::string def_anch2 = jpip.contains("cam1") ? std::string("top_right") : def_anch;
+        auto& jc2 = jpip.contains("cam2") ? jpip["cam2"] : jpip;
+        pip_overlay_cfg2.size   = jval(jc2, "size",   def_size);
+        pip_overlay_cfg2.anchor = parse_anchor(jc2.value("anchor", def_anch2));
     }
 
     if (cfg.contains("android")) {
@@ -659,9 +677,13 @@ int main(int argc, char* argv[]) {
 
     // ── Menu system ───────────────────────────────────────────────────────────
 
+    bool pip_cam1_overlay_active = false, pip_cam2_overlay_active = false;
+
     MenuSystem menu(build_menu(&teensy, &xr, &cameras, &lora, &knob, &audio, state,
                                &android_mirror, &android_overlay_active,
-                               &pip_overlay_cfg, &android_overlay_cfg));
+                               &pip_overlay_cfg1, &pip_overlay_cfg2,
+                               &pip_cam1_overlay_active, &pip_cam2_overlay_active,
+                               &android_overlay_cfg));
 
     menu.set_detent_callback([&knob, &menu](int count) {
         knob.set_detents(count);
@@ -872,12 +894,14 @@ int main(int argc, char* argv[]) {
         hud.draw_frame(snap, xr.eye_width(), xr.eye_height());
         menu.draw(xr.eye_width(), xr.eye_height());
 
-        if (pip_left_active || pip_right_active) {
-            hud.draw_pip(tex_usb1, tex_usb2,
-                         xr.eye_width(), xr.eye_height(),
-                         pip_left_active || pip_right_active,
-                         pip_overlay_cfg);
-        }
+        hud.draw_pip(tex_usb1, "Cam 1",
+                     xr.eye_width(), xr.eye_height(),
+                     pip_cam1_overlay_active || pip_left_active,
+                     pip_overlay_cfg1);
+        hud.draw_pip(tex_usb2, "Cam 2",
+                     xr.eye_width(), xr.eye_height(),
+                     pip_cam2_overlay_active || pip_right_active,
+                     pip_overlay_cfg2);
 
         hud.draw_android_overlay(tex_android,
                                   xr.eye_width(), xr.eye_height(),


### PR DESCRIPTION
…hread

draw_pip now takes a single texture + label and is called once per camera, allowing each camera its own OverlayConfig (position, size) and independent show/hide state.

Fixes:
- open_usb1/2 now runs on a detached thread so the render loop doesn't freeze while the V4L2 device initialises (same pattern as Android mirror)

Menu (USB Cameras → Cam 1 / Cam 2):
  Open / Close / Show Overlay / Hide Overlay / Position / Size

Show Overlay sets a menu-controlled flag; GPIO buttons (pip_left/right) are OR-ed in so both control paths remain active independently.

config.json: pip.cam1 and pip.cam2 sub-objects set per-camera defaults (top_left / top_right); the parser falls back to pip-level values if the sub-objects are absent.

https://claude.ai/code/session_01TxT4j1se1Vg9GmBmZTJSii