### PR TITLE
Vision Assist: silhouette-only outlines, detail/threshold controls, full-color foreground

### DIFF
--- a/assets/shaders/postprocess.fs
+++ b/assets/shaders/postprocess.fs
@@ -23,6 +23,8 @@ uniform float     u_desat_str;  // 0.0–1.0 background desaturation intensity
 uniform vec3      u_edge_col;   // edge overlay colour (normalised RGB)
 uniform float     u_threshold;  // local contrast below this = background (0.07–0.25)
 uniform float     u_has_depth;  // 0.0 = use contrast proxy, 1.0 = sample u_depth
+uniform float     u_edge_scale; // sampling step multiplier (1.0–5.0); larger = coarser outline
+uniform float     u_edge_thresh;// minimum edge magnitude (0.0–0.6); suppresses weak interior edges
 
 varying vec2 v_uv;
 
@@ -32,15 +34,17 @@ float luma(vec3 c) {
 
 void main() {
     // ── Sample 3×3 neighbourhood ──────────────────────────────────────────────
-    vec3 c00 = texture2D(u_scene, v_uv + vec2(-1.0, -1.0) * u_texel).rgb;
-    vec3 c10 = texture2D(u_scene, v_uv + vec2( 0.0, -1.0) * u_texel).rgb;
-    vec3 c20 = texture2D(u_scene, v_uv + vec2( 1.0, -1.0) * u_texel).rgb;
-    vec3 c01 = texture2D(u_scene, v_uv + vec2(-1.0,  0.0) * u_texel).rgb;
+    // u_edge_scale widens the kernel: scale=1 detects all texture, scale=5 = silhouette only
+    vec2 step = u_texel * u_edge_scale;
+    vec3 c00 = texture2D(u_scene, v_uv + vec2(-1.0, -1.0) * step).rgb;
+    vec3 c10 = texture2D(u_scene, v_uv + vec2( 0.0, -1.0) * step).rgb;
+    vec3 c20 = texture2D(u_scene, v_uv + vec2( 1.0, -1.0) * step).rgb;
+    vec3 c01 = texture2D(u_scene, v_uv + vec2(-1.0,  0.0) * step).rgb;
     vec3 c11 = texture2D(u_scene, v_uv).rgb;
-    vec3 c21 = texture2D(u_scene, v_uv + vec2( 1.0,  0.0) * u_texel).rgb;
-    vec3 c02 = texture2D(u_scene, v_uv + vec2(-1.0,  1.0) * u_texel).rgb;
-    vec3 c12 = texture2D(u_scene, v_uv + vec2( 0.0,  1.0) * u_texel).rgb;
-    vec3 c22 = texture2D(u_scene, v_uv + vec2( 1.0,  1.0) * u_texel).rgb;
+    vec3 c21 = texture2D(u_scene, v_uv + vec2( 1.0,  0.0) * step).rgb;
+    vec3 c02 = texture2D(u_scene, v_uv + vec2(-1.0,  1.0) * step).rgb;
+    vec3 c12 = texture2D(u_scene, v_uv + vec2( 0.0,  1.0) * step).rgb;
+    vec3 c22 = texture2D(u_scene, v_uv + vec2( 1.0,  1.0) * step).rgb;
 
     float l00 = luma(c00); float l10 = luma(c10); float l20 = luma(c20);
     float l01 = luma(c01); float l11 = luma(c11); float l21 = luma(c21);
@@ -49,7 +53,9 @@ void main() {
     // ── Sobel edge detection ──────────────────────────────────────────────────
     float gx = -l00 - 2.0*l01 - l02 + l20 + 2.0*l21 + l22;
     float gy = -l00 - 2.0*l10 - l20 + l02 + 2.0*l12 + l22;
-    float edge = clamp(sqrt(gx*gx + gy*gy) * 4.0, 0.0, 1.0);
+    float raw_edge = clamp(sqrt(gx*gx + gy*gy) * 4.0, 0.0, 1.0);
+    // Remap so edges below u_edge_thresh vanish and strong edges stay at 1.0
+    float edge = clamp((raw_edge - u_edge_thresh) / (1.0 - u_edge_thresh + 0.001), 0.0, 1.0);
 
     // ── Background weight ─────────────────────────────────────────────────────
     float bg_weight;
@@ -66,8 +72,10 @@ void main() {
     }
 
     // ── Desaturate background ─────────────────────────────────────────────────
+    // Outlined pixels stay in full color: strong edges suppress desaturation.
+    // When edge detection is off (u_edge_str=0) this reduces to standard bg_weight behaviour.
     vec3  grey  = vec3(l11);
-    vec3  color = mix(c11, grey, bg_weight * u_desat_str);
+    vec3  color = mix(c11, grey, bg_weight * (1.0 - edge * u_edge_str) * u_desat_str);
 
     // ── Overlay edges ─────────────────────────────────────────────────────────
     color = mix(color, u_edge_col, edge * u_edge_str);

--- a/config/config.json
+++ b/config/config.json
@@ -146,7 +146,9 @@
     "edge_color": [255, 160, 32, 255],
     "desat_enabled": false,
     "desat_strength": 0.8,
-    "contrast_threshold": 0.15
+    "contrast_threshold": 0.15,
+    "edge_scale": 2.0,
+    "edge_threshold": 0.0
   },
   "colors": {
     "hud_primary":    [0, 220, 180, 220],

--- a/src/app_state.h
+++ b/src/app_state.h
@@ -19,6 +19,8 @@ struct PostProcessConfig {
     bool  desat_enabled      = false;
     float desat_strength     = 0.8f;
     float contrast_threshold = 0.15f;  // 0.07 = aggressive, 0.25 = subtle
+    float edge_scale         = 2.0f;   // 1.0–5.0; larger step = coarser outline, fewer interior edges
+    float edge_threshold     = 0.0f;   // 0.0–0.6; suppress edges weaker than this magnitude
 };
 
 // ── Overlay layout config (PiP and Android mirror) ───────────────────────────

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -709,6 +709,20 @@ static std::vector<MenuItem> build_menu(
         leaf("White",  [&state]{ state.pp_cfg.edge_color = IM_COL32(255, 255, 255, 255); }),
     };
 
+    std::vector<MenuItem> edge_detail_menu = {
+        leaf("Fine (1x)",       [&state]{ state.pp_cfg.edge_scale = 1.0f; }),
+        leaf("Standard (2x)",   [&state]{ state.pp_cfg.edge_scale = 2.0f; }),
+        leaf("Coarse (3x)",     [&state]{ state.pp_cfg.edge_scale = 3.0f; }),
+        leaf("Silhouette (5x)", [&state]{ state.pp_cfg.edge_scale = 5.0f; }),
+    };
+
+    std::vector<MenuItem> edge_threshold_menu = {
+        leaf("None",   [&state]{ state.pp_cfg.edge_threshold = 0.00f; }),
+        leaf("Low",    [&state]{ state.pp_cfg.edge_threshold = 0.15f; }),
+        leaf("Medium", [&state]{ state.pp_cfg.edge_threshold = 0.30f; }),
+        leaf("High",   [&state]{ state.pp_cfg.edge_threshold = 0.50f; }),
+    };
+
     std::vector<MenuItem> desat_strength_menu = {
         leaf("25%",  [&state]{ state.pp_cfg.desat_strength = 0.25f; }),
         leaf("50%",  [&state]{ state.pp_cfg.desat_strength = 0.50f; }),
@@ -728,6 +742,8 @@ static std::vector<MenuItem> build_menu(
             [&state](bool v){ state.pp_cfg.edge_enabled = v; }),
         submenu("Edge Strength",  std::move(edge_strength_menu)),
         submenu("Edge Color",     std::move(edge_color_menu)),
+        submenu("Edge Detail",    std::move(edge_detail_menu)),
+        submenu("Edge Threshold", std::move(edge_threshold_menu)),
         toggle("Bg Desaturate",
             [&state]{ return state.pp_cfg.desat_enabled; },
             [&state](bool v){ state.pp_cfg.desat_enabled = v; }),
@@ -962,6 +978,8 @@ int main(int argc, char* argv[]) {
         state.pp_cfg.desat_enabled      = jpp.value("desat_enabled",      false);
         state.pp_cfg.desat_strength     = jpp.value("desat_strength",     0.8f);
         state.pp_cfg.contrast_threshold = jpp.value("contrast_threshold", 0.15f);
+        state.pp_cfg.edge_scale         = jpp.value("edge_scale",         2.0f);
+        state.pp_cfg.edge_threshold     = jpp.value("edge_threshold",     0.0f);
         if (jpp.contains("edge_color") && jpp["edge_color"].is_array() &&
             jpp["edge_color"].size() >= 3) {
             auto& jc = jpp["edge_color"];
@@ -1477,6 +1495,8 @@ int main(int argc, char* argv[]) {
         jpp["desat_enabled"]      = state.pp_cfg.desat_enabled;
         jpp["desat_strength"]     = state.pp_cfg.desat_strength;
         jpp["contrast_threshold"] = state.pp_cfg.contrast_threshold;
+        jpp["edge_scale"]         = state.pp_cfg.edge_scale;
+        jpp["edge_threshold"]     = state.pp_cfg.edge_threshold;
 
         auto& jm = cfg["menu_style"];
         jm["accent_color"] = color_to_json(menu.accent_color());

--- a/src/post_process.cpp
+++ b/src/post_process.cpp
@@ -12,13 +12,15 @@ bool PostProcessor::init(int w, int h, const char* vs_path, const char* fs_path)
         return false;
     }
 
-    loc_scene_     = glGetUniformLocation(prog_, "u_scene");
-    loc_texel_     = glGetUniformLocation(prog_, "u_texel");
-    loc_edge_str_  = glGetUniformLocation(prog_, "u_edge_str");
-    loc_desat_str_ = glGetUniformLocation(prog_, "u_desat_str");
-    loc_edge_col_  = glGetUniformLocation(prog_, "u_edge_col");
-    loc_threshold_ = glGetUniformLocation(prog_, "u_threshold");
-    loc_has_depth_ = glGetUniformLocation(prog_, "u_has_depth");
+    loc_scene_       = glGetUniformLocation(prog_, "u_scene");
+    loc_texel_       = glGetUniformLocation(prog_, "u_texel");
+    loc_edge_str_    = glGetUniformLocation(prog_, "u_edge_str");
+    loc_desat_str_   = glGetUniformLocation(prog_, "u_desat_str");
+    loc_edge_col_    = glGetUniformLocation(prog_, "u_edge_col");
+    loc_threshold_   = glGetUniformLocation(prog_, "u_threshold");
+    loc_has_depth_   = glGetUniformLocation(prog_, "u_has_depth");
+    loc_edge_scale_  = glGetUniformLocation(prog_, "u_edge_scale");
+    loc_edge_thresh_ = glGetUniformLocation(prog_, "u_edge_thresh");
 
     vbo_ = gl::make_quad_vbo();
     if (!vbo_) {
@@ -59,8 +61,10 @@ void PostProcessor::process(GLuint src_tex, const gl::Fbo& dst,
     const float eb = ((cfg.edge_color >> 16) & 0xFF) / 255.f;
     glUniform3f(loc_edge_col_, er, eg, eb);
 
-    glUniform1f(loc_threshold_, cfg.contrast_threshold);
-    glUniform1f(loc_has_depth_, 0.f);
+    glUniform1f(loc_threshold_,   cfg.contrast_threshold);
+    glUniform1f(loc_has_depth_,   0.f);
+    glUniform1f(loc_edge_scale_,  cfg.edge_scale);
+    glUniform1f(loc_edge_thresh_, cfg.edge_threshold);
 
     gl::bind_quad(vbo_);
     gl::draw_quad();

--- a/src/post_process.h
+++ b/src/post_process.h
@@ -38,13 +38,15 @@ private:
     GLuint vbo_  = 0;
 
     // Cached uniform locations (set at init time)
-    GLint loc_scene_     = -1;
-    GLint loc_texel_     = -1;
-    GLint loc_edge_str_  = -1;
-    GLint loc_desat_str_ = -1;
-    GLint loc_edge_col_  = -1;
-    GLint loc_threshold_ = -1;
-    GLint loc_has_depth_ = -1;
+    GLint loc_scene_      = -1;
+    GLint loc_texel_      = -1;
+    GLint loc_edge_str_   = -1;
+    GLint loc_desat_str_  = -1;
+    GLint loc_edge_col_   = -1;
+    GLint loc_threshold_  = -1;
+    GLint loc_has_depth_  = -1;
+    GLint loc_edge_scale_ = -1;
+    GLint loc_edge_thresh_= -1;
 
     int w_ = 0, h_ = 0;
 };


### PR DESCRIPTION
AI Vision Improvements
## Summary

- **Main outlines only**: Wide-baseline Sobel (`u_edge_scale`) widens the 3×3 sampling step so high-frequency texture inside objects averages out — only structural boundaries survive. Default raised from 1× to 2× so the new behavior is active out of the box.
- **Detail and intensity controls**: Two new Vision Assist submenus — *Edge Detail* (Fine 1×/ Standard 2×/ Coarse 3×/ Silhouette 5×) and *Edge Threshold* (None / Low / Medium / High) — let the user tune exactly how coarse and how strong the outline needs to be before it's drawn.
- **Full-color foreground**: Desaturation is now suppressed where edges are detected (`bg_weight × (1 − edge × edge_str)`). Items with visible outlines stay in natural color while the flat background fades to grey. When edge detection is off the desaturation behavior is unchanged.

## Files changed

| File | Change |
|------|--------|
| `assets/shaders/postprocess.fs` | Scale sampling step, threshold remapping, desaturation coupling |
| `src/app_state.h` | `edge_scale` and `edge_threshold` fields in `PostProcessConfig` |
| `src/post_process.h` | `loc_edge_scale_` / `loc_edge_thresh_` uniform location members |
| `src/post_process.cpp` | Cache + upload new uniforms |
| `src/main.cpp` | Edge Detail + Edge Threshold menus; config load/save |
| `config/config.json` | Default values (`edge_scale: 2.0`, `edge_threshold: 0.0`) |

## Test plan

- [ ] Enable Edge Highlight at Standard (2×) — clothing texture should not produce interior outlines; body boundary should be clearly highlighted
- [ ] Switch to Silhouette (5×) — only the outermost contour of objects should appear
- [ ] Set Edge Threshold → High — weak interior gradients disappear, only sharp boundaries remain
- [ ] Enable both Edge Highlight and Bg Desaturate — outlined person's body stays in full color, plain background turns grey
- [ ] Verify backward compat: Fine (1×) + Threshold None produces visually identical output to the old behavior
- [ ] Exit and relaunch — `edge_scale` and `edge_threshold` are restored from config

https://claude.ai/code/session_01LH94rdjztXGergQJDGJ3sV
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH94rdjztXGergQJDGJ3sV)_