### PR TITLE
Add runtime-configurable HUD menu with compass/color/indicator/menu o…

### DIFF
--- a/src/hud/hud_renderer.cpp
+++ b/src/hud/hud_renderer.cpp
@@ -29,6 +29,11 @@ static std::string fmt_time(time_t t) {
     return buf;
 }
 
+// Replace the alpha byte of an ImU32 color (format: ABGR, alpha in high byte).
+static ImU32 with_alpha(ImU32 col, uint8_t a) {
+    return (col & 0x00FFFFFFu) | (static_cast<ImU32>(a) << 24u);
+}
+
 // Draw text with an orange glow outline matching the compass tick style.
 // selected=true → full white + bright glow; false → dim white + faint glow.
 static void hud_glow_text(ImDrawList* dl, ImVec2 pos, const char* text,
@@ -39,6 +44,17 @@ static void hud_glow_text(ImDrawList* dl, ImVec2 pos, const char* text,
     constexpr ImU32 FILL_OFF = IM_COL32(255, 255, 255, 160);
     const ImU32 glow = selected ? GLOW_ON  : GLOW_OFF;
     const ImU32 fill = selected ? FILL_ON  : FILL_OFF;
+    constexpr int D1[8][2] = {{-1,-1},{0,-1},{1,-1},{-1,0},{1,0},{-1,1},{0,1},{1,1}};
+    for (auto& o : D1) dl->AddText({pos.x+o[0], pos.y+o[1]}, glow, text);
+    dl->AddText(pos, fill, text);
+}
+
+// Color-parameterized variant: glow_col and fill_col are full-brightness (alpha=255);
+// glow alphas are derived internally.
+static void hud_glow_text(ImDrawList* dl, ImVec2 pos, const char* text,
+                           bool selected, ImU32 glow_col, ImU32 fill_col) {
+    const ImU32 glow = selected ? with_alpha(glow_col, 72) : with_alpha(glow_col, 22);
+    const ImU32 fill = selected ? fill_col : with_alpha(fill_col, 160);
     constexpr int D1[8][2] = {{-1,-1},{0,-1},{1,-1},{-1,0},{1,0},{-1,1},{0,1},{1,1}};
     for (auto& o : D1) dl->AddText({pos.x+o[0], pos.y+o[1]}, glow, text);
     dl->AddText(pos, fill, text);
@@ -363,13 +379,13 @@ void HudRenderer::draw_health_side(ImDrawList* dl, const SystemHealth& h,
     const float tape_x   = fw / 2.f - tape_w / 2.f;
     const float fade_w   = static_cast<float>(cfg_.compass_bg_side_fade);
     const float c_margin = static_cast<float>(cfg_.compass_bottom_margin);
-    const float anchor_y = fh - c_margin;  // bottom of compass tape
+    const float anchor_y = fh - c_margin;
     const float anchor_x = right_side ? tape_x + tape_w + fade_w
                                        : tape_x - fade_w;
 
-    constexpr ImU32 COL_MAJ  = IM_COL32(255, 160, 32, 255);
-    constexpr ImU32 COL_GLW1 = IM_COL32(255, 160, 32,  70);
-    constexpr ImU32 COL_GLW2 = IM_COL32(255, 160, 32,  28);
+    const ImU32 COL_MAJ  = col_.glow_base;
+    const ImU32 COL_GLW1 = with_alpha(col_.glow_base, 70);
+    const ImU32 COL_GLW2 = with_alpha(col_.glow_base, 28);
 
     struct Ind { const char* label; bool ok; };
     const Ind left_items[]  = {{"Proot",     h.teensy_ok},
@@ -383,24 +399,41 @@ void HudRenderer::draw_health_side(ImDrawList* dl, const SystemHealth& h,
     const Ind* items   = right_side ? right_items : left_items;
     const int  n_items = 4;
 
-    constexpr float ROW_H = 18.f;
-    constexpr float DOT_R = 4.f;
-    constexpr float ANGLE = 130.f * 3.14159265f / 180.f; // supplementary of 50°
+    constexpr float ROW_H  = 18.f;
+    constexpr float DOT_R  = 4.f;
+    constexpr float ANGLE  = 130.f * 3.14159265f / 180.f;
+    constexpr float H_LEN  = 300.f;
 
-    const float dir_x = std::cos(ANGLE) * (right_side ? 1.f : -1.f);
-    const float dir_y = -std::sin(ANGLE);
-
-    // Diagonal glow line — drawn first so items render on top
-    // extends to cover all items plus the 1-item lift offset
+    const float dir_x    = std::cos(ANGLE) * (right_side ? 1.f : -1.f);
+    const float dir_y    = -std::sin(ANGLE);
     const float diag_len = static_cast<float>(n_items + 1) * ROW_H;
-    const ImVec2 diag_end = {anchor_x + dir_x * diag_len,
-                              anchor_y + dir_y * diag_len};
+
+    // Optional parallelogram background (same color/opacity as compass bg)
+    if (cfg_.indicator_bg_enabled) {
+        const uint8_t bg_a  = static_cast<uint8_t>(cfg_.compass_bg_opacity * 255.f);
+        const ImU32   bg_col = with_alpha(col_.compass_bg_color, bg_a);
+        ImVec2 para[4];
+        if (right_side) {
+            para[0] = {anchor_x,                              anchor_y};
+            para[1] = {anchor_x + H_LEN,                      anchor_y};
+            para[2] = {anchor_x + H_LEN + dir_x * diag_len,   anchor_y + dir_y * diag_len};
+            para[3] = {anchor_x + dir_x * diag_len,            anchor_y + dir_y * diag_len};
+        } else {
+            para[0] = {anchor_x,                              anchor_y};
+            para[1] = {anchor_x + dir_x * diag_len,           anchor_y + dir_y * diag_len};
+            para[2] = {anchor_x - H_LEN + dir_x * diag_len,   anchor_y + dir_y * diag_len};
+            para[3] = {anchor_x - H_LEN,                      anchor_y};
+        }
+        dl->AddConvexPolyFilled(para, 4, bg_col);
+    }
+
+    // Diagonal glow line
+    const ImVec2 diag_end = {anchor_x + dir_x * diag_len, anchor_y + dir_y * diag_len};
     dl->AddLine({anchor_x, anchor_y}, diag_end, COL_GLW2, 5.f);
     dl->AddLine({anchor_x, anchor_y}, diag_end, COL_GLW1, 2.5f);
     dl->AddLine({anchor_x, anchor_y}, diag_end, COL_MAJ,  1.f);
 
-    // Horizontal glow line — 150px outward from anchor
-    constexpr float H_LEN = 150.f;
+    // Horizontal glow line — 300px outward from anchor
     const float h_end_x = anchor_x + (right_side ? H_LEN : -H_LEN);
     dl->AddLine({anchor_x, anchor_y}, {h_end_x, anchor_y}, COL_GLW2, 5.f);
     dl->AddLine({anchor_x, anchor_y}, {h_end_x, anchor_y}, COL_GLW1, 2.5f);
@@ -414,18 +447,20 @@ void HudRenderer::draw_health_side(ImDrawList* dl, const SystemHealth& h,
         const float iy = anchor_y + dir_y * t;
 
         if (items[i].ok) {
-            dl->AddCircleFilled({ix, iy}, DOT_R + 2.f, col_.orange_dim);
-            dl->AddCircleFilled({ix, iy}, DOT_R,        col_.orange);
+            dl->AddCircleFilled({ix, iy}, DOT_R + 2.f, with_alpha(col_.ind_good, 28));
+            dl->AddCircleFilled({ix, iy}, DOT_R,        col_.ind_good);
         } else {
-            dl->AddCircleFilled({ix, iy}, DOT_R, col_.danger);
+            dl->AddCircleFilled({ix, iy}, DOT_R, col_.ind_fail);
         }
 
         const char* lbl = items[i].label;
         if (right_side) {
-            hud_glow_text(dl, {ix + DOT_R + 6.f, iy - 7.f}, lbl, items[i].ok);
+            hud_glow_text(dl, {ix + DOT_R + 6.f, iy - 7.f}, lbl, items[i].ok,
+                          col_.glow_base, col_.text_fill);
         } else {
             float tw = ImGui::CalcTextSize(lbl).x;
-            hud_glow_text(dl, {ix - DOT_R - 6.f - tw, iy - 7.f}, lbl, items[i].ok);
+            hud_glow_text(dl, {ix - DOT_R - 6.f - tw, iy - 7.f}, lbl, items[i].ok,
+                          col_.glow_base, col_.text_fill);
         }
     }
     if (font_mono_) ImGui::PopFont();
@@ -594,19 +629,17 @@ void HudRenderer::draw_compass_tape(ImDrawList* dl, const AppState& s,
     const float center_x = origin.x + tw / 2.f;
     const float tick_y   = origin.y + th - 8.f;
 
-    constexpr ImU32 col_major  = IM_COL32(255, 160,  32, 255);
-    constexpr ImU32 col_mid    = IM_COL32(255, 140,  20, 180);
-    constexpr ImU32 col_minor  = IM_COL32(255, 130,  20, 110);
-    constexpr ImU32 col_glow1  = IM_COL32(255, 160,  32,  70);
-    constexpr ImU32 col_glow2  = IM_COL32(255, 160,  32,  28);
+    const ImU32 col_major = col_.compass_tick;
+    const ImU32 col_mid   = with_alpha(col_.compass_tick, 180);
+    const ImU32 col_minor = with_alpha(col_.compass_tick, 110);
+    const ImU32 col_glow1 = with_alpha(col_.compass_glow, 70);
+    const ImU32 col_glow2 = with_alpha(col_.compass_glow, 28);
 
-    // Optional gradient background: transparent at top and outer edges, opaque at bottom.
-    // Three strips so the left and right sides also fade in from transparent.
     if (s.compass_bg_enabled) {
         const uint8_t a  = static_cast<uint8_t>(cfg_.compass_bg_opacity * 255.f);
         const float   fw = static_cast<float>(cfg_.compass_bg_side_fade);
-        const ImU32   T  = IM_COL32(8, 12, 18, 0);
-        const ImU32   A  = IM_COL32(8, 12, 18, a);
+        const ImU32   T  = with_alpha(col_.compass_bg_color, 0);
+        const ImU32   A  = with_alpha(col_.compass_bg_color, a);
         // Left strip: fully transparent outer edge, opaque only at inner-bottom corner
         dl->AddRectFilledMultiColor(
             {origin.x - fw, origin.y}, {origin.x,       origin.y + th}, T, T, A, T);

--- a/src/hud/hud_renderer.h
+++ b/src/hud/hud_renderer.h
@@ -32,6 +32,15 @@ struct HudColors {
     ImU32 orange      = IM_COL32(255, 160,  32, 255);
     ImU32 orange_glow = IM_COL32(255, 160,  32,  70);
     ImU32 orange_dim  = IM_COL32(255, 160,  32,  28);
+    // Runtime-configurable HUD palette (full RGB, alpha=255; glow alphas derived at draw time)
+    ImU32 glow_base       = IM_COL32(255, 160,  32, 255); // outline/glow base color
+    ImU32 text_fill       = IM_COL32(255, 255, 255, 255); // main text fill
+    ImU32 ind_good        = IM_COL32(255, 160,  32, 255); // indicator OK dot
+    ImU32 ind_inactive    = IM_COL32(120, 120, 120, 255); // indicator inactive/disconnected dot
+    ImU32 ind_fail        = IM_COL32(255,  60,  60, 255); // indicator failure dot
+    ImU32 compass_tick    = IM_COL32(255, 160,  32, 255); // compass major tick
+    ImU32 compass_glow    = IM_COL32(255, 160,  32, 255); // compass glow (alphas derived at draw time)
+    ImU32 compass_bg_color= IM_COL32(  8,  12,  18, 255); // compass bg RGB (alpha from opacity cfg)
 };
 
 struct HudConfig {
@@ -45,12 +54,19 @@ struct HudConfig {
     float scale                 = 1.0f;
     float health_panel_opacity  = 0.71f;
     float pip_corner_clip_px    = 16.f;
+    bool  indicator_bg_enabled  = false;  // parallelogram bg behind health indicators
 };
 
 class HudRenderer {
 public:
     HudRenderer(const HudConfig& cfg, const HudColors& colors);
     ~HudRenderer();
+
+    // Runtime access to palette and layout config for live menu editing.
+    HudColors&       colors()       { return col_; }
+    const HudColors& colors() const { return col_; }
+    HudConfig&       config()       { return cfg_; }
+    const HudConfig& config() const { return cfg_; }
 
     // Call after GL context is current. Sets up ImGui context and loads fonts.
     // glfw_window: the GLFW window ImGui should attach to for input bridging.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -78,7 +78,8 @@ static std::vector<MenuItem> build_menu(
         AndroidMirror* android_mirror, bool* android_overlay,
         OverlayConfig* pip_cfg1, OverlayConfig* pip_cfg2,
         bool* pip_cam1_overlay, bool* pip_cam2_overlay,
-        OverlayConfig* android_cfg)
+        OverlayConfig* android_cfg,
+        HudColors* hud_col, HudConfig* hud_cfg, MenuSystem** menu_sys_pp)
 {
     (void)lora; (void)knob;
 
@@ -360,14 +361,6 @@ static std::vector<MenuItem> build_menu(
         { "Size",         nullptr, make_size_items(android_cfg)     },
     };
 
-    // ── Compass ───────────────────────────────────────────────────────────────
-    std::vector<MenuItem> compass_menu = {
-        { "BG On",  [&state]{ std::lock_guard<std::mutex> lk(state.mtx);
-                               state.compass_bg_enabled = true;  }, {} },
-        { "BG Off", [&state]{ std::lock_guard<std::mutex> lk(state.mtx);
-                               state.compass_bg_enabled = false; }, {} },
-    };
-
     // ── Prototracer (face controller) submenu ─────────────────────────────────
     std::vector<MenuItem> prototracer_menu = {
         { "Effects",        nullptr, std::move(effects)            },
@@ -377,8 +370,132 @@ static std::vector<MenuItem> build_menu(
         { "Lens Brightness",nullptr, std::move(glasses_brightness) },
     };
 
-    // Compass tucked into Headset
-    headset_menu.push_back({ "Compass", nullptr, std::move(compass_menu) });
+    // ── HUD settings ──────────────────────────────────────────────────────────
+
+    // Compass submenu
+    auto make_color_items = [](std::vector<std::pair<const char*, ImU32>> presets,
+                                std::function<void(ImU32)> apply) {
+        std::vector<MenuItem> v;
+        for (auto& [lbl, col] : presets)
+            v.push_back({ lbl, [apply, col]{ apply(col); }, {} });
+        return v;
+    };
+
+    std::vector<MenuItem> compass_bg_color_menu = make_color_items({
+        { "Default", IM_COL32(  8,  12,  18, 255) },
+        { "Teal",    IM_COL32(  5,  30,  25, 255) },
+        { "Purple",  IM_COL32( 18,   8,  28, 255) },
+        { "Blue",    IM_COL32( 10,  10,  40, 255) },
+        { "Black",   IM_COL32(  0,   0,   0, 255) },
+    }, [hud_col](ImU32 c){ hud_col->compass_bg_color = c; });
+
+    std::vector<MenuItem> compass_tick_color_menu = make_color_items({
+        { "Orange", IM_COL32(255, 160,  32, 255) },
+        { "Teal",   IM_COL32(  0, 220, 180, 255) },
+        { "Cyan",   IM_COL32(  0, 180, 255, 255) },
+        { "Green",  IM_COL32( 30, 220,  60, 255) },
+        { "Purple", IM_COL32(180,  30, 220, 255) },
+        { "White",  IM_COL32(255, 255, 255, 255) },
+    }, [hud_col](ImU32 c){ hud_col->compass_tick = c; });
+
+    std::vector<MenuItem> compass_glow_color_menu = make_color_items({
+        { "Orange", IM_COL32(255, 160,  32, 255) },
+        { "Teal",   IM_COL32(  0, 220, 180, 255) },
+        { "Cyan",   IM_COL32(  0, 180, 255, 255) },
+        { "Green",  IM_COL32( 30, 220,  60, 255) },
+        { "Purple", IM_COL32(180,  30, 220, 255) },
+        { "White",  IM_COL32(255, 255, 255, 255) },
+    }, [hud_col](ImU32 c){ hud_col->compass_glow = c; });
+
+    std::vector<MenuItem> compass_menu = {
+        { "BG On",      [&state]{ std::lock_guard<std::mutex> lk(state.mtx);
+                                   state.compass_bg_enabled = true;  }, {} },
+        { "BG Off",     [&state]{ std::lock_guard<std::mutex> lk(state.mtx);
+                                   state.compass_bg_enabled = false; }, {} },
+        { "BG Color",   nullptr, std::move(compass_bg_color_menu)   },
+        { "Tick Color", nullptr, std::move(compass_tick_color_menu)  },
+        { "Glow Color", nullptr, std::move(compass_glow_color_menu)  },
+    };
+
+    // Text Color submenu
+    std::vector<MenuItem> text_color_menu = make_color_items({
+        { "White",  IM_COL32(255, 255, 255, 255) },
+        { "Cyan",   IM_COL32(  0, 240, 220, 255) },
+        { "Orange", IM_COL32(255, 200, 100, 255) },
+        { "Green",  IM_COL32(100, 255, 160, 255) },
+    }, [hud_col](ImU32 c){ hud_col->text_fill = c; });
+
+    // Glow Color submenu (applies to all HUD glow/outline effects)
+    std::vector<MenuItem> glow_color_menu = make_color_items({
+        { "Orange", IM_COL32(255, 160,  32, 255) },
+        { "Teal",   IM_COL32(  0, 220, 180, 255) },
+        { "Cyan",   IM_COL32(  0, 180, 255, 255) },
+        { "Green",  IM_COL32( 30, 220,  60, 255) },
+        { "Purple", IM_COL32(180,  30, 220, 255) },
+        { "White",  IM_COL32(255, 255, 255, 255) },
+    }, [hud_col](ImU32 c){ hud_col->glow_base = c; });
+
+    // Indicator Options submenu
+    std::vector<MenuItem> ind_good_color_menu = make_color_items({
+        { "Orange", IM_COL32(255, 160,  32, 255) },
+        { "Green",  IM_COL32( 30, 220,  60, 255) },
+        { "Teal",   IM_COL32(  0, 220, 180, 255) },
+        { "Cyan",   IM_COL32(  0, 180, 255, 255) },
+        { "White",  IM_COL32(255, 255, 255, 255) },
+    }, [hud_col](ImU32 c){ hud_col->ind_good = c; });
+
+    std::vector<MenuItem> ind_inactive_color_menu = make_color_items({
+        { "Gray",   IM_COL32(120, 120, 120, 255) },
+        { "Blue",   IM_COL32( 60,  80, 160, 255) },
+        { "Dim",    IM_COL32( 80,  80,  80, 255) },
+    }, [hud_col](ImU32 c){ hud_col->ind_inactive = c; });
+
+    std::vector<MenuItem> ind_fail_color_menu = make_color_items({
+        { "Red",    IM_COL32(255,  60,  60, 255) },
+        { "Orange", IM_COL32(255, 120,   0, 255) },
+        { "Yellow", IM_COL32(240, 220,   0, 255) },
+    }, [hud_col](ImU32 c){ hud_col->ind_fail = c; });
+
+    std::vector<MenuItem> indicator_options_menu = {
+        { "Active Color",   nullptr, std::move(ind_good_color_menu)     },
+        { "Inactive Color", nullptr, std::move(ind_inactive_color_menu) },
+        { "Fail Color",     nullptr, std::move(ind_fail_color_menu)     },
+        { "BG On",          [hud_cfg]{ hud_cfg->indicator_bg_enabled = true;  }, {} },
+        { "BG Off",         [hud_cfg]{ hud_cfg->indicator_bg_enabled = false; }, {} },
+    };
+
+    // Menu Options submenu
+    std::vector<MenuItem> menu_color_menu = make_color_items({
+        { "Orange", IM_COL32(255, 160,  32, 255) },
+        { "Teal",   IM_COL32(  0, 220, 180, 255) },
+        { "Cyan",   IM_COL32(  0, 180, 255, 255) },
+        { "Green",  IM_COL32( 30, 220,  60, 255) },
+        { "Purple", IM_COL32(180,  30, 220, 255) },
+    }, [menu_sys_pp](ImU32 c){ if (*menu_sys_pp) (*menu_sys_pp)->set_accent_color(c); });
+
+    std::vector<MenuItem> menu_bg_color_menu = make_color_items({
+        { "Dark",    IM_COL32( 10,  15,  20, 225) },
+        { "Teal",    IM_COL32(  5,  25,  22, 225) },
+        { "Purple",  IM_COL32( 20,   8,  28, 225) },
+        { "Navy",    IM_COL32(  8,   8,  35, 225) },
+        { "Black",   IM_COL32(  0,   0,   0, 230) },
+    }, [menu_sys_pp](ImU32 c){ if (*menu_sys_pp) (*menu_sys_pp)->set_bg_color(c); });
+
+    std::vector<MenuItem> menu_options_menu = {
+        { "Menu Color",  nullptr, std::move(menu_color_menu)    },
+        { "BG Color",    nullptr, std::move(menu_bg_color_menu) },
+        { "BG On",  [menu_sys_pp]{ if (*menu_sys_pp) (*menu_sys_pp)->set_bg_enabled(true);  }, {} },
+        { "BG Off", [menu_sys_pp]{ if (*menu_sys_pp) (*menu_sys_pp)->set_bg_enabled(false); }, {} },
+    };
+
+    // HUD top-level menu
+    std::vector<MenuItem> hud_menu = {
+        { "Compass",           nullptr, std::move(compass_menu)          },
+        { "Text Color",        nullptr, std::move(text_color_menu)       },
+        { "Glow Color",        nullptr, std::move(glow_color_menu)       },
+        { "Indicator Options", nullptr, std::move(indicator_options_menu)},
+        { "Menu Options",      nullptr, std::move(menu_options_menu)     },
+    };
 
     return {
         { "Camera",         nullptr, std::move(camera_menu)        },
@@ -387,6 +504,7 @@ static std::vector<MenuItem> build_menu(
         { "Headset",        nullptr, std::move(headset_menu)       },
         { "Audio",          nullptr, std::move(audio_menu)         },
         { "Android Mirror", nullptr, std::move(android_menu)       },
+        { "HUD",            nullptr, std::move(hud_menu)           },
         { "Request Status", [teensy]{ teensy->request_status(); }, {} },
     };
 }
@@ -703,11 +821,16 @@ int main(int argc, char* argv[]) {
     bool pip_cam1_overlay_active = false;
     bool pip_cam2_overlay_active = false;
 
+    // menu_ptr is set to &menu after construction so HUD menu lambdas can call
+    // into MenuSystem without a circular dependency at build time.
+    MenuSystem* menu_ptr = nullptr;
     MenuSystem menu(build_menu(&teensy, &xr, &cameras, &lora, &knob, &audio, state,
                                &android_mirror, &android_overlay_active,
                                &pip_overlay_cfg1, &pip_overlay_cfg2,
                                &pip_cam1_overlay_active, &pip_cam2_overlay_active,
-                               &android_overlay_cfg));
+                               &android_overlay_cfg,
+                               &hud_col, &hud_cfg, &menu_ptr));
+    menu_ptr = &menu;
 
     menu.set_detent_callback([&knob, &menu](int count) {
         knob.set_detents(count);

--- a/src/menu/menu_system.cpp
+++ b/src/menu/menu_system.cpp
@@ -16,7 +16,12 @@ MenuSystem::MenuSystem(std::vector<MenuItem> root)
 
 void MenuSystem::push_level(const std::vector<MenuItem>& items) {
     if (items.empty()) return;
-    stack_.push_back({ items });
+    std::vector<MenuItem> aug = items;
+    // Back only makes sense when there is a parent level
+    if (!stack_.empty())
+        aug.push_back({ "< Back", [this]{ back();  }, {} });
+    aug.push_back(    { "Exit",   [this]{ close(); }, {} });
+    stack_.push_back({ std::move(aug) });
     cursor_ = 0;
     emit_detents();
 }
@@ -52,7 +57,7 @@ void MenuSystem::select() {
         push_level(item.children);
     } else if (item.action) {
         item.action();
-        close();
+        // Menu stays open — user explicitly navigates away via Back or Exit.
     }
 }
 
@@ -69,24 +74,35 @@ const std::string& MenuSystem::current_label() const {
 
 // ── draw ──────────────────────────────────────────────────────────────────────
 
-// Draw text with an orange glow outline, matching the compass tick style.
-// selected = full white + bright glow; unselected = dim white + faint glow.
-static void draw_glow_text(ImDrawList* dl, ImVec2 pos, const char* text, bool selected) {
-    constexpr ImU32 GLOW_SEL = IM_COL32(255, 160, 32,  72);
-    constexpr ImU32 GLOW_DIM = IM_COL32(255, 160, 32,  22);
-    constexpr ImU32 FILL_SEL = IM_COL32(255, 255, 255, 255);
-    constexpr ImU32 FILL_DIM = IM_COL32(255, 255, 255, 160);
+// Derive alpha-variant of an ImU32 (format ABGR, alpha in high byte).
+static ImU32 menu_with_alpha(ImU32 col, uint8_t a) {
+    return (col & 0x00FFFFFFu) | (static_cast<ImU32>(a) << 24u);
+}
 
-    const ImU32 glow = selected ? GLOW_SEL : GLOW_DIM;
-    const ImU32 fill = selected ? FILL_SEL : FILL_DIM;
+// Convert ImU32 to ImVec4, optionally overriding alpha.
+static ImVec4 col_to_vec4(ImU32 col, float alpha_override = -1.f) {
+    float r = ((col >>  0) & 0xFF) / 255.f;
+    float g = ((col >>  8) & 0xFF) / 255.f;
+    float b = ((col >> 16) & 0xFF) / 255.f;
+    float a = alpha_override >= 0.f ? alpha_override : ((col >> 24) & 0xFF) / 255.f;
+    return {r, g, b, a};
+}
 
-    // 8-direction glow at 1px, 4-cardinal at 2px
+// Draw text with a glow outline using the supplied accent color.
+// selected = full fill + bright glow; unselected = dim fill + faint glow.
+static void draw_glow_text(ImDrawList* dl, ImVec2 pos, const char* text,
+                            bool selected, ImU32 accent_col) {
+    const ImU32 glow     = selected ? menu_with_alpha(accent_col, 72) : menu_with_alpha(accent_col, 22);
+    const ImU32 glow_far = menu_with_alpha(accent_col, 28);
+    const ImU32 fill_sel = IM_COL32(255, 255, 255, 255);
+    const ImU32 fill_dim = IM_COL32(255, 255, 255, 160);
+    const ImU32 fill     = selected ? fill_sel : fill_dim;
+
     constexpr int D1[8][2] = {{-1,-1},{0,-1},{1,-1},{-1,0},{1,0},{-1,1},{0,1},{1,1}};
     constexpr int D2[4][2] = {{-2,0},{2,0},{0,-2},{0,2}};
     for (auto& o : D1) dl->AddText({pos.x+o[0], pos.y+o[1]}, glow, text);
     if (selected)
-        for (auto& o : D2) dl->AddText({pos.x+o[0], pos.y+o[1]},
-                                       IM_COL32(255,160,32,28), text);
+        for (auto& o : D2) dl->AddText({pos.x+o[0], pos.y+o[1]}, glow_far, text);
     dl->AddText(pos, fill, text);
 }
 
@@ -101,17 +117,14 @@ void MenuSystem::draw(int screen_w, int screen_h) {
     const float total_h = pad_y * 2.f
                           + item_h * static_cast<float>(items.size());
 
-    // Left-side positioning, vertically centered
     const float x = 48.f;
     const float y = ((float)screen_h - total_h) * 0.5f;
 
-    // Compass orange palette
-    constexpr ImU32 COL_ORANGE = IM_COL32(255, 160,  32, 255);
-    constexpr ImU32 COL_SEP    = IM_COL32(255, 160,  32,  45);
+    const ImU32 COL_SEP = menu_with_alpha(accent_color_, 45);
 
     ImGui::SetNextWindowPos ({ x, y }, ImGuiCond_Always);
     ImGui::SetNextWindowSize({ width, total_h }, ImGuiCond_Always);
-    ImGui::SetNextWindowBgAlpha(0.88f);
+    if (!bg_enabled_) ImGui::SetNextWindowBgAlpha(0.f);
 
     ImGuiWindowFlags flags =
         ImGuiWindowFlags_NoDecoration     |
@@ -119,10 +132,11 @@ void MenuSystem::draw(int screen_w, int screen_h) {
         ImGuiWindowFlags_NoSavedSettings  |
         ImGuiWindowFlags_NoFocusOnAppearing;
 
-    ImGui::PushStyleColor(ImGuiCol_Border,        ImVec4(1.f, 0.627f, 0.125f, 0.86f));
-    ImGui::PushStyleColor(ImGuiCol_Header,        ImVec4(1.f, 0.627f, 0.125f, 0.10f));
-    ImGui::PushStyleColor(ImGuiCol_HeaderHovered, ImVec4(1.f, 0.627f, 0.125f, 0.20f));
-    ImGui::PushStyleColor(ImGuiCol_HeaderActive,  ImVec4(1.f, 0.627f, 0.125f, 0.32f));
+    ImGui::PushStyleColor(ImGuiCol_WindowBg,      bg_color_);
+    ImGui::PushStyleColor(ImGuiCol_Border,        col_to_vec4(accent_color_, 0.86f));
+    ImGui::PushStyleColor(ImGuiCol_Header,        col_to_vec4(accent_color_, 0.10f));
+    ImGui::PushStyleColor(ImGuiCol_HeaderHovered, col_to_vec4(accent_color_, 0.20f));
+    ImGui::PushStyleColor(ImGuiCol_HeaderActive,  col_to_vec4(accent_color_, 0.32f));
     // Suppress Selectable's own text — we draw it manually via DrawList
     ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.f, 0.f, 0.f, 0.f));
     ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 1.5f);
@@ -132,12 +146,10 @@ void MenuSystem::draw(int screen_w, int screen_h) {
     ImGui::Begin("##menu", nullptr, flags);
     ImDrawList* dl = ImGui::GetWindowDrawList();
 
-    // Item list
     const float line_h = ImGui::GetTextLineHeight();
     for (int i = 0; i < static_cast<int>(items.size()); i++) {
         bool selected = (i == cursor_);
 
-        // Empty-label selectable — provides background highlight + click detection
         char id[32]; snprintf(id, sizeof(id), "##item%d", i);
         if (ImGui::Selectable(id, selected, 0,
                               ImVec2(0.f, item_h - 1.f))) {
@@ -151,13 +163,13 @@ void MenuSystem::draw(int screen_w, int screen_h) {
         // Left accent bar
         if (selected)
             dl->AddRectFilled({rmin.x - pad_x,       rmin.y},
-                              {rmin.x - pad_x + 4.f,  rmax.y}, COL_ORANGE);
+                              {rmin.x - pad_x + 4.f,  rmax.y}, accent_color_);
 
         // Glow text — vertically centered in the item row
         std::string label = to_upper(items[i].label);
         if (!items[i].children.empty()) label += "   >";
         ImVec2 tpos = {rmin.x + 4.f, rmin.y + (item_h - line_h) * 0.5f - 0.5f};
-        draw_glow_text(dl, tpos, label.c_str(), selected);
+        draw_glow_text(dl, tpos, label.c_str(), selected, accent_color_);
 
         // Thin bottom separator
         dl->AddLine({rmin.x - pad_x, rmax.y - 1.f},
@@ -166,5 +178,5 @@ void MenuSystem::draw(int screen_w, int screen_h) {
 
     ImGui::End();
     ImGui::PopStyleVar(3);
-    ImGui::PopStyleColor(5);
+    ImGui::PopStyleColor(6);
 }

--- a/src/menu/menu_system.h
+++ b/src/menu/menu_system.h
@@ -3,6 +3,7 @@
 #include <string>
 #include <vector>
 #include <memory>
+#include <imgui.h>
 
 struct MenuItem {
     std::string label;
@@ -21,6 +22,11 @@ public:
     explicit MenuSystem(std::vector<MenuItem> root);
 
     void set_detent_callback(DetentCallback cb) { detent_cb_ = std::move(cb); }
+
+    // Runtime style setters — take effect immediately on the next draw() call.
+    void set_accent_color(ImU32 c) { accent_color_ = c; }
+    void set_bg_enabled(bool e)    { bg_enabled_   = e; }
+    void set_bg_color(ImU32 c)     { bg_color_     = c; }
 
     // Drive from knob events
     void navigate(int direction);   // +1 = next, -1 = prev
@@ -50,4 +56,9 @@ private:
     int                         cursor_ = 0;
     bool                        open_   = false;
     DetentCallback              detent_cb_;
+
+    // Runtime style
+    ImU32 accent_color_ = IM_COL32(255, 160,  32, 255);
+    bool  bg_enabled_   = true;
+    ImU32 bg_color_     = IM_COL32( 10,  15,  20, 225);
 };


### PR DESCRIPTION
…ptions

- Add HUD top-level menu with Compass, Text Color, Glow Color, Indicator Options, and Menu Options submenus; each submenu offers color presets
- Compass submenu: BG on/off, BG color, tick color, glow color; compass is moved from Headset into the new HUD menu
- Indicator Options: Active/Good/Fail color presets, indicator BG on/off (parallelogram behind health indicators matching compass bg color+opacity)
- Menu Options: menu accent color, bg color presets, bg on/off
- Extend health indicator horizontal glow line from 150 px to 300 px
- Add HudColors runtime fields (glow_base, text_fill, ind_good/inactive/fail, compass_tick/glow/bg_color); add HudConfig::indicator_bg_enabled; expose colors()/config() accessors on HudRenderer
- Add with_alpha() helper; derive all glow alpha variants at draw time
- Add MenuSystem accent_color_/bg_enabled_/bg_color_ with setters
- Menu no longer auto-closes after leaf selection; every page injects Back and Exit items via push_level() so the user can always navigate out
- All menu glow/border/separator colors follow the runtime accent_color_

https://claude.ai/code/session_01TxT4j1se1Vg9GmBmZTJSii