### PR TITLE
input: fix keyboard pip keys clobbered by GPIO; add no-signal text in…

### DIFF
--- a/src/hud/hud_renderer.cpp
+++ b/src/hud/hud_renderer.cpp
@@ -179,13 +179,19 @@ void HudRenderer::draw_pip(unsigned int tex, const char* label,
                       { pos.x + ov_w, pos.y + ov_h },
                       col_.background);
 
-    // Camera image or dark placeholder
+    // Camera image or "No Signal" placeholder
     if (tex) {
         dl->AddImage(reinterpret_cast<ImTextureID>(static_cast<uintptr_t>(tex)),
                      { pos.x, pos.y }, { pos.x + ov_w, pos.y + ov_h });
+    } else {
+        if (font_mono_) ImGui::PushFont(font_mono_);
+        const char* msg = "No Signal";
+        dl->AddText({ pos.x + ov_w * 0.5f - 36.f, pos.y + ov_h * 0.5f - 7.f },
+                    col_.text_dim, msg);
+        if (font_mono_) ImGui::PopFont();
     }
 
-    // Label (always on top so it's visible even with no signal)
+    // Label (top-left corner, always visible)
     if (font_mono_) ImGui::PushFont(font_mono_);
     dl->AddText({ pos.x + 4.f, pos.y + 4.f }, col_.primary, label);
     if (font_mono_) ImGui::PopFont();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -735,7 +735,8 @@ int main(int argc, char* argv[]) {
     int pip_trigger_ms  = jval(cfg.contains("gpio") ? cfg["gpio"] : empty, "pip_trigger_time_ms",2000);
 
     GpioButtons buttons(button_1_gpio, button_2_gpio, button_3_gpio, af_trigger_ms, pip_trigger_ms);
-    bool pip_left_active = false, pip_right_active = false;
+    bool pip_left_active  = false, pip_right_active  = false;  // GPIO-driven
+    bool kb_pip_left      = false, kb_pip_right      = false;  // keyboard-driven
 
     if (gpio_enabled) {
         if (buttons.init()) {
@@ -813,9 +814,10 @@ int main(int argc, char* argv[]) {
         // 1/2 = toggle PiP left/right   (short-press buttons 1/2)
         // 3   = menu select             (button 3 / aux)
         // 4/5 = autofocus left/right    (long-press buttons 1/2)
+        // kb_pip_* are independent of gpio; GPIO does not overwrite them.
         if (!menu.is_open()) {
-            if (key_pressed(ImGuiKey_1)) pip_left_active  = !pip_left_active;
-            if (key_pressed(ImGuiKey_2)) pip_right_active = !pip_right_active;
+            if (key_pressed(ImGuiKey_1)) kb_pip_left  = !kb_pip_left;
+            if (key_pressed(ImGuiKey_2)) kb_pip_right = !kb_pip_right;
         }
         if (key_pressed(ImGuiKey_3) && menu.is_open()) menu.select();
         if (key_pressed(ImGuiKey_4)) {
@@ -929,11 +931,11 @@ int main(int argc, char* argv[]) {
 
         hud.draw_pip(tex_usb1, "Cam 1",
                      xr.eye_width(), xr.eye_height(),
-                     pip_cam1_overlay_active || pip_left_active,
+                     pip_cam1_overlay_active || pip_left_active || kb_pip_left,
                      pip_overlay_cfg1);
         hud.draw_pip(tex_usb2, "Cam 2",
                      xr.eye_width(), xr.eye_height(),
-                     pip_cam2_overlay_active || pip_right_active,
+                     pip_cam2_overlay_active || pip_right_active || kb_pip_right,
                      pip_overlay_cfg2);
 
         hud.draw_android_overlay(tex_android,


### PR DESCRIPTION
… PiP

GPIO block ran every frame and wrote pip_left/right_active = false, so keyboard toggles lasted exactly one frame. Fix: keyboard uses separate kb_pip_left / kb_pip_right booleans that GPIO never touches; draw_pip ORs all three sources (menu overlay, GPIO, keyboard).

Also adds a "No Signal" message centred in the PiP box when no texture is available, so it's obvious when the overlay is active but the camera hasn't produced a frame yet.

https://claude.ai/code/session_01TxT4j1se1Vg9GmBmZTJSii