### PR TITLE
Fix HUD menu color changes not taking effect

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -829,7 +829,7 @@ int main(int argc, char* argv[]) {
                                &pip_overlay_cfg1, &pip_overlay_cfg2,
                                &pip_cam1_overlay_active, &pip_cam2_overlay_active,
                                &android_overlay_cfg,
-                               &hud_col, &hud_cfg, &menu_ptr));
+                               &hud.colors(), &hud.config(), &menu_ptr));
     menu_ptr = &menu;
 
     menu.set_detent_callback([&knob, &menu](int count) {


### PR DESCRIPTION
build_menu was passed pointers to the local hud_col/hud_cfg copies, but HudRenderer stores its own copies made at construction time. Pass &hud.colors() and &hud.config() instead so lambdas write directly into the renderer's live palette and layout config.

https://claude.ai/code/session_01TxT4j1se1Vg9GmBmZTJSii