### PR TITLE
compass: widen background with configurable side fades + gradient on …

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -68,6 +68,7 @@
     "compass_bottom_margin_px": 20,
     "compass_bg": false,
     "compass_bg_opacity": 0.75,
+    "compass_bg_side_fade_px": 80,
     "panel_width_px": 320,
     "lora_message_history": 50,
     "show_secondary_cams": true,

--- a/src/hud/hud_renderer.cpp
+++ b/src/hud/hud_renderer.cpp
@@ -466,13 +466,22 @@ void HudRenderer::draw_compass_tape(ImDrawList* dl, const AppState& s,
     constexpr ImU32 col_glow1  = IM_COL32(255, 160,  32,  70);
     constexpr ImU32 col_glow2  = IM_COL32(255, 160,  32,  28);
 
-    // Optional gradient background: transparent at top, opaque at bottom
+    // Optional gradient background: transparent at top and outer edges, opaque at bottom.
+    // Three strips so the left and right sides also fade in from transparent.
     if (s.compass_bg_enabled) {
-        const uint8_t a = static_cast<uint8_t>(cfg_.compass_bg_opacity * 255.f);
+        const uint8_t a  = static_cast<uint8_t>(cfg_.compass_bg_opacity * 255.f);
+        const float   fw = static_cast<float>(cfg_.compass_bg_side_fade);
+        const ImU32   T  = IM_COL32(8, 12, 18, 0);
+        const ImU32   A  = IM_COL32(8, 12, 18, a);
+        // Left strip: fully transparent outer edge, opaque only at inner-bottom corner
         dl->AddRectFilledMultiColor(
-            {origin.x, origin.y}, {origin.x + tw, origin.y + th},
-            IM_COL32(8, 12, 18,  0), IM_COL32(8, 12, 18,  0),  // top: clear
-            IM_COL32(8, 12, 18,  a), IM_COL32(8, 12, 18,  a)); // bottom: solid
+            {origin.x - fw, origin.y}, {origin.x,       origin.y + th}, T, T, A, T);
+        // Center: transparent top, opaque bottom
+        dl->AddRectFilledMultiColor(
+            {origin.x,      origin.y}, {origin.x + tw,  origin.y + th}, T, T, A, A);
+        // Right strip: opaque only at inner-bottom corner, fully transparent outer edge
+        dl->AddRectFilledMultiColor(
+            {origin.x + tw, origin.y}, {origin.x + tw + fw, origin.y + th}, T, T, T, A);
     }
 
     if (font_mono_) ImGui::PushFont(font_mono_);

--- a/src/hud/hud_renderer.h
+++ b/src/hud/hud_renderer.h
@@ -34,6 +34,7 @@ struct HudConfig {
     int   compass_height        = 72;
     int   compass_bottom_margin = 20;
     float compass_bg_opacity    = 0.75f;
+    int   compass_bg_side_fade  = 80;    // extra px on each side; also the fade zone width
     int   panel_width           = 200;
     int   top_bar_height        = 52;
     float opacity               = 0.85f;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -504,6 +504,7 @@ int main(int argc, char* argv[]) {
     hud_cfg.compass_height        = jval(jhud, "compass_height_px",        60);
     hud_cfg.compass_bottom_margin = jval(jhud, "compass_bottom_margin_px",  20);
     hud_cfg.compass_bg_opacity    = jval(jhud, "compass_bg_opacity",        0.75f);
+    hud_cfg.compass_bg_side_fade  = jval(jhud, "compass_bg_side_fade_px",   80);
     hud_cfg.panel_width          = jval(jhud, "panel_width_px",       200);
     hud_cfg.health_panel_opacity = jval(jhud, "health_panel_opacity", 0.71f);
     hud_cfg.opacity              = jval(jdisp,"hud_opacity",          0.85f);


### PR DESCRIPTION
…all three sides

Replaces the single-rect compass background with three strips so the left and right edges fade in from transparent, matching the existing top-to-bottom gradient. The fade width is configurable as compass_bg_side_fade_px in config.json (default 80 px). HudConfig gains the matching compass_bg_side_fade field loaded in main.cpp.

https://claude.ai/code/session_01TxT4j1se1Vg9GmBmZTJSii