### PR TITLE
input: switch to direct glfwGetKey polling with edge detection

### DIFF
--- a/src/hud/hud_renderer.cpp
+++ b/src/hud/hud_renderer.cpp
@@ -8,6 +8,7 @@
 #include <cmath>
 #include <ctime>
 #include <cstring>
+#include <iostream>
 #include <algorithm>
 #include <sstream>
 #include <iomanip>
@@ -160,6 +161,10 @@ static ImVec2 overlay_origin(const OverlayConfig& cfg,
 void HudRenderer::draw_pip(unsigned int tex, const char* label,
                             int w, int h, bool active, const OverlayConfig& cfg) {
     if (!active) return;
+    // One-shot diagnostic: confirm overlay is actually being rendered
+    { static bool once = false; if (!once) { once = true;
+        std::cerr << "[pip] " << label << " overlay active, tex=" << tex
+                  << " sw=" << w << " sh=" << h << "\n"; } }
 
     ImGui::SetCurrentContext(ctx_);
     ImDrawList* dl = ImGui::GetForegroundDrawList();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -738,6 +738,9 @@ int main(int argc, char* argv[]) {
     bool pip_left_active  = false, pip_right_active  = false;  // GPIO-driven
     bool kb_pip_left      = false, kb_pip_right      = false;  // keyboard-driven
 
+    // Edge-detection state for direct GLFW key polling (keys 1-5)
+    bool prev_key[6] = {};  // indexed by key number 1-5
+
     if (gpio_enabled) {
         if (buttons.init()) {
             buttons.on_af_left([&cameras]() {
@@ -810,21 +813,26 @@ int main(int argc, char* argv[]) {
             pip_right_active = buttons.pip_right_active();
         }
 
-        // ── Keyboard button emulation (number keys) ───────────────────────────
-        // 1/2 = toggle PiP left/right   (short-press buttons 1/2)
-        // 3   = menu select             (button 3 / aux)
-        // 4/5 = autofocus left/right    (long-press buttons 1/2)
-        // kb_pip_* are independent of gpio; GPIO does not overwrite them.
-        if (!menu.is_open()) {
-            if (key_pressed(ImGuiKey_1)) kb_pip_left  = !kb_pip_left;
-            if (key_pressed(ImGuiKey_2)) kb_pip_right = !kb_pip_right;
-        }
-        if (key_pressed(ImGuiKey_3) && menu.is_open()) menu.select();
-        if (key_pressed(ImGuiKey_4)) {
-            if (cameras.owl_left())  cameras.owl_left()->start_autofocus();
-        }
-        if (key_pressed(ImGuiKey_5)) {
-            if (cameras.owl_right()) cameras.owl_right()->start_autofocus();
+        // ── Keyboard button emulation (number keys, direct GLFW polling) ─────
+        // Uses glfwGetKey() directly — independent of ImGui key mapping and
+        // the glfwPollEvents/begin_frame ordering.  Edge detection via prev_key[].
+        // 1/2 = toggle PiP left/right   4/5 = autofocus left/right
+        // 3   = menu select
+        {
+            GLFWwindow* win = static_cast<GLFWwindow*>(xr.glfw_window());
+            auto edge = [&](int n, int glfw_key) -> bool {
+                bool now = (glfwGetKey(win, glfw_key) == GLFW_PRESS);
+                bool fired = now && !prev_key[n];
+                prev_key[n] = now;
+                return fired;
+            };
+            if (!menu.is_open()) {
+                if (edge(1, GLFW_KEY_1)) kb_pip_left  = !kb_pip_left;
+                if (edge(2, GLFW_KEY_2)) kb_pip_right = !kb_pip_right;
+            }
+            if (edge(3, GLFW_KEY_3) && menu.is_open()) menu.select();
+            if (edge(4, GLFW_KEY_4) && cameras.owl_left())  cameras.owl_left()->start_autofocus();
+            if (edge(5, GLFW_KEY_5) && cameras.owl_right()) cameras.owl_right()->start_autofocus();
         }
 
         // ── USB camera / Android mirror health update ─────────────────────────


### PR DESCRIPTION
Replaces ImGui::IsKeyPressed() for number keys with glfwGetKey() + manual rising-edge detection, which is independent of ImGui's key mapping table and the glfwPollEvents/begin_frame ordering. prev_key[] tracks the previous state for each key 1-5 so toggling fires exactly once per physical press.

Also adds a one-shot stderr diagnostic in draw_pip that prints the first time a given overlay goes active, confirming it reaches the renderer and what screen dimensions are in use.

https://claude.ai/code/session_01TxT4j1se1Vg9GmBmZTJSii