### PR TITLE
usb cameras: fix overlay not showing on Open; fix spurious red health…

### DIFF
--- a/src/camera/camera_manager.cpp
+++ b/src/camera/camera_manager.cpp
@@ -114,11 +114,13 @@ void CameraManager::usb_capture_thread() {
         bool got_frame = false;
         {
             std::lock_guard<std::mutex> lk(cap_mtx);
-            if (!cap.isOpened()) return false;
-            if (!cap.read(frame) || frame.empty()) { ok_flag = false; return true; }
-            cv::cvtColor(frame, rgba, cv::COLOR_BGR2RGBA);
-            got_frame = true;
-            ok_flag   = true;
+            if (!cap.isOpened()) { ok_flag = false; return false; }
+            cap.read(frame);
+            if (!frame.empty()) {
+                cv::cvtColor(frame, rgba, cv::COLOR_BGR2RGBA);
+                got_frame = true;
+            }
+            // Don't clear ok_flag on a dropped frame — only when device closes
         }
         if (got_frame) {
             std::lock_guard<std::mutex> lk(slot.mtx);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -316,16 +316,28 @@ static std::vector<MenuItem> build_menu(
 
     // ── USB camera PiP layout ─────────────────────────────────────────────────
     std::vector<MenuItem> cam1_menu = {
-        { "Open",         [cameras]{ std::thread([cameras]{ cameras->open_usb1(); }).detach(); }, {} },
-        { "Close",        [cameras]{ cameras->close_usb1(); }, {} },
+        { "Open",         [cameras, pip_cam1_overlay]{
+                              std::thread([cameras, pip_cam1_overlay]{
+                                  cameras->open_usb1();
+                                  *pip_cam1_overlay = true;
+                              }).detach(); }, {} },
+        { "Close",        [cameras, pip_cam1_overlay]{
+                              cameras->close_usb1();
+                              *pip_cam1_overlay = false; }, {} },
         { "Show Overlay", [pip_cam1_overlay]{ *pip_cam1_overlay = true;  }, {} },
         { "Hide Overlay", [pip_cam1_overlay]{ *pip_cam1_overlay = false; }, {} },
         { "Position",     nullptr, make_position_items(pip_cfg1) },
         { "Size",         nullptr, make_size_items(pip_cfg1)     },
     };
     std::vector<MenuItem> cam2_menu = {
-        { "Open",         [cameras]{ std::thread([cameras]{ cameras->open_usb2(); }).detach(); }, {} },
-        { "Close",        [cameras]{ cameras->close_usb2(); }, {} },
+        { "Open",         [cameras, pip_cam2_overlay]{
+                              std::thread([cameras, pip_cam2_overlay]{
+                                  cameras->open_usb2();
+                                  *pip_cam2_overlay = true;
+                              }).detach(); }, {} },
+        { "Close",        [cameras, pip_cam2_overlay]{
+                              cameras->close_usb2();
+                              *pip_cam2_overlay = false; }, {} },
         { "Show Overlay", [pip_cam2_overlay]{ *pip_cam2_overlay = true;  }, {} },
         { "Hide Overlay", [pip_cam2_overlay]{ *pip_cam2_overlay = false; }, {} },
         { "Position",     nullptr, make_position_items(pip_cfg2) },
@@ -678,7 +690,9 @@ int main(int argc, char* argv[]) {
 
     // ── Menu system ───────────────────────────────────────────────────────────
 
-    bool pip_cam1_overlay_active = false, pip_cam2_overlay_active = false;
+    // Auto-show overlay for cameras that opened successfully at startup
+    bool pip_cam1_overlay_active = cameras.usb1_ok();
+    bool pip_cam2_overlay_active = cameras.usb2_ok();
 
     MenuSystem menu(build_menu(&teensy, &xr, &cameras, &lora, &knob, &audio, state,
                                &android_mirror, &android_overlay_active,


### PR DESCRIPTION
… status

- Open menu item now also sets overlay active (and Close hides it), so a single click both opens the device and shows the PiP — no more needing a separate Show Overlay step.
- Cameras that open successfully at startup auto-show their overlay.
- Capture thread no longer flips health red on a dropped frame; ok_flag only clears when the VideoCapture is actually closed/released.

https://claude.ai/code/session_01TxT4j1se1Vg9GmBmZTJSii