### PR TITLE
android: fix aspect ratio, add reconnect, keep phone awake

### DIFF
--- a/src/android/android_mirror.cpp
+++ b/src/android/android_mirror.cpp
@@ -59,13 +59,25 @@ bool AndroidMirror::get_frame(GLuint& out) {
 
 void AndroidMirror::capture_loop() {
     cv::Mat frame, rgba;
+    int fail_streak = 0;
     while (running_) {
         if (!cap_.read(frame) || frame.empty()) {
             connected_ = false;
-            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+            if (++fail_streak > 50) {
+                // ~5 s of failures — reopen the v4l2 device in case scrcpy restarted
+                cap_.release();
+                std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+                cap_.open(cfg_.v4l2_sink, cv::CAP_V4L2);
+                fail_streak = 0;
+            } else {
+                std::this_thread::sleep_for(std::chrono::milliseconds(100));
+            }
             continue;
         }
-        connected_ = true;
+        fail_streak = 0;
+        connected_  = true;
+        if (frame.cols > 0 && frame.rows > 0)
+            frame_aspect_.store(static_cast<float>(frame.cols) / static_cast<float>(frame.rows));
         cv::cvtColor(frame, rgba, cv::COLOR_BGR2RGBA);
         {
             std::lock_guard<std::mutex> lk(slot_.mtx);
@@ -92,6 +104,7 @@ bool AndroidMirror::spawn_scrcpy() {
         "--no-audio",      // audio is handled by the spatial audio engine
         "--no-control",    // read-only mirror; disables touch/input injection
         "--no-playback",   // don't open a preview window (scrcpy 2.x+)
+        "--stay-awake",    // prevent phone screen from sleeping while mirroring
         "--video-codec=h264",
         max_size_arg,
         v4l2_arg,

--- a/src/android/android_mirror.h
+++ b/src/android/android_mirror.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <thread>
 #include <vector>
+#include <cstdint>
 
 #include <GLES2/gl2.h>
 #include <opencv2/videoio.hpp>
@@ -40,8 +41,10 @@ public:
     // Stops capture thread and kills scrcpy. Idempotent.
     void stop();
 
-    bool is_running()   const { return running_;   }
-    bool is_connected() const { return connected_; }
+    bool  is_running()    const { return running_;   }
+    bool  is_connected()  const { return connected_; }
+    // Aspect ratio (w/h) of the live frame; 9/16 until first frame arrives.
+    float frame_aspect()  const { return frame_aspect_.load(); }
 
     // Render-thread only: upload latest frame to a GL texture.
     // Returns true if a new frame was uploaded. out is always set to
@@ -71,6 +74,7 @@ private:
 
     cv::VideoCapture  cap_;
     std::thread       thread_;
-    std::atomic<bool> running_   { false };
-    std::atomic<bool> connected_ { false };
+    std::atomic<bool>  running_      { false };
+    std::atomic<bool>  connected_   { false };
+    std::atomic<float> frame_aspect_{ 9.f / 16.f };
 };

--- a/src/hud/hud_renderer.cpp
+++ b/src/hud/hud_renderer.cpp
@@ -285,7 +285,8 @@ void HudRenderer::draw_pip(unsigned int tex, const char* label,
 
 void HudRenderer::draw_android_overlay(unsigned int tex, int w, int h,
                                         bool active, bool connecting,
-                                        const OverlayConfig& cfg) {
+                                        const OverlayConfig& cfg,
+                                        float frame_aspect) {
     if (!active) return;
 
     ImGui::SetCurrentContext(ctx_);
@@ -293,7 +294,7 @@ void HudRenderer::draw_android_overlay(unsigned int tex, int w, int h,
     const float sw     = static_cast<float>(w);
     const float sh     = static_cast<float>(h);
     const float ov_h   = sh * cfg.size;
-    const float ov_w   = ov_h * (9.f / 16.f);   // phone portrait aspect
+    const float ov_w   = ov_h * frame_aspect;
     const float margin = static_cast<float>(cfg_.compass_height);
     const auto  pos    = overlay_origin(cfg, sw, sh, ov_w, ov_h, margin);
 

--- a/src/hud/hud_renderer.h
+++ b/src/hud/hud_renderer.h
@@ -77,7 +77,8 @@ public:
     // connecting: scrcpy is running but no frame has arrived yet.
     // cfg controls anchor position and size as a fraction of screen height.
     void draw_android_overlay(unsigned int tex, int w, int h,
-                              bool active, bool connecting, const OverlayConfig& cfg);
+                              bool active, bool connecting, const OverlayConfig& cfg,
+                              float frame_aspect = 9.f / 16.f);
 
     // Execute ImGui::Render → flush to current GL framebuffer.
     void render_overlay();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -957,7 +957,8 @@ int main(int argc, char* argv[]) {
                                   xr.eye_width(), xr.eye_height(),
                                   android_overlay_active,
                                   android_mirror.is_running() && !android_mirror.is_connected(),
-                                  android_overlay_cfg);
+                                  android_overlay_cfg,
+                                  android_mirror.frame_aspect());
 
         hud.render_overlay();
 


### PR DESCRIPTION
- frame_aspect() atomically tracks actual w/h from live frames so the overlay scales correctly for any phone resolution (was hardcoded 9:16)
- capture_loop reopens /dev/video4 after 5 s of failed reads so the overlay recovers if scrcpy briefly drops the connection
- --stay-awake added to scrcpy args to prevent phone screen sleep
- draw_android_overlay accepts frame_aspect param (default 9/16)

https://claude.ai/code/session_01TxT4j1se1Vg9GmBmZTJSii