### PR TITLE
Compass glow, indicator gradient bg, and persistent HUD settings

### DIFF
--- a/src/hud/hud_renderer.cpp
+++ b/src/hud/hud_renderer.cpp
@@ -408,23 +408,23 @@ void HudRenderer::draw_health_side(ImDrawList* dl, const SystemHealth& h,
     const float dir_y    = -std::sin(ANGLE);
     const float diag_len = static_cast<float>(n_items + 1) * ROW_H;
 
-    // Optional parallelogram background (same color/opacity as compass bg)
+    // Parallelogram background — 16 strips fading from opaque (inner) to transparent (outer).
     if (cfg_.indicator_bg_enabled) {
-        const uint8_t bg_a  = static_cast<uint8_t>(cfg_.compass_bg_opacity * 255.f);
-        const ImU32   bg_col = with_alpha(col_.compass_bg_color, bg_a);
-        ImVec2 para[4];
-        if (right_side) {
-            para[0] = {anchor_x,                              anchor_y};
-            para[1] = {anchor_x + H_LEN,                      anchor_y};
-            para[2] = {anchor_x + H_LEN + dir_x * diag_len,   anchor_y + dir_y * diag_len};
-            para[3] = {anchor_x + dir_x * diag_len,            anchor_y + dir_y * diag_len};
-        } else {
-            para[0] = {anchor_x,                              anchor_y};
-            para[1] = {anchor_x + dir_x * diag_len,           anchor_y + dir_y * diag_len};
-            para[2] = {anchor_x - H_LEN + dir_x * diag_len,   anchor_y + dir_y * diag_len};
-            para[3] = {anchor_x - H_LEN,                      anchor_y};
+        const uint8_t bg_a       = static_cast<uint8_t>(cfg_.compass_bg_opacity * 255.f);
+        const float   outer_sign = right_side ? 1.f : -1.f;
+        constexpr int N = 16;
+        for (int i = 0; i < N; i++) {
+            const float t0 = float(i)     / float(N);
+            const float t1 = float(i + 1) / float(N);
+            const uint8_t a0 = static_cast<uint8_t>(bg_a * (1.f - t0));
+            ImVec2 strip[4] = {
+                {anchor_x + outer_sign * t0 * H_LEN,                    anchor_y},
+                {anchor_x + outer_sign * t0 * H_LEN + dir_x * diag_len, anchor_y + dir_y * diag_len},
+                {anchor_x + outer_sign * t1 * H_LEN + dir_x * diag_len, anchor_y + dir_y * diag_len},
+                {anchor_x + outer_sign * t1 * H_LEN,                    anchor_y},
+            };
+            dl->AddConvexPolyFilled(strip, 4, with_alpha(col_.compass_bg_color, a0));
         }
-        dl->AddConvexPolyFilled(para, 4, bg_col);
     }
 
     // Diagonal glow line
@@ -635,33 +635,32 @@ void HudRenderer::draw_compass_tape(ImDrawList* dl, const AppState& s,
     const ImU32 col_glow1 = with_alpha(col_.compass_glow, 70);
     const ImU32 col_glow2 = with_alpha(col_.compass_glow, 28);
 
+    const float fw = static_cast<float>(cfg_.compass_bg_side_fade);
     if (s.compass_bg_enabled) {
-        const uint8_t a  = static_cast<uint8_t>(cfg_.compass_bg_opacity * 255.f);
-        const float   fw = static_cast<float>(cfg_.compass_bg_side_fade);
-        const ImU32   T  = with_alpha(col_.compass_bg_color, 0);
-        const ImU32   A  = with_alpha(col_.compass_bg_color, a);
-        // Left strip: fully transparent outer edge, opaque only at inner-bottom corner
-        dl->AddRectFilledMultiColor(
-            {origin.x - fw, origin.y}, {origin.x,       origin.y + th}, T, T, A, T);
-        // Center: transparent top, opaque bottom
-        dl->AddRectFilledMultiColor(
-            {origin.x,      origin.y}, {origin.x + tw,  origin.y + th}, T, T, A, A);
-        // Right strip: opaque only at inner-bottom corner, fully transparent outer edge
-        dl->AddRectFilledMultiColor(
-            {origin.x + tw, origin.y}, {origin.x + tw + fw, origin.y + th}, T, T, T, A);
+        const uint8_t a = static_cast<uint8_t>(cfg_.compass_bg_opacity * 255.f);
+        const ImU32   A = with_alpha(col_.compass_bg_color, a);
 
-        // Extend background below tape, fading back to transparent
-        constexpr float LINE_GAP = 6.f;
-        constexpr float LINE_EXT = 8.f;
-        const float bot  = origin.y + th;
-        const float bot2 = bot + LINE_GAP + LINE_EXT;
-        dl->AddRectFilledMultiColor({origin.x - fw, bot}, {origin.x,        bot2}, T, A, T, T);
-        dl->AddRectFilledMultiColor({origin.x,      bot}, {origin.x + tw,   bot2}, A, A, T, T);
-        dl->AddRectFilledMultiColor({origin.x + tw, bot}, {origin.x+tw+fw,  bot2}, A, T, T, T);
+        // Diagonal inset at the top edge to match the health indicator 130° angle.
+        // Both sides taper inward as height increases, connecting flush to the
+        // health indicator diagonal lines when those are also enabled.
+        constexpr float kIndAngle = 130.f * 3.14159265f / 180.f;
+        const float inset = std::abs(std::cos(kIndAngle)) / std::sin(kIndAngle) * th;
 
-        // Glowing horizontal line below tape (same 3-pass glow as major ticks)
-        const float line_y = bot + LINE_GAP;
+        // Solid trapezoid — wider at bottom (anchor_y), narrower at top.
+        ImVec2 bg[4] = {
+            {origin.x - fw + inset,      origin.y     },  // TL
+            {origin.x + tw + fw - inset, origin.y     },  // TR
+            {origin.x + tw + fw,         origin.y + th},  // BR
+            {origin.x - fw,              origin.y + th},  // BL
+        };
+        dl->AddConvexPolyFilled(bg, 4, A);
+    }
+
+    // Glow line at the tape base — always visible, connects flush to the health
+    // indicator horizontal lines when those are also enabled.
+    {
         const float lx0 = origin.x - fw, lx1 = origin.x + tw + fw;
+        const float line_y = origin.y + th;
         dl->AddLine({lx0, line_y}, {lx1, line_y}, col_glow2, 5.f);
         dl->AddLine({lx0, line_y}, {lx1, line_y}, col_glow1, 2.5f);
         dl->AddLine({lx0, line_y}, {lx1, line_y}, col_major, 1.f);
@@ -683,10 +682,13 @@ void HudRenderer::draw_compass_tape(ImDrawList* dl, const AppState& s,
             dl->AddLine({px, origin.y}, {px, tick_y}, col_glow1, 4.f);
             dl->AddLine({px, origin.y}, {px, tick_y}, col_major, 1.5f);
         } else if (deg % 10 == 0) {
+            dl->AddLine({px, tick_y - 12.f}, {px, tick_y}, col_glow2, 3.f);
             dl->AddLine({px, tick_y - 12.f}, {px, tick_y}, col_mid);
             char buf[8]; snprintf(buf, sizeof(buf), "%d", deg);
-            dl->AddText({px - 8.f, tick_y - 28.f}, col_major, buf);
+            hud_glow_text(dl, {px - 8.f, tick_y - 28.f}, buf,
+                          true, col_.compass_glow, col_.compass_tick);
         } else if (deg % 5 == 0) {
+            dl->AddLine({px, tick_y - 8.f}, {px, tick_y}, col_glow2, 2.f);
             dl->AddLine({px, tick_y - 8.f}, {px, tick_y}, col_minor);
         }
     }
@@ -700,8 +702,9 @@ void HudRenderer::draw_compass_tape(ImDrawList* dl, const AppState& s,
         float px = center_x + offset * ppd;
         if (px < origin.x || px > origin.x + tw) continue;
 
-        dl->AddText({px - 8.f, origin.y - 16.f}, col_major,
-                    cardinal_str(static_cast<float>(deg)));
+        hud_glow_text(dl, {px - 8.f, origin.y - 16.f},
+                      cardinal_str(static_cast<float>(deg)),
+                      true, col_.compass_glow, col_.compass_tick);
     }
 
     // Centre cursor triangle — glow halo then sharp fill
@@ -718,7 +721,8 @@ void HudRenderer::draw_compass_tape(ImDrawList* dl, const AppState& s,
 
     // Heading readout
     char hdg[16]; snprintf(hdg, sizeof(hdg), "%03.0f°", heading);
-    dl->AddText({center_x - 16.f, origin.y + 16.f}, col_major, hdg);
+    hud_glow_text(dl, {center_x - 16.f, origin.y + 16.f}, hdg,
+                  true, col_.compass_glow, col_.compass_tick);
 
     if (font_mono_) ImGui::PopFont();
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -62,6 +62,31 @@ static OverlayConfig::Anchor parse_anchor(const std::string& s) {
     return OverlayConfig::Anchor::TOP_CENTER;
 }
 
+// ── Color serialization helpers ───────────────────────────────────────────────
+// ImU32 is ABGR: alpha in high byte, red in low byte.
+
+static ImU32 jcolor(const json& j, const std::string& key, ImU32 def) {
+    if (!j.contains(key)) return def;
+    try {
+        const auto& a = j[key];
+        if (a.is_array() && a.size() >= 3) {
+            int r = a[0].get<int>(), g = a[1].get<int>(), b = a[2].get<int>();
+            int al = a.size() >= 4 ? a[3].get<int>() : 255;
+            return IM_COL32(r, g, b, al);
+        }
+    } catch (...) {}
+    return def;
+}
+
+static json color_to_json(ImU32 col) {
+    return json::array({
+        int((col >>  0) & 0xFF),   // R
+        int((col >>  8) & 0xFF),   // G
+        int((col >> 16) & 0xFF),   // B
+        int((col >> 24) & 0xFF),   // A
+    });
+}
+
 // ── GLFW key edge detection ───────────────────────────────────────────────────
 // Returns true on the frame the key transitions from released to pressed.
 // ImGui intercepts GLFW callbacks; after begin_frame() we use ImGui's key state.
@@ -650,9 +675,10 @@ int main(int argc, char* argv[]) {
     hud_cfg.compass_bg_side_fade  = jval(jhud, "compass_bg_side_fade_px",   80);
     hud_cfg.panel_width          = jval(jhud, "panel_width_px",       200);
     hud_cfg.health_panel_opacity = jval(jhud, "health_panel_opacity", 0.71f);
-    hud_cfg.pip_corner_clip_px   = jval(jhud, "pip_corner_clip_px",   16.f);
-    hud_cfg.opacity              = jval(jdisp,"hud_opacity",          0.85f);
-    hud_cfg.scale                = jval(jdisp,"hud_scale",            1.0f);
+    hud_cfg.pip_corner_clip_px    = jval(jhud, "pip_corner_clip_px",   16.f);
+    hud_cfg.opacity               = jval(jdisp,"hud_opacity",          0.85f);
+    hud_cfg.scale                 = jval(jdisp,"hud_scale",            1.0f);
+    hud_cfg.indicator_bg_enabled  = jval(jhud, "indicator_bg_enabled", false);
 
     AndroidMirrorConfig and_cfg;
     OverlayConfig       pip_overlay_cfg1, pip_overlay_cfg2;
@@ -747,7 +773,19 @@ int main(int argc, char* argv[]) {
     // ── HUD renderer ──────────────────────────────────────────────────────────
     // Must be after xr.init() so the GLFW window + GL context exist.
 
-    HudColors   hud_col;
+    HudColors hud_col;
+    // Load runtime palette (saved by a previous session via menu edits).
+    if (cfg.contains("hud_colors")) {
+        auto& jc = cfg["hud_colors"];
+        hud_col.glow_base        = jcolor(jc, "glow_base",        hud_col.glow_base);
+        hud_col.text_fill        = jcolor(jc, "text_fill",        hud_col.text_fill);
+        hud_col.ind_good         = jcolor(jc, "ind_good",         hud_col.ind_good);
+        hud_col.ind_inactive     = jcolor(jc, "ind_inactive",     hud_col.ind_inactive);
+        hud_col.ind_fail         = jcolor(jc, "ind_fail",         hud_col.ind_fail);
+        hud_col.compass_tick     = jcolor(jc, "compass_tick",     hud_col.compass_tick);
+        hud_col.compass_glow     = jcolor(jc, "compass_glow",     hud_col.compass_glow);
+        hud_col.compass_bg_color = jcolor(jc, "compass_bg_color", hud_col.compass_bg_color);
+    }
     HudRenderer hud(hud_cfg, hud_col);
     hud.load(xr.glfw_window());
 
@@ -835,6 +873,14 @@ int main(int argc, char* argv[]) {
                                &android_overlay_cfg,
                                &hud.colors(), &hud.config(), &menu_ptr));
     menu_ptr = &menu;
+
+    // Restore menu style from a previous session.
+    if (cfg.contains("menu_style")) {
+        auto& jm = cfg["menu_style"];
+        menu.set_accent_color(jcolor(jm, "accent_color", menu.accent_color()));
+        menu.set_bg_color    (jcolor(jm, "bg_color",     menu.bg_color()));
+        menu.set_bg_enabled  (jval  (jm, "bg_enabled",   menu.bg_enabled()));
+    }
 
     menu.set_detent_callback([&knob, &menu](int count) {
         knob.set_detents(count);
@@ -1091,6 +1137,40 @@ int main(int argc, char* argv[]) {
 
         // ── Swap ──────────────────────────────────────────────────────────────
         xr.present();
+    }
+
+    // ── Persist runtime settings ──────────────────────────────────────────────
+    // Capture whatever colors/flags the user set via the HUD menu and write
+    // them back to the config file so they survive a restart.
+    try {
+        auto& jc = cfg["hud_colors"];
+        jc["glow_base"]        = color_to_json(hud.colors().glow_base);
+        jc["text_fill"]        = color_to_json(hud.colors().text_fill);
+        jc["ind_good"]         = color_to_json(hud.colors().ind_good);
+        jc["ind_inactive"]     = color_to_json(hud.colors().ind_inactive);
+        jc["ind_fail"]         = color_to_json(hud.colors().ind_fail);
+        jc["compass_tick"]     = color_to_json(hud.colors().compass_tick);
+        jc["compass_glow"]     = color_to_json(hud.colors().compass_glow);
+        jc["compass_bg_color"] = color_to_json(hud.colors().compass_bg_color);
+
+        cfg["hud"]["indicator_bg_enabled"] = hud.config().indicator_bg_enabled;
+
+        auto& jm = cfg["menu_style"];
+        jm["accent_color"] = color_to_json(menu.accent_color());
+        jm["bg_color"]     = color_to_json(menu.bg_color());
+        jm["bg_enabled"]   = menu.bg_enabled();
+
+        FILE* f = fopen(cfg_path.c_str(), "w");
+        if (f) {
+            std::string s = cfg.dump(2);
+            fwrite(s.c_str(), 1, s.size(), f);
+            fclose(f);
+            std::cout << "[cfg] settings saved to " << cfg_path << "\n";
+        } else {
+            std::cerr << "[cfg] cannot write to " << cfg_path << "\n";
+        }
+    } catch (const std::exception& e) {
+        std::cerr << "[cfg] save failed: " << e.what() << "\n";
     }
 
     // ── Cleanup ───────────────────────────────────────────────────────────────

--- a/src/menu/menu_system.h
+++ b/src/menu/menu_system.h
@@ -28,6 +28,11 @@ public:
     void set_bg_enabled(bool e)    { bg_enabled_   = e; }
     void set_bg_color(ImU32 c)     { bg_color_     = c; }
 
+    // Runtime style getters — for persisting user changes to config on exit.
+    ImU32 accent_color() const { return accent_color_; }
+    ImU32 bg_color()     const { return bg_color_;     }
+    bool  bg_enabled()   const { return bg_enabled_;   }
+
     // Drive from knob events
     void navigate(int direction);   // +1 = next, -1 = prev
     void select();                  // confirm current item (also callable from GPIO)


### PR DESCRIPTION
- draw_compass_tape: move glow line at tape base outside compass_bg_enabled guard so it always renders; add 3-pass glow to 10° and 5° tick lines; replace AddText with hud_glow_text on degree labels, cardinal labels, and heading readout so all compass text uses the configurable compass_glow/tick colors
- draw_health_side: replace solid parallelogram bg with 16-strip gradient fading from opaque at the compass edge to transparent at the screen edge
- menu_system.h: add accent_color()/bg_color()/bg_enabled() getters
- main.cpp: add jcolor()/color_to_json() helpers; load hud_colors/menu_style/ indicator_bg_enabled from config on startup; write them back to config.json on clean exit so menu-driven palette changes persist across restarts

https://claude.ai/code/session_01TxT4j1se1Vg9GmBmZTJSii