### PR TITLE
Add USB camera auto-reconnect on disconnect

### DIFF
--- a/src/camera/camera_manager.cpp
+++ b/src/camera/camera_manager.cpp
@@ -168,12 +168,19 @@ bool CameraManager::set_resolution(int width, int height, int fps) {
 
 void CameraManager::usb_capture_thread() {
     cv::Mat frame, rgba;
-    int frames1 = 0, empty1 = 0;
-    int frames2 = 0, empty2 = 0;
+    int frames1 = 0, empty1 = 0, consec1 = 0;
+    int frames2 = 0, empty2 = 0, consec2 = 0;
+
+    // Consecutive empty reads before declaring a camera disconnected.
+    // At ~30fps with near-instant V4L2 failures this triggers in ~1 s.
+    constexpr int kDisconnectThreshold = 30;
+    // How often to attempt a reconnect when enabled.
+    constexpr auto kReconnectInterval = std::chrono::seconds(5);
 
     auto capture = [&](cv::VideoCapture& cap, std::mutex& cap_mtx,
                        TexSlot& slot, std::atomic<bool>& ok_flag,
-                       int& good, int& bad, const char* name) -> bool {
+                       int& good, int& bad, int& consec,
+                       const char* name) -> bool {
         bool got_frame = false;
         {
             std::lock_guard<std::mutex> lk(cap_mtx);
@@ -182,6 +189,7 @@ void CameraManager::usb_capture_thread() {
             if (!frame.empty()) {
                 cv::cvtColor(frame, rgba, cv::COLOR_BGR2RGBA);
                 got_frame = true;
+                consec = 0;
                 ++good;
                 if (good == 1)
                     std::cerr << "[cam] " << name << ": first frame received ("
@@ -190,6 +198,14 @@ void CameraManager::usb_capture_thread() {
                 if (++bad % 30 == 1)
                     std::cerr << "[cam] " << name << ": " << bad
                               << " empty reads (good=" << good << ")\n";
+                // After enough consecutive failures (and we know the camera
+                // worked before), release it so reconnect logic can trigger.
+                if (++consec >= kDisconnectThreshold && good > 0) {
+                    std::cerr << "[cam] " << name << ": disconnected\n";
+                    ok_flag = false;
+                    cap.release();  // isOpened() now returns false
+                    consec = 0;
+                }
             }
         }
         if (got_frame) {
@@ -200,12 +216,32 @@ void CameraManager::usb_capture_thread() {
             std::memcpy(slot.buf.data(), rgba.data, slot.buf.size());
             slot.dirty = true;
         }
-        return true;
+        return got_frame || ok_flag.load();  // keep spinning while open even if no frame
     };
 
     while (running_) {
-        bool any = capture(usb_cap1_, usb1_cap_mtx_, usb1_slot_, usb1_ok_, frames1, empty1, "usb1");
-        any      |= capture(usb_cap2_, usb2_cap_mtx_, usb2_slot_, usb2_ok_, frames2, empty2, "usb2");
+        bool any = capture(usb_cap1_, usb1_cap_mtx_, usb1_slot_, usb1_ok_,
+                           frames1, empty1, consec1, "usb1");
+        any      |= capture(usb_cap2_, usb2_cap_mtx_, usb2_slot_, usb2_ok_,
+                            frames2, empty2, consec2, "usb2");
+
+        // Auto-reconnect: periodically reopen disconnected cameras when enabled.
+        auto now = std::chrono::steady_clock::now();
+        if (usb1_reconnect_ && !usb1_ok_ && !usb1_cfg_.device.empty() &&
+            now - usb1_last_retry_ >= kReconnectInterval) {
+            usb1_last_retry_ = now;
+            consec1 = 0; empty1 = 0;  // reset counters for the new attempt
+            std::cerr << "[cam] usb1: auto-reconnect attempt\n";
+            open_usb1();  // mutex already released by capture lambda
+        }
+        if (usb2_reconnect_ && !usb2_ok_ && !usb2_cfg_.device.empty() &&
+            now - usb2_last_retry_ >= kReconnectInterval) {
+            usb2_last_retry_ = now;
+            consec2 = 0; empty2 = 0;
+            std::cerr << "[cam] usb2: auto-reconnect attempt\n";
+            open_usb2();
+        }
+
         if (!any)
             std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
@@ -225,6 +261,7 @@ void CameraManager::open_usb1() {
 }
 
 void CameraManager::close_usb1() {
+    usb1_reconnect_ = false;   // explicit close — don't auto-reopen
     std::lock_guard<std::mutex> lk(usb1_cap_mtx_);
     usb_cap1_.release();
     usb1_ok_ = false;
@@ -243,6 +280,7 @@ void CameraManager::open_usb2() {
 }
 
 void CameraManager::close_usb2() {
+    usb2_reconnect_ = false;   // explicit close — don't auto-reopen
     std::lock_guard<std::mutex> lk(usb2_cap_mtx_);
     usb_cap2_.release();
     usb2_ok_ = false;

--- a/src/camera/camera_manager.h
+++ b/src/camera/camera_manager.h
@@ -3,6 +3,7 @@
 #include "dma_camera.h"
 
 #include <atomic>
+#include <chrono>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -86,6 +87,15 @@ public:
     bool usb1_ok()      const { return usb1_ok_; }
     bool usb2_ok()      const { return usb2_ok_; }
 
+    // ── Auto-reconnect ────────────────────────────────────────────────────────
+    // When enabled, the capture thread will attempt to reopen a disconnected
+    // USB camera every ~5 s. Calling close_usbN() disables reconnect for that
+    // camera so an explicit close stays closed.
+    void set_usb1_reconnect(bool v) { usb1_reconnect_ = v; }
+    void set_usb2_reconnect(bool v) { usb2_reconnect_ = v; }
+    bool usb1_reconnect_enabled() const { return usb1_reconnect_; }
+    bool usb2_reconnect_enabled() const { return usb2_reconnect_; }
+
 private:
     void usb_capture_thread();
     // Upload pixel data to a GL texture; creates/reallocates as needed.
@@ -104,6 +114,11 @@ private:
     std::mutex       usb1_cap_mtx_, usb2_cap_mtx_;
     std::atomic<bool> usb1_ok_ { false };
     std::atomic<bool> usb2_ok_ { false };
+    std::atomic<bool> usb1_reconnect_ { false };
+    std::atomic<bool> usb2_reconnect_ { false };
+    // Written only by the capture thread; no extra sync needed.
+    std::chrono::steady_clock::time_point usb1_last_retry_ {};
+    std::chrono::steady_clock::time_point usb2_last_retry_ {};
 
     // Per-USB-camera slot: capture thread writes buf/w/h, render thread uploads
     struct TexSlot {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -317,32 +317,36 @@ static std::vector<MenuItem> build_menu(
 
     // ── USB camera PiP layout ─────────────────────────────────────────────────
     std::vector<MenuItem> cam1_menu = {
-        { "Open",         [cameras, pip_cam1_overlay]{
-                              std::thread([cameras, pip_cam1_overlay]{
-                                  cameras->open_usb1();
-                                  *pip_cam1_overlay = true;
-                              }).detach(); }, {} },
-        { "Close",        [cameras, pip_cam1_overlay]{
-                              cameras->close_usb1();
-                              *pip_cam1_overlay = false; }, {} },
-        { "Show Overlay", [pip_cam1_overlay]{ *pip_cam1_overlay = true;  }, {} },
-        { "Hide Overlay", [pip_cam1_overlay]{ *pip_cam1_overlay = false; }, {} },
-        { "Position",     nullptr, make_position_items(pip_cfg1) },
-        { "Size",         nullptr, make_size_items(pip_cfg1)     },
+        { "Open",              [cameras, pip_cam1_overlay]{
+                                   std::thread([cameras, pip_cam1_overlay]{
+                                       cameras->open_usb1();
+                                       *pip_cam1_overlay = true;
+                                   }).detach(); }, {} },
+        { "Close",             [cameras, pip_cam1_overlay]{
+                                   cameras->close_usb1();   // also clears reconnect flag
+                                   *pip_cam1_overlay = false; }, {} },
+        { "Auto-Reconnect On", [cameras]{ cameras->set_usb1_reconnect(true);  }, {} },
+        { "Auto-Reconnect Off",[cameras]{ cameras->set_usb1_reconnect(false); }, {} },
+        { "Show Overlay",      [pip_cam1_overlay]{ *pip_cam1_overlay = true;  }, {} },
+        { "Hide Overlay",      [pip_cam1_overlay]{ *pip_cam1_overlay = false; }, {} },
+        { "Position",          nullptr, make_position_items(pip_cfg1) },
+        { "Size",              nullptr, make_size_items(pip_cfg1)     },
     };
     std::vector<MenuItem> cam2_menu = {
-        { "Open",         [cameras, pip_cam2_overlay]{
-                              std::thread([cameras, pip_cam2_overlay]{
-                                  cameras->open_usb2();
-                                  *pip_cam2_overlay = true;
-                              }).detach(); }, {} },
-        { "Close",        [cameras, pip_cam2_overlay]{
-                              cameras->close_usb2();
-                              *pip_cam2_overlay = false; }, {} },
-        { "Show Overlay", [pip_cam2_overlay]{ *pip_cam2_overlay = true;  }, {} },
-        { "Hide Overlay", [pip_cam2_overlay]{ *pip_cam2_overlay = false; }, {} },
-        { "Position",     nullptr, make_position_items(pip_cfg2) },
-        { "Size",         nullptr, make_size_items(pip_cfg2)     },
+        { "Open",              [cameras, pip_cam2_overlay]{
+                                   std::thread([cameras, pip_cam2_overlay]{
+                                       cameras->open_usb2();
+                                       *pip_cam2_overlay = true;
+                                   }).detach(); }, {} },
+        { "Close",             [cameras, pip_cam2_overlay]{
+                                   cameras->close_usb2();   // also clears reconnect flag
+                                   *pip_cam2_overlay = false; }, {} },
+        { "Auto-Reconnect On", [cameras]{ cameras->set_usb2_reconnect(true);  }, {} },
+        { "Auto-Reconnect Off",[cameras]{ cameras->set_usb2_reconnect(false); }, {} },
+        { "Show Overlay",      [pip_cam2_overlay]{ *pip_cam2_overlay = true;  }, {} },
+        { "Hide Overlay",      [pip_cam2_overlay]{ *pip_cam2_overlay = false; }, {} },
+        { "Position",          nullptr, make_position_items(pip_cfg2) },
+        { "Size",              nullptr, make_size_items(pip_cfg2)     },
     };
     std::vector<MenuItem> pip_menu = {
         { "Cam 1", nullptr, std::move(cam1_menu) },


### PR DESCRIPTION
Capture thread now tracks consecutive empty reads per camera. After 30 consecutive failures (post first frame) the VideoCapture is released and the camera is marked disconnected. When auto-reconnect is enabled, the capture thread retries open every 5 s.

- CameraManager: add usb1/2_reconnect_ atomics, set_usb1/2_reconnect(), usb1/2_reconnect_enabled() — close_usbN() clears the flag so an explicit close stays closed
- capture thread: consec_empty counter per camera, disconnect on threshold, reconnect poll block after capture calls
- Menu: "Auto-Reconnect On/Off" added to Cam 1 and Cam 2 submenus

https://claude.ai/code/session_01TxT4j1se1Vg9GmBmZTJSii