### PR TITLE
cameras: negotiate MJPEG format on open; log negotiated resolution

### DIFF
--- a/src/camera/camera_manager.cpp
+++ b/src/camera/camera_manager.cpp
@@ -14,6 +14,30 @@
 CameraManager::CameraManager()  = default;
 CameraManager::~CameraManager() { shutdown(); }
 
+// Shared helper: open a V4L2 device, negotiate MJPEG + requested resolution,
+// log what was actually accepted by the driver.
+static bool open_v4l2(cv::VideoCapture& cap, const UsbCamConfig& cfg,
+                      const char* name) {
+    cap.open(cfg.device, cv::CAP_V4L2);
+    if (!cap.isOpened()) {
+        std::cerr << "[cam] " << name << ": open failed (" << cfg.device
+                  << ") — wrong path or no permission\n";
+        return false;
+    }
+    // Prefer MJPEG: far wider camera support and lower USB bandwidth than raw YUV.
+    cap.set(cv::CAP_PROP_FOURCC, cv::VideoWriter::fourcc('M','J','P','G'));
+    cap.set(cv::CAP_PROP_FRAME_WIDTH,  cfg.width);
+    cap.set(cv::CAP_PROP_FRAME_HEIGHT, cfg.height);
+    cap.set(cv::CAP_PROP_FPS,          cfg.fps);
+    // Log what the driver actually negotiated (may differ from requested)
+    int aw = static_cast<int>(cap.get(cv::CAP_PROP_FRAME_WIDTH));
+    int ah = static_cast<int>(cap.get(cv::CAP_PROP_FRAME_HEIGHT));
+    int af = static_cast<int>(cap.get(cv::CAP_PROP_FPS));
+    std::cerr << "[cam] " << name << ": opened " << cfg.device
+              << " — negotiated " << aw << "x" << ah << " @" << af << "fps\n";
+    return true;
+}
+
 bool CameraManager::init(const CamConfig& left, const CamConfig& right,
                          const UsbCamConfig& usb1, const UsbCamConfig& usb2,
                          const char* nv12_vs, const char* nv12_fs) {
@@ -46,23 +70,8 @@ bool CameraManager::init(const CamConfig& left, const CamConfig& right,
     usb1_cfg_ = usb1;
     usb2_cfg_ = usb2;
 
-    auto open_cap = [](cv::VideoCapture& cap, const UsbCamConfig& cfg,
-                       const char* name) -> bool {
-        if (cfg.device.empty()) return false;
-        std::cerr << "[cam] " << name << ": opening " << cfg.device << " at startup\n";
-        cap.open(cfg.device, cv::CAP_V4L2);
-        if (!cap.isOpened()) {
-            std::cerr << "[cam] " << name << ": startup open failed\n";
-            return false;
-        }
-        cap.set(cv::CAP_PROP_FRAME_WIDTH,  cfg.width);
-        cap.set(cv::CAP_PROP_FRAME_HEIGHT, cfg.height);
-        cap.set(cv::CAP_PROP_FPS,          cfg.fps);
-        std::cerr << "[cam] " << name << ": startup open ok\n";
-        return true;
-    };
-    usb1_ok_ = open_cap(usb_cap1_, usb1, "usb1");
-    usb2_ok_ = open_cap(usb_cap2_, usb2, "usb2");
+    usb1_ok_ = !usb1.device.empty() && open_v4l2(usb_cap1_, usb1, "usb1");
+    usb2_ok_ = !usb2.device.empty() && open_v4l2(usb_cap2_, usb2, "usb2");
 
     // Start thread whenever USB devices are configured so open/close can work
     // later even if the cameras were not available at startup.
@@ -152,23 +161,12 @@ void CameraManager::usb_capture_thread() {
 void CameraManager::open_usb1() {
     std::lock_guard<std::mutex> lk(usb1_cap_mtx_);
     if (usb1_cfg_.device.empty()) {
-        std::cerr << "[cam] usb1: no device path configured\n"; return;
+        std::cerr << "[cam] usb1: no device configured\n"; return;
     }
     if (usb_cap1_.isOpened()) {
         std::cerr << "[cam] usb1: already open\n"; return;
     }
-    std::cerr << "[cam] usb1: opening " << usb1_cfg_.device << "\n";
-    usb_cap1_.open(usb1_cfg_.device, cv::CAP_V4L2);
-    if (!usb_cap1_.isOpened()) {
-        std::cerr << "[cam] usb1: open failed — check device path and permissions\n";
-        usb1_ok_ = false; return;
-    }
-    usb_cap1_.set(cv::CAP_PROP_FRAME_WIDTH,  usb1_cfg_.width);
-    usb_cap1_.set(cv::CAP_PROP_FRAME_HEIGHT, usb1_cfg_.height);
-    usb_cap1_.set(cv::CAP_PROP_FPS,          usb1_cfg_.fps);
-    usb1_ok_ = true;
-    std::cerr << "[cam] usb1: open ok (" << usb1_cfg_.width
-              << "x" << usb1_cfg_.height << " @" << usb1_cfg_.fps << "fps)\n";
+    usb1_ok_ = open_v4l2(usb_cap1_, usb1_cfg_, "usb1");
 }
 
 void CameraManager::close_usb1() {
@@ -181,23 +179,12 @@ void CameraManager::close_usb1() {
 void CameraManager::open_usb2() {
     std::lock_guard<std::mutex> lk(usb2_cap_mtx_);
     if (usb2_cfg_.device.empty()) {
-        std::cerr << "[cam] usb2: no device path configured\n"; return;
+        std::cerr << "[cam] usb2: no device configured\n"; return;
     }
     if (usb_cap2_.isOpened()) {
         std::cerr << "[cam] usb2: already open\n"; return;
     }
-    std::cerr << "[cam] usb2: opening " << usb2_cfg_.device << "\n";
-    usb_cap2_.open(usb2_cfg_.device, cv::CAP_V4L2);
-    if (!usb_cap2_.isOpened()) {
-        std::cerr << "[cam] usb2: open failed — check device path and permissions\n";
-        usb2_ok_ = false; return;
-    }
-    usb_cap2_.set(cv::CAP_PROP_FRAME_WIDTH,  usb2_cfg_.width);
-    usb_cap2_.set(cv::CAP_PROP_FRAME_HEIGHT, usb2_cfg_.height);
-    usb_cap2_.set(cv::CAP_PROP_FPS,          usb2_cfg_.fps);
-    usb2_ok_ = true;
-    std::cerr << "[cam] usb2: open ok (" << usb2_cfg_.width
-              << "x" << usb2_cfg_.height << " @" << usb2_cfg_.fps << "fps)\n";
+    usb2_ok_ = open_v4l2(usb_cap2_, usb2_cfg_, "usb2");
 }
 
 void CameraManager::close_usb2() {


### PR DESCRIPTION
Most USB cameras don't support uncompressed YUV at 720p/30 over USB bandwidth, but do support MJPEG. Set CAP_PROP_FOURCC=MJPEG before requesting resolution and FPS so the driver picks the right mode. After open, log the resolution/fps the driver actually accepted so mismatches are visible in the terminal.

Consolidates all V4L2 open logic into a single open_v4l2() helper used by both startup and menu Open.

https://claude.ai/code/session_01TxT4j1se1Vg9GmBmZTJSii