### PR TITLE
android: add --no-playback for scrcpy 2.x/3.x compatibility

### DIFF
--- a/src/android/android_mirror.cpp
+++ b/src/android/android_mirror.cpp
@@ -91,6 +91,7 @@ bool AndroidMirror::spawn_scrcpy() {
         "scrcpy",
         "--no-audio",      // audio is handled by the spatial audio engine
         "--no-control",    // read-only mirror; disables touch/input injection
+        "--no-playback",   // don't open a preview window (scrcpy 2.x+)
         "--video-codec=h264",
         max_size_arg,
         v4l2_arg,


### PR DESCRIPTION
scrcpy 2.0+ removed --no-display; --no-playback is the replacement. Without it scrcpy opens a stray preview window alongside ProtoHUD.

https://claude.ai/code/session_01TxT4j1se1Vg9GmBmZTJSii