### PR TITLE
Vision assist: focal-sharpness bg detection, coarser outline defaults

### DIFF
--- a/assets/shaders/postprocess.fs
+++ b/assets/shaders/postprocess.fs
@@ -25,6 +25,8 @@ uniform float     u_threshold;  // local contrast below this = background (0.07�
 uniform float     u_has_depth;  // 0.0 = use contrast proxy, 1.0 = sample u_depth
 uniform float     u_edge_scale; // sampling step multiplier (1.0–5.0); larger = coarser outline
 uniform float     u_edge_thresh;// minimum edge magnitude (0.0–0.6); suppresses weak interior edges
+uniform float     u_focus_str;  // 0.0=contrast proxy only, 1.0=Laplacian sharpness only for bg_weight
+uniform float     u_focus_sens; // Laplacian sensitivity (scales with lens proximity)
 
 varying vec2 v_uv;
 
@@ -70,6 +72,14 @@ void main() {
         float contrast = hi - lo;
         bg_weight = clamp(1.0 - contrast / max(u_threshold, 0.01), 0.0, 1.0);
     }
+
+    // ── Focus-based sharpness refinement ──────────────────────────────────────
+    // Laplacian at center pixel: measures how sharp/in-focus this pixel is.
+    // High = sharp (in focus = foreground). Low = blurry (out of focus = background).
+    // Sensitivity scales with lens proximity: close focus → narrow DoF → stronger separation.
+    float lap        = abs(8.0*l11 - l00 - l10 - l20 - l01 - l21 - l02 - l12 - l22);
+    float sharpness  = clamp(lap * u_focus_sens, 0.0, 1.0);
+    bg_weight        = mix(bg_weight, 1.0 - sharpness, u_focus_str);
 
     // ── Desaturate background ─────────────────────────────────────────────────
     // Outlined pixels stay in full color: strong edges suppress desaturation.

--- a/config/config.json
+++ b/config/config.json
@@ -147,8 +147,9 @@
     "desat_enabled": false,
     "desat_strength": 0.8,
     "contrast_threshold": 0.15,
-    "edge_scale": 2.0,
-    "edge_threshold": 0.0
+    "edge_scale": 3.0,
+    "edge_threshold": 0.15,
+    "focus_str": 0.0
   },
   "colors": {
     "hud_primary":    [0, 220, 180, 220],

--- a/src/app_state.h
+++ b/src/app_state.h
@@ -19,8 +19,10 @@ struct PostProcessConfig {
     bool  desat_enabled      = false;
     float desat_strength     = 0.8f;
     float contrast_threshold = 0.15f;  // 0.07 = aggressive, 0.25 = subtle
-    float edge_scale         = 2.0f;   // 1.0–5.0; larger step = coarser outline, fewer interior edges
-    float edge_threshold     = 0.0f;   // 0.0–0.6; suppress edges weaker than this magnitude
+    float edge_scale         = 3.0f;   // 1.0–5.0; larger step = coarser outline, fewer interior edges
+    float edge_threshold     = 0.15f;  // 0.0–0.6; suppress edges weaker than this magnitude
+    float focus_str          = 0.0f;   // 0.0–1.0; blend Laplacian sharpness into bg_weight
+    int   focus_lens_pos     = 500;    // 0–1000 from AF; set each frame — not persisted
 };
 
 // ── Overlay layout config (PiP and Android mirror) ───────────────────────────

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -736,6 +736,13 @@ static std::vector<MenuItem> build_menu(
         leaf("Aggressive (0.07)", [&state]{ state.pp_cfg.contrast_threshold = 0.07f; }),
     };
 
+    std::vector<MenuItem> focus_blend_menu = {
+        leaf("Off",    [&state]{ state.pp_cfg.focus_str = 0.0f; }),
+        leaf("Low",    [&state]{ state.pp_cfg.focus_str = 0.3f; }),
+        leaf("Medium", [&state]{ state.pp_cfg.focus_str = 0.6f; }),
+        leaf("Full",   [&state]{ state.pp_cfg.focus_str = 1.0f; }),
+    };
+
     std::vector<MenuItem> vision_menu = {
         toggle("Edge Highlight",
             [&state]{ return state.pp_cfg.edge_enabled; },
@@ -749,6 +756,7 @@ static std::vector<MenuItem> build_menu(
             [&state](bool v){ state.pp_cfg.desat_enabled = v; }),
         submenu("Desat Strength", std::move(desat_strength_menu)),
         submenu("BG Threshold",   std::move(bg_threshold_menu)),
+        submenu("Focus Blend",    std::move(focus_blend_menu)),
     };
 
     std::vector<MenuItem> settings_menu = {
@@ -978,8 +986,9 @@ int main(int argc, char* argv[]) {
         state.pp_cfg.desat_enabled      = jpp.value("desat_enabled",      false);
         state.pp_cfg.desat_strength     = jpp.value("desat_strength",     0.8f);
         state.pp_cfg.contrast_threshold = jpp.value("contrast_threshold", 0.15f);
-        state.pp_cfg.edge_scale         = jpp.value("edge_scale",         2.0f);
-        state.pp_cfg.edge_threshold     = jpp.value("edge_threshold",     0.0f);
+        state.pp_cfg.edge_scale         = jpp.value("edge_scale",         3.0f);
+        state.pp_cfg.edge_threshold     = jpp.value("edge_threshold",     0.15f);
+        state.pp_cfg.focus_str          = jpp.value("focus_str",          0.0f);
         if (jpp.contains("edge_color") && jpp["edge_color"].is_array() &&
             jpp["edge_color"].size() >= 3) {
             auto& jc = jpp["edge_color"];
@@ -1357,6 +1366,10 @@ int main(int argc, char* argv[]) {
             snap.pp_cfg             = state.pp_cfg;
         }
 
+        // Inject live AF lens position into the snapshot (atomic read, no lock needed)
+        if (cameras.owl_left())
+            snap.pp_cfg.focus_lens_pos = cameras.owl_left()->get_focus_position();
+
         // Record render-time pose for timewarp
         timewarp.begin_frame(snap.imu_pose);
 
@@ -1497,6 +1510,7 @@ int main(int argc, char* argv[]) {
         jpp["contrast_threshold"] = state.pp_cfg.contrast_threshold;
         jpp["edge_scale"]         = state.pp_cfg.edge_scale;
         jpp["edge_threshold"]     = state.pp_cfg.edge_threshold;
+        jpp["focus_str"]          = state.pp_cfg.focus_str;
 
         auto& jm = cfg["menu_style"];
         jm["accent_color"] = color_to_json(menu.accent_color());

--- a/src/post_process.cpp
+++ b/src/post_process.cpp
@@ -21,6 +21,8 @@ bool PostProcessor::init(int w, int h, const char* vs_path, const char* fs_path)
     loc_has_depth_   = glGetUniformLocation(prog_, "u_has_depth");
     loc_edge_scale_  = glGetUniformLocation(prog_, "u_edge_scale");
     loc_edge_thresh_ = glGetUniformLocation(prog_, "u_edge_thresh");
+    loc_focus_str_   = glGetUniformLocation(prog_, "u_focus_str");
+    loc_focus_sens_  = glGetUniformLocation(prog_, "u_focus_sens");
 
     vbo_ = gl::make_quad_vbo();
     if (!vbo_) {
@@ -65,6 +67,11 @@ void PostProcessor::process(GLuint src_tex, const gl::Fbo& dst,
     glUniform1f(loc_has_depth_,   0.f);
     glUniform1f(loc_edge_scale_,  cfg.edge_scale);
     glUniform1f(loc_edge_thresh_, cfg.edge_threshold);
+
+    // Focus-based sharpness: sensitivity scales with lens proximity (close = narrow DoF = stronger separation)
+    const float focus_norm = static_cast<float>(cfg.focus_lens_pos) / 1000.0f;
+    glUniform1f(loc_focus_str_,  cfg.focus_str);
+    glUniform1f(loc_focus_sens_, 1.0f + focus_norm * 3.0f);
 
     gl::bind_quad(vbo_);
     gl::draw_quad();

--- a/src/post_process.h
+++ b/src/post_process.h
@@ -45,8 +45,10 @@ private:
     GLint loc_edge_col_   = -1;
     GLint loc_threshold_  = -1;
     GLint loc_has_depth_  = -1;
-    GLint loc_edge_scale_ = -1;
-    GLint loc_edge_thresh_= -1;
+    GLint loc_edge_scale_  = -1;
+    GLint loc_edge_thresh_ = -1;
+    GLint loc_focus_str_   = -1;
+    GLint loc_focus_sens_  = -1;
 
     int w_ = 0, h_ = 0;
 };


### PR DESCRIPTION
- Add Laplacian-based sharpness proxy to bg_weight: the center-pixel Laplacian measures focus sharpness directly from the image. Blurry (out-of-focus) pixels get high bg_weight (desaturated); sharp (in-focus) pixels stay in full color. Sensitivity auto-scales with the live AF lens position from owl_left (close focus → narrow DoF → stronger separation).
- New 'Focus Blend' menu (Off/Low/Medium/Full) blends the Laplacian proxy into the existing contrast proxy; Off preserves old behavior.
- Raise default edge_scale 2.0 → 3.0 and edge_threshold 0.0 → 0.15 so the out-of-the-box experience shows structural outlines only, not clothing texture or fine interior detail.
- focus_str persists in config; focus_lens_pos is runtime-only.

https://claude.ai/code/session_01LH94rdjztXGergQJDGJ3sV