### PR TITLE
config: update USB camera paths to /dev/video17 and /dev/video18

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -26,13 +26,13 @@
       "flip_v": false
     },
     "usb_cam_1": {
-      "device": "/dev/video2",
+      "device": "/dev/video17",
       "width": 1280,
       "height": 720,
       "fps": 30
     },
     "usb_cam_2": {
-      "device": "/dev/video3",
+      "device": "/dev/video18",
       "width": 1280,
       "height": 720,
       "fps": 30


### PR DESCRIPTION
libcamera/rp1-cfe occupies video0-16 on this CM5. The Logitech C920 cameras enumerate at video17 and video18.

https://claude.ai/code/session_01TxT4j1se1Vg9GmBmZTJSii