### PR TITLE
Fix ImGui v1.91.0 API name mismatches

### DIFF
--- a/src/hud/hud_renderer.cpp
+++ b/src/hud/hud_renderer.cpp
@@ -197,7 +197,7 @@ void HudRenderer::draw_pip(unsigned int tex, const char* label,
         ImGuiWindowFlags_NoInputs             |
         ImGuiWindowFlags_NoMove               |
         ImGuiWindowFlags_NoNav                |
-        ImGuiWindowFlags_NoBringToDisplayFront|
+        ImGuiWindowFlags_NoBringToFrontOnFocus|
         ImGuiWindowFlags_NoSavedSettings);
     ImDrawList* dl = ImGui::GetWindowDrawList();
 
@@ -305,7 +305,7 @@ void HudRenderer::draw_android_overlay(unsigned int tex, int w, int h,
         ImGuiWindowFlags_NoInputs             |
         ImGuiWindowFlags_NoMove               |
         ImGuiWindowFlags_NoNav                |
-        ImGuiWindowFlags_NoBringToDisplayFront|
+        ImGuiWindowFlags_NoBringToFrontOnFocus|
         ImGuiWindowFlags_NoSavedSettings);
     ImDrawList* dl = ImGui::GetWindowDrawList();
 

--- a/src/menu/menu_system.cpp
+++ b/src/menu/menu_system.cpp
@@ -109,7 +109,6 @@ void MenuSystem::draw(int screen_w, int screen_h) {
     constexpr ImU32 COL_ORANGE = IM_COL32(255, 160,  32, 255);
     constexpr ImU32 COL_SEP    = IM_COL32(255, 160,  32,  45);
 
-    ImGui::SetNextWindowBringToDisplayFront();
     ImGui::SetNextWindowPos ({ x, y }, ImGuiCond_Always);
     ImGui::SetNextWindowSize({ width, total_h }, ImGuiCond_Always);
     ImGui::SetNextWindowBgAlpha(0.88f);
@@ -140,8 +139,7 @@ void MenuSystem::draw(int screen_w, int screen_h) {
 
         // Empty-label selectable — provides background highlight + click detection
         char id[32]; snprintf(id, sizeof(id), "##item%d", i);
-        if (ImGui::Selectable(id, selected,
-                              ImGuiSelectableFlags_SpanAvailWidth,
+        if (ImGui::Selectable(id, selected, 0,
                               ImVec2(0.f, item_h - 1.f))) {
             cursor_ = i;
             select();


### PR DESCRIPTION
- NoBringToDisplayFront → NoBringToFrontOnFocus (correct v1.91 flag name)
- Remove SetNextWindowBringToDisplayFront() (not in v1.91; not needed since pip/android windows have NoBringToFrontOnFocus)
- SpanAvailWidth → 0 (not in v1.91; size x=0 already spans available width)

https://claude.ai/code/session_01TxT4j1se1Vg9GmBmZTJSii