### PR TITLE
Add Vision Assist post-processing: edge highlight + background desatu…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,7 @@ set(SOURCES
     src/vitrue/xr_display.cpp
     src/vitrue/timewarp.cpp
     src/audio/audio_engine.cpp
+    src/post_process.cpp
 )
 
 add_executable(protohud ${SOURCES})

--- a/assets/shaders/postprocess.fs
+++ b/assets/shaders/postprocess.fs
@@ -1,0 +1,76 @@
+// postprocess.fs — edge highlight + background desaturation post-processing pass
+//
+// Samples a 3×3 neighbourhood (9 texels, fully unrolled for GLES 2.0 compatibility)
+// to compute:
+//   1. Sobel edge magnitude on the luma channel
+//   2. Local luma contrast (max-min over 3×3) as a background depth proxy
+//      — or real depth from a hardware depth camera when u_has_depth=1.0
+//
+// Both effects are independently gated by their strength uniforms (0 = off).
+//
+// Depth hardware path (future):
+//   Bind an 8-bit GL_LUMINANCE depth texture to unit 1 and set u_has_depth=1.0.
+//   Near objects should map to dark values (0), far to bright (1) so that
+//   bg_weight = depth value (high depth = background = desaturate).
+
+precision mediump float;
+
+uniform sampler2D u_scene;      // camera FBO (RGBA8), unit 0
+uniform sampler2D u_depth;      // depth map (GL_LUMINANCE), unit 1 (optional)
+uniform vec2      u_texel;      // vec2(1/width, 1/height)
+uniform float     u_edge_str;   // 0.0–1.0 edge overlay intensity
+uniform float     u_desat_str;  // 0.0–1.0 background desaturation intensity
+uniform vec3      u_edge_col;   // edge overlay colour (normalised RGB)
+uniform float     u_threshold;  // local contrast below this = background (0.07–0.25)
+uniform float     u_has_depth;  // 0.0 = use contrast proxy, 1.0 = sample u_depth
+
+varying vec2 v_uv;
+
+float luma(vec3 c) {
+    return dot(c, vec3(0.299, 0.587, 0.114));
+}
+
+void main() {
+    // ── Sample 3×3 neighbourhood ──────────────────────────────────────────────
+    vec3 c00 = texture2D(u_scene, v_uv + vec2(-1.0, -1.0) * u_texel).rgb;
+    vec3 c10 = texture2D(u_scene, v_uv + vec2( 0.0, -1.0) * u_texel).rgb;
+    vec3 c20 = texture2D(u_scene, v_uv + vec2( 1.0, -1.0) * u_texel).rgb;
+    vec3 c01 = texture2D(u_scene, v_uv + vec2(-1.0,  0.0) * u_texel).rgb;
+    vec3 c11 = texture2D(u_scene, v_uv).rgb;
+    vec3 c21 = texture2D(u_scene, v_uv + vec2( 1.0,  0.0) * u_texel).rgb;
+    vec3 c02 = texture2D(u_scene, v_uv + vec2(-1.0,  1.0) * u_texel).rgb;
+    vec3 c12 = texture2D(u_scene, v_uv + vec2( 0.0,  1.0) * u_texel).rgb;
+    vec3 c22 = texture2D(u_scene, v_uv + vec2( 1.0,  1.0) * u_texel).rgb;
+
+    float l00 = luma(c00); float l10 = luma(c10); float l20 = luma(c20);
+    float l01 = luma(c01); float l11 = luma(c11); float l21 = luma(c21);
+    float l02 = luma(c02); float l12 = luma(c12); float l22 = luma(c22);
+
+    // ── Sobel edge detection ──────────────────────────────────────────────────
+    float gx = -l00 - 2.0*l01 - l02 + l20 + 2.0*l21 + l22;
+    float gy = -l00 - 2.0*l10 - l20 + l02 + 2.0*l12 + l22;
+    float edge = clamp(sqrt(gx*gx + gy*gy) * 4.0, 0.0, 1.0);
+
+    // ── Background weight ─────────────────────────────────────────────────────
+    float bg_weight;
+    if (u_has_depth > 0.5) {
+        bg_weight = texture2D(u_depth, v_uv).r;
+    } else {
+        // Local contrast proxy: low contrast = background
+        float lo = min(min(min(l00, l10), min(l20, l01)),
+                       min(min(l11, l21), min(l02, min(l12, l22))));
+        float hi = max(max(max(l00, l10), max(l20, l01)),
+                       max(max(l11, l21), max(l02, max(l12, l22))));
+        float contrast = hi - lo;
+        bg_weight = clamp(1.0 - contrast / max(u_threshold, 0.01), 0.0, 1.0);
+    }
+
+    // ── Desaturate background ─────────────────────────────────────────────────
+    vec3  grey  = vec3(l11);
+    vec3  color = mix(c11, grey, bg_weight * u_desat_str);
+
+    // ── Overlay edges ─────────────────────────────────────────────────────────
+    color = mix(color, u_edge_col, edge * u_edge_str);
+
+    gl_FragColor = vec4(color, 1.0);
+}

--- a/assets/shaders/postprocess.vs
+++ b/assets/shaders/postprocess.vs
@@ -1,0 +1,11 @@
+// postprocess.vs — vertex shader for fullscreen post-processing pass
+// Attributes bound at locations 0 (a_pos) and 1 (a_uv) by gl_utils link_program().
+attribute vec2 a_pos;
+attribute vec2 a_uv;
+
+varying vec2 v_uv;
+
+void main() {
+    gl_Position = vec4(a_pos, 0.0, 1.0);
+    v_uv = a_uv;
+}

--- a/config/config.json
+++ b/config/config.json
@@ -127,6 +127,14 @@
     "anchor":    "bottom_left",
     "_anchor_values": "top_left | top_center | top_right | bottom_left | bottom_center | bottom_right"
   },
+  "post_process": {
+    "edge_enabled": false,
+    "edge_strength": 0.7,
+    "edge_color": [255, 160, 32, 255],
+    "desat_enabled": false,
+    "desat_strength": 0.8,
+    "contrast_threshold": 0.15
+  },
   "colors": {
     "hud_primary":    [0, 220, 180, 220],
     "hud_accent":     [0, 180, 255, 255],

--- a/src/app_state.h
+++ b/src/app_state.h
@@ -6,6 +6,20 @@
 #include <vector>
 #include <cstdint>
 #include <ctime>
+#include <imgui.h>
+
+// ── Post-processing config ────────────────────────────────────────────────────
+// Modified from menu (any thread); read by the render thread via snap.
+// Simple struct — individual fields are written atomically enough for a bool/float.
+
+struct PostProcessConfig {
+    bool  edge_enabled       = false;
+    float edge_strength      = 0.7f;
+    ImU32 edge_color         = IM_COL32(255, 160, 32, 255);
+    bool  desat_enabled      = false;
+    float desat_strength     = 0.8f;
+    float contrast_threshold = 0.15f;  // 0.07 = aggressive, 0.25 = subtle
+};
 
 // ── Overlay layout config (PiP and Android mirror) ───────────────────────────
 // Modified at runtime by menu actions; read exclusively on the render thread,
@@ -133,6 +147,9 @@ struct AppState {
     CameraFocusState     focus_left, focus_right;
     NightVisionState     night_vision;
     CameraResolutionState camera_resolution;
+
+    // Post-processing (edge highlight + background desaturation)
+    PostProcessConfig    pp_cfg;
 
     // Signals render thread to quit.
     std::atomic<bool> quit { false };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,6 +25,7 @@
 #include "vitrue/xr_display.h"
 #include "vitrue/timewarp.h"
 #include "audio/audio_engine.h"
+#include "post_process.h"
 
 using json = nlohmann::json;
 
@@ -555,6 +556,48 @@ static std::vector<MenuItem> build_menu(
         { "Menu Options",      nullptr, std::move(menu_options_menu)     },
     };
 
+    // ── Vision Assist (post-processing depth cues) ────────────────────────────
+
+    std::vector<MenuItem> edge_strength_menu = {
+        { "10%",  [&state]{ state.pp_cfg.edge_strength = 0.10f; }, {} },
+        { "30%",  [&state]{ state.pp_cfg.edge_strength = 0.30f; }, {} },
+        { "50%",  [&state]{ state.pp_cfg.edge_strength = 0.50f; }, {} },
+        { "70%",  [&state]{ state.pp_cfg.edge_strength = 0.70f; }, {} },
+        { "100%", [&state]{ state.pp_cfg.edge_strength = 1.00f; }, {} },
+    };
+
+    std::vector<MenuItem> edge_color_menu = {
+        { "Orange", [&state]{ state.pp_cfg.edge_color = IM_COL32(255, 160,  32, 255); }, {} },
+        { "Teal",   [&state]{ state.pp_cfg.edge_color = IM_COL32(  0, 220, 180, 255); }, {} },
+        { "Cyan",   [&state]{ state.pp_cfg.edge_color = IM_COL32(  0, 180, 255, 255); }, {} },
+        { "Green",  [&state]{ state.pp_cfg.edge_color = IM_COL32( 30, 220,  60, 255); }, {} },
+        { "White",  [&state]{ state.pp_cfg.edge_color = IM_COL32(255, 255, 255, 255); }, {} },
+    };
+
+    std::vector<MenuItem> desat_strength_menu = {
+        { "25%",  [&state]{ state.pp_cfg.desat_strength = 0.25f; }, {} },
+        { "50%",  [&state]{ state.pp_cfg.desat_strength = 0.50f; }, {} },
+        { "75%",  [&state]{ state.pp_cfg.desat_strength = 0.75f; }, {} },
+        { "100%", [&state]{ state.pp_cfg.desat_strength = 1.00f; }, {} },
+    };
+
+    std::vector<MenuItem> bg_threshold_menu = {
+        { "Subtle (0.25)",     [&state]{ state.pp_cfg.contrast_threshold = 0.25f; }, {} },
+        { "Medium (0.15)",     [&state]{ state.pp_cfg.contrast_threshold = 0.15f; }, {} },
+        { "Aggressive (0.07)", [&state]{ state.pp_cfg.contrast_threshold = 0.07f; }, {} },
+    };
+
+    std::vector<MenuItem> vision_menu = {
+        { "Edge Highlight", [&state]{ state.pp_cfg.edge_enabled  = !state.pp_cfg.edge_enabled;  }, {},
+          [&state]{ return state.pp_cfg.edge_enabled;  } },
+        { "Edge Strength",  nullptr, std::move(edge_strength_menu) },
+        { "Edge Color",     nullptr, std::move(edge_color_menu)    },
+        { "Bg Desaturate",  [&state]{ state.pp_cfg.desat_enabled = !state.pp_cfg.desat_enabled; }, {},
+          [&state]{ return state.pp_cfg.desat_enabled; } },
+        { "Desat Strength", nullptr, std::move(desat_strength_menu) },
+        { "BG Threshold",   nullptr, std::move(bg_threshold_menu)   },
+    };
+
     return {
         { "Camera",         nullptr, std::move(camera_menu)        },
         { "USB Cameras",    nullptr, std::move(pip_menu)           },
@@ -563,6 +606,7 @@ static std::vector<MenuItem> build_menu(
         { "Audio",          nullptr, std::move(audio_menu)         },
         { "Android Mirror", nullptr, std::move(android_menu)       },
         { "HUD",            nullptr, std::move(hud_menu)           },
+        { "Vision Assist",  nullptr, std::move(vision_menu)        },
         { "Request Status", [teensy]{ teensy->request_status(); }, {} },
         { "Close Program",  [&state]{ state.quit = true; },         {} },
     };
@@ -755,6 +799,22 @@ int main(int argc, char* argv[]) {
         state.night_vision.shutter_us  = jnv.value("shutter_us",  33333);
     }
 
+    if (cfg.contains("post_process")) {
+        auto& jpp = cfg["post_process"];
+        state.pp_cfg.edge_enabled       = jpp.value("edge_enabled",       false);
+        state.pp_cfg.edge_strength      = jpp.value("edge_strength",      0.7f);
+        state.pp_cfg.desat_enabled      = jpp.value("desat_enabled",      false);
+        state.pp_cfg.desat_strength     = jpp.value("desat_strength",     0.8f);
+        state.pp_cfg.contrast_threshold = jpp.value("contrast_threshold", 0.15f);
+        if (jpp.contains("edge_color") && jpp["edge_color"].is_array() &&
+            jpp["edge_color"].size() >= 3) {
+            auto& jc = jpp["edge_color"];
+            uint8_t r = jc[0], g = jc[1], b = jc[2];
+            uint8_t a = jpp["edge_color"].size() >= 4 ? (uint8_t)jc[3] : 255;
+            state.pp_cfg.edge_color = IM_COL32(r, g, b, a);
+        }
+    }
+
     // Seed resolution state from whatever the OWLsight config says
     state.camera_resolution.width  = owl_left.width;
     state.camera_resolution.height = owl_left.height;
@@ -795,6 +855,21 @@ int main(int argc, char* argv[]) {
     bool use_timewarp = timewarp.init();
     if (!use_timewarp)
         std::cerr << "[main] timewarp shader unavailable — skipping\n";
+
+    // ── Post-processing (Vision Assist) ───────────────────────────────────────
+
+    PostProcessor post_proc;
+    gl::Fbo pp_fbo_left, pp_fbo_right;
+    const bool pp_ok = post_proc.init(
+        xr.eye_width(), xr.eye_height(),
+        res("assets/shaders/postprocess.vs").c_str(),
+        res("assets/shaders/postprocess.fs").c_str());
+    if (pp_ok) {
+        pp_fbo_left  = gl::make_fbo(xr.eye_width(), xr.eye_height());
+        pp_fbo_right = gl::make_fbo(xr.eye_width(), xr.eye_height());
+    } else {
+        std::cerr << "[main] post-process shader unavailable — Vision Assist disabled\n";
+    }
 
     // ── Spatial audio ─────────────────────────────────────────────────────────
 
@@ -1080,6 +1155,7 @@ int main(int argc, char* argv[]) {
             snap.focus_left         = state.focus_left;
             snap.focus_right        = state.focus_right;
             snap.night_vision       = state.night_vision;
+            snap.pp_cfg             = state.pp_cfg;
         }
 
         // Record render-time pose for timewarp
@@ -1128,6 +1204,17 @@ int main(int argc, char* argv[]) {
             xr.eye_right().unbind();
         }
 
+        // ── Post-processing (Vision Assist depth cues) ────────────────────────
+        GLuint left_src  = xr.eye_left().tex;
+        GLuint right_src = xr.eye_right().tex;
+        if (pp_ok && post_proc.any_enabled(snap.pp_cfg) &&
+                pp_fbo_left.valid() && pp_fbo_right.valid()) {
+            post_proc.process(xr.eye_left().tex,  pp_fbo_left,  snap.pp_cfg);
+            post_proc.process(xr.eye_right().tex, pp_fbo_right, snap.pp_cfg);
+            left_src  = pp_fbo_left.tex;
+            right_src = pp_fbo_right.tex;
+        }
+
         // ── Composite or timewarp ─────────────────────────────────────────────
         ImuPose current_pose = xr.get_latest_imu_pose();
 
@@ -1148,9 +1235,9 @@ int main(int argc, char* argv[]) {
             int half_w = xr.display_width() / 2;
             int dh     = xr.display_height();
             glViewport(0,      0, half_w, dh);
-            timewarp.warp_frame(xr.eye_left().tex,  ew, eh, current_pose);
+            timewarp.warp_frame(left_src,  ew, eh, current_pose);
             glViewport(half_w, 0, half_w, dh);
-            timewarp.warp_frame(xr.eye_right().tex, ew, eh, current_pose);
+            timewarp.warp_frame(right_src, ew, eh, current_pose);
         } else {
             // Standard composite (no latency correction)
             xr.composite();
@@ -1201,6 +1288,14 @@ int main(int argc, char* argv[]) {
 
         cfg["hud"]["indicator_bg_enabled"] = hud.config().indicator_bg_enabled;
 
+        auto& jpp = cfg["post_process"];
+        jpp["edge_enabled"]       = state.pp_cfg.edge_enabled;
+        jpp["edge_strength"]      = state.pp_cfg.edge_strength;
+        jpp["edge_color"]         = color_to_json(state.pp_cfg.edge_color);
+        jpp["desat_enabled"]      = state.pp_cfg.desat_enabled;
+        jpp["desat_strength"]     = state.pp_cfg.desat_strength;
+        jpp["contrast_threshold"] = state.pp_cfg.contrast_threshold;
+
         auto& jm = cfg["menu_style"];
         jm["accent_color"] = color_to_json(menu.accent_color());
         jm["bg_color"]     = color_to_json(menu.bg_color());
@@ -1234,6 +1329,10 @@ int main(int argc, char* argv[]) {
     if (tex_usb2)    glDeleteTextures(1, &tex_usb2);
     if (tex_beast)   glDeleteTextures(1, &tex_beast);
     if (tex_android) glDeleteTextures(1, &tex_android);
+
+    pp_fbo_left.destroy();
+    pp_fbo_right.destroy();
+    post_proc.shutdown();
 
     xr.shutdown();
     return 0;

--- a/src/post_process.cpp
+++ b/src/post_process.cpp
@@ -1,0 +1,71 @@
+#include "post_process.h"
+#include "gl_utils.h"
+#include <iostream>
+
+bool PostProcessor::init(int w, int h, const char* vs_path, const char* fs_path) {
+    w_ = w;
+    h_ = h;
+
+    prog_ = gl::build_program(vs_path, fs_path);
+    if (!prog_) {
+        std::cerr << "[post_process] shader build failed\n";
+        return false;
+    }
+
+    loc_scene_     = glGetUniformLocation(prog_, "u_scene");
+    loc_texel_     = glGetUniformLocation(prog_, "u_texel");
+    loc_edge_str_  = glGetUniformLocation(prog_, "u_edge_str");
+    loc_desat_str_ = glGetUniformLocation(prog_, "u_desat_str");
+    loc_edge_col_  = glGetUniformLocation(prog_, "u_edge_col");
+    loc_threshold_ = glGetUniformLocation(prog_, "u_threshold");
+    loc_has_depth_ = glGetUniformLocation(prog_, "u_has_depth");
+
+    vbo_ = gl::make_quad_vbo();
+    if (!vbo_) {
+        std::cerr << "[post_process] VBO creation failed\n";
+        glDeleteProgram(prog_);
+        prog_ = 0;
+        return false;
+    }
+    return true;
+}
+
+void PostProcessor::shutdown() {
+    if (prog_) { glDeleteProgram(prog_); prog_ = 0; }
+    if (vbo_)  { glDeleteBuffers(1, &vbo_); vbo_ = 0; }
+}
+
+void PostProcessor::process(GLuint src_tex, const gl::Fbo& dst,
+                             const PostProcessConfig& cfg) {
+    dst.bind();
+    glClearColor(0.f, 0.f, 0.f, 1.f);
+    glClear(GL_COLOR_BUFFER_BIT);
+
+    glUseProgram(prog_);
+
+    glActiveTexture(GL_TEXTURE0);
+    glBindTexture(GL_TEXTURE_2D, src_tex);
+    glUniform1i(loc_scene_, 0);
+
+    glUniform2f(loc_texel_, 1.f / static_cast<float>(w_),
+                             1.f / static_cast<float>(h_));
+
+    glUniform1f(loc_edge_str_,  cfg.edge_enabled  ? cfg.edge_strength  : 0.f);
+    glUniform1f(loc_desat_str_, cfg.desat_enabled ? cfg.desat_strength : 0.f);
+
+    // ImU32 is IM_COL32(R,G,B,A) = A<<24 | B<<16 | G<<8 | R<<0
+    const float er = ((cfg.edge_color >>  0) & 0xFF) / 255.f;
+    const float eg = ((cfg.edge_color >>  8) & 0xFF) / 255.f;
+    const float eb = ((cfg.edge_color >> 16) & 0xFF) / 255.f;
+    glUniform3f(loc_edge_col_, er, eg, eb);
+
+    glUniform1f(loc_threshold_, cfg.contrast_threshold);
+    glUniform1f(loc_has_depth_, 0.f);
+
+    gl::bind_quad(vbo_);
+    gl::draw_quad();
+    gl::unbind_quad();
+
+    glUseProgram(0);
+    dst.unbind();
+}

--- a/src/post_process.h
+++ b/src/post_process.h
@@ -1,0 +1,50 @@
+#pragma once
+#include "app_state.h"
+#include "gl_utils.h"
+#include <GLES2/gl2.h>
+
+// ── PostProcessor ─────────────────────────────────────────────────────────────
+// Single fullscreen GLES 2.0 post-processing pass: Sobel edge highlight and
+// local-contrast background desaturation. Both effects are independently gated
+// by PostProcessConfig::edge_enabled / desat_enabled.
+//
+// Usage (render thread only):
+//   if (!post_proc.init(eye_w, eye_h, vs_path, fs_path)) { ... }
+//   ...
+//   // Each frame:
+//   if (post_proc.any_enabled(pp_cfg))
+//       post_proc.process(src_tex, dst_fbo, pp_cfg);
+//   xr.composite(dst_fbo.tex or src_tex);
+//   ...
+//   post_proc.shutdown();
+
+class PostProcessor {
+public:
+    // Allocate the output FBO and compile shaders. Must be called after the GL
+    // context is current. Returns false on any GL error.
+    bool init(int w, int h, const char* vs_path, const char* fs_path);
+    void shutdown();
+
+    // Apply the post-process pass: read src_tex, write result to dst.
+    // dst must be a valid gl::Fbo with matching dimensions.
+    void process(GLuint src_tex, const gl::Fbo& dst, const PostProcessConfig& cfg);
+
+    bool any_enabled(const PostProcessConfig& cfg) const {
+        return cfg.edge_enabled || cfg.desat_enabled;
+    }
+
+private:
+    GLuint prog_ = 0;
+    GLuint vbo_  = 0;
+
+    // Cached uniform locations (set at init time)
+    GLint loc_scene_     = -1;
+    GLint loc_texel_     = -1;
+    GLint loc_edge_str_  = -1;
+    GLint loc_desat_str_ = -1;
+    GLint loc_edge_col_  = -1;
+    GLint loc_threshold_ = -1;
+    GLint loc_has_depth_ = -1;
+
+    int w_ = 0, h_ = 0;
+};


### PR DESCRIPTION
…ration

Implements a GLES 2.0 fullscreen post-processing pass that creates artificial monocular depth cues for single-eye vision. Two effects are independently toggleable: Sobel edge highlighting accentuates foreground object boundaries, and local-contrast-based desaturation mutes background regions where uniform areas (sky, walls) lack depth cues.

- assets/shaders/postprocess.{vs,fs}: passthrough vertex + 9-sample Sobel
  + contrast proxy fragment shader, fully unrolled for GLES 2.0
- src/post_process.{h,cpp}: PostProcessor class (init/shutdown/process) using existing gl:: quad/FBO/program infrastructure
- src/app_state.h: PostProcessConfig struct + pp_cfg field in AppState
- src/main.cpp: init two per-eye FBOs, apply pass before timewarp, Vision Assist submenu with toggle/strength/color/threshold presets, config load/save
- config/config.json: post_process block with defaults (both disabled)
- CMakeLists.txt: add post_process.cpp to source list

Depth hardware path (OAK-D Lite or RealSense) is pre-wired in the shader via u_depth sampler + u_has_depth uniform; enabling it only requires binding a depth texture and setting the uniform to 1.0.

https://claude.ai/code/session_01TxT4j1se1Vg9GmBmZTJSii