### PR TITLE
Frameless window option, indicator bg fade fix, and compass draw order

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -3,6 +3,7 @@
     "width": 1920,
     "height": 1080,
     "fullscreen": true,
+    "frameless": false,
     "target_fps": 90,
     "eye_separation": 0.064,
     "hud_opacity": 0.85,

--- a/src/hud/hud_renderer.cpp
+++ b/src/hud/hud_renderer.cpp
@@ -158,12 +158,12 @@ void HudRenderer::draw_frame(const AppState& s, int w, int h) {
         draw_lora_messages(dl, s,       { 0.f, th }, msg_w, mid_h);
     }
 
+    const float cw       = fw / 3.f;
+    const float c_margin = static_cast<float>(cfg_.compass_bottom_margin);
+    // Compass (bg + ticks) drawn first so health indicators render on top of it.
+    draw_compass_tape(dl, s, {fw / 2.f - cw / 2.f, fh - ch - c_margin}, cw, ch);
     draw_health_side(dl, s.health, fw, fh, false);
     draw_health_side(dl, s.health, fw, fh, true);
-
-    const float cw      = fw / 3.f;
-    const float c_margin = static_cast<float>(cfg_.compass_bottom_margin);
-    draw_compass_tape(dl, s, {fw / 2.f - cw / 2.f, fh - ch - c_margin}, cw, ch);
 }
 
 // ── Shared overlay layout helper ──────────────────────────────────────────────
@@ -416,7 +416,10 @@ void HudRenderer::draw_health_side(ImDrawList* dl, const SystemHealth& h,
         for (int i = 0; i < N; i++) {
             const float t0 = float(i)     / float(N);
             const float t1 = float(i + 1) / float(N);
-            const uint8_t a0 = static_cast<uint8_t>(bg_a * (1.f - t0));
+            constexpr float FADE_START = 0.9f;
+            const float fade_t = (t0 < FADE_START) ? 0.f
+                                 : (t0 - FADE_START) / (1.f - FADE_START);
+            const uint8_t a0 = static_cast<uint8_t>(bg_a * (1.f - fade_t));
             ImVec2 strip[4] = {
                 {anchor_x + outer_sign * t0 * H_LEN,                    anchor_y},
                 {anchor_x + outer_sign * t0 * H_LEN + dir_x * diag_len, anchor_y + dir_y * diag_len},

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -637,6 +637,7 @@ int main(int argc, char* argv[]) {
     xr_cfg.target_fps       = jval(jdisp, "target_fps",       90);
     xr_cfg.use_beast_camera = jval(jvtr,  "use_beast_camera", true);
     xr_cfg.enable_imu       = jval(jvtr,  "enable_imu",       true);
+    xr_cfg.frameless        = jval(jdisp, "frameless",         false);
 
     CamConfig owl_left, owl_right;
     if (jcam.contains("owlsight_left")) {

--- a/src/vitrue/xr_display.cpp
+++ b/src/vitrue/xr_display.cpp
@@ -95,7 +95,8 @@ bool XRDisplay::init() {
     glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 0);
     glfwWindowHint(GLFW_CONTEXT_CREATION_API, GLFW_EGL_CONTEXT_API);
     glfwWindowHint(GLFW_DOUBLEBUFFER,          GLFW_TRUE);
-    glfwWindowHint(GLFW_RESIZABLE,             GLFW_FALSE);
+    glfwWindowHint(GLFW_RESIZABLE,  GLFW_FALSE);
+    glfwWindowHint(GLFW_DECORATED,  cfg_.frameless ? GLFW_FALSE : GLFW_TRUE);
 
     mon = choose_monitor();
     window_ = glfwCreateWindow(disp_w_, disp_h_, "ProtoHUD", mon, nullptr);

--- a/src/vitrue/xr_display.h
+++ b/src/vitrue/xr_display.h
@@ -28,6 +28,7 @@ struct XRConfig {
     int  target_fps      = 90;
     bool use_beast_camera = true;
     bool enable_imu       = true;
+    bool frameless        = false;  // remove OS window decorations (windowed mode only)
 };
 
 class XRDisplay {


### PR DESCRIPTION
- xr_display.h/cpp: add XRConfig::frameless field; apply GLFW_DECORATED hint before glfwCreateWindow() — when false (default) the window has OS decorations, when true the titlebar and border are removed (useful for desktop dev/kiosk)
- config.json: add "frameless": false under "display"
- main.cpp: read display.frameless into xr_cfg
- hud_renderer.cpp: fix health indicator bg gradient — holds full opacity for the first 90% of the width, fades to transparent only over the last 10% (~30px) instead of fading across the full 300px; swap draw_compass_tape before draw_health_side in draw_frame so the compass background trapezoid is rendered behind health indicator dots and glow lines rather than over them

https://claude.ai/code/session_01TxT4j1se1Vg9GmBmZTJSii