### PR TITLE
Vision assist: dual-scale edge gate suppresses small objects and noise

### DIFF
--- a/assets/shaders/postprocess.fs
+++ b/assets/shaders/postprocess.fs
@@ -27,6 +27,7 @@ uniform float     u_edge_scale; // sampling step multiplier (1.0–5.0); larger 
 uniform float     u_edge_thresh;// minimum edge magnitude (0.0–0.6); suppresses weak interior edges
 uniform float     u_focus_str;  // 0.0=contrast proxy only, 1.0=Laplacian sharpness only for bg_weight
 uniform float     u_focus_sens; // Laplacian sensitivity (scales with lens proximity)
+uniform float     u_gate_scale; // 0.0=off, else=step multiplier for confirmatory coarse Sobel (size filter)
 
 varying vec2 v_uv;
 
@@ -58,6 +59,26 @@ void main() {
     float raw_edge = clamp(sqrt(gx*gx + gy*gy) * 4.0, 0.0, 1.0);
     // Remap so edges below u_edge_thresh vanish and strong edges stay at 1.0
     float edge = clamp((raw_edge - u_edge_thresh) / (1.0 - u_edge_thresh + 0.001), 0.0, 1.0);
+
+    // ── Dual-scale size gate ──────────────────────────────────────────────────
+    // Confirm edge at a coarser scale: small objects/noise vanish at larger step,
+    // so the product suppresses them while large objects pass both tests.
+    // g11 (center) is shared with l11 — 8 new samples only.
+    if (u_gate_scale >= 1.0) {
+        vec2 step2  = step * u_gate_scale;
+        float g00 = luma(texture2D(u_scene, v_uv + vec2(-1.0,-1.0)*step2).rgb);
+        float g10 = luma(texture2D(u_scene, v_uv + vec2( 0.0,-1.0)*step2).rgb);
+        float g20 = luma(texture2D(u_scene, v_uv + vec2( 1.0,-1.0)*step2).rgb);
+        float g01 = luma(texture2D(u_scene, v_uv + vec2(-1.0, 0.0)*step2).rgb);
+        float g21 = luma(texture2D(u_scene, v_uv + vec2( 1.0, 0.0)*step2).rgb);
+        float g02 = luma(texture2D(u_scene, v_uv + vec2(-1.0, 1.0)*step2).rgb);
+        float g12 = luma(texture2D(u_scene, v_uv + vec2( 0.0, 1.0)*step2).rgb);
+        float g22 = luma(texture2D(u_scene, v_uv + vec2( 1.0, 1.0)*step2).rgb);
+        float gx2 = -g00 - 2.0*g01 - g02 + g20 + 2.0*g21 + g22;
+        float gy2 = -g00 - 2.0*g10 - g20 + g02 + 2.0*g12 + g22;
+        float edge2 = clamp(sqrt(gx2*gx2 + gy2*gy2) * 4.0, 0.0, 1.0);
+        edge = edge * edge2;
+    }
 
     // ── Background weight ─────────────────────────────────────────────────────
     float bg_weight;

--- a/config/config.json
+++ b/config/config.json
@@ -149,7 +149,8 @@
     "contrast_threshold": 0.15,
     "edge_scale": 3.0,
     "edge_threshold": 0.15,
-    "focus_str": 0.0
+    "focus_str": 0.0,
+    "edge_gate_scale": 2.0
   },
   "colors": {
     "hud_primary":    [0, 220, 180, 220],

--- a/src/app_state.h
+++ b/src/app_state.h
@@ -23,6 +23,7 @@ struct PostProcessConfig {
     float edge_threshold     = 0.15f;  // 0.0–0.6; suppress edges weaker than this magnitude
     float focus_str          = 0.0f;   // 0.0–1.0; blend Laplacian sharpness into bg_weight
     int   focus_lens_pos     = 500;    // 0–1000 from AF; set each frame — not persisted
+    float edge_gate_scale    = 2.0f;   // 0.0=off, else=step multiplier for coarse confirmatory Sobel
 };
 
 // ── Overlay layout config (PiP and Android mirror) ───────────────────────────

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -743,6 +743,12 @@ static std::vector<MenuItem> build_menu(
         leaf("Full",   [&state]{ state.pp_cfg.focus_str = 1.0f; }),
     };
 
+    std::vector<MenuItem> size_filter_menu = {
+        leaf("Off",        [&state]{ state.pp_cfg.edge_gate_scale = 0.0f; }),
+        leaf("Medium (2x)",[&state]{ state.pp_cfg.edge_gate_scale = 2.0f; }),
+        leaf("Strong (3x)",[&state]{ state.pp_cfg.edge_gate_scale = 3.0f; }),
+    };
+
     std::vector<MenuItem> vision_menu = {
         toggle("Edge Highlight",
             [&state]{ return state.pp_cfg.edge_enabled; },
@@ -751,6 +757,7 @@ static std::vector<MenuItem> build_menu(
         submenu("Edge Color",     std::move(edge_color_menu)),
         submenu("Edge Detail",    std::move(edge_detail_menu)),
         submenu("Edge Threshold", std::move(edge_threshold_menu)),
+        submenu("Size Filter",    std::move(size_filter_menu)),
         toggle("Bg Desaturate",
             [&state]{ return state.pp_cfg.desat_enabled; },
             [&state](bool v){ state.pp_cfg.desat_enabled = v; }),
@@ -989,6 +996,7 @@ int main(int argc, char* argv[]) {
         state.pp_cfg.edge_scale         = jpp.value("edge_scale",         3.0f);
         state.pp_cfg.edge_threshold     = jpp.value("edge_threshold",     0.15f);
         state.pp_cfg.focus_str          = jpp.value("focus_str",          0.0f);
+        state.pp_cfg.edge_gate_scale    = jpp.value("edge_gate_scale",    2.0f);
         if (jpp.contains("edge_color") && jpp["edge_color"].is_array() &&
             jpp["edge_color"].size() >= 3) {
             auto& jc = jpp["edge_color"];
@@ -1511,6 +1519,7 @@ int main(int argc, char* argv[]) {
         jpp["edge_scale"]         = state.pp_cfg.edge_scale;
         jpp["edge_threshold"]     = state.pp_cfg.edge_threshold;
         jpp["focus_str"]          = state.pp_cfg.focus_str;
+        jpp["edge_gate_scale"]    = state.pp_cfg.edge_gate_scale;
 
         auto& jm = cfg["menu_style"];
         jm["accent_color"] = color_to_json(menu.accent_color());

--- a/src/post_process.cpp
+++ b/src/post_process.cpp
@@ -23,6 +23,7 @@ bool PostProcessor::init(int w, int h, const char* vs_path, const char* fs_path)
     loc_edge_thresh_ = glGetUniformLocation(prog_, "u_edge_thresh");
     loc_focus_str_   = glGetUniformLocation(prog_, "u_focus_str");
     loc_focus_sens_  = glGetUniformLocation(prog_, "u_focus_sens");
+    loc_gate_scale_  = glGetUniformLocation(prog_, "u_gate_scale");
 
     vbo_ = gl::make_quad_vbo();
     if (!vbo_) {
@@ -72,6 +73,7 @@ void PostProcessor::process(GLuint src_tex, const gl::Fbo& dst,
     const float focus_norm = static_cast<float>(cfg.focus_lens_pos) / 1000.0f;
     glUniform1f(loc_focus_str_,  cfg.focus_str);
     glUniform1f(loc_focus_sens_, 1.0f + focus_norm * 3.0f);
+    glUniform1f(loc_gate_scale_, cfg.edge_gate_scale);
 
     gl::bind_quad(vbo_);
     gl::draw_quad();

--- a/src/post_process.h
+++ b/src/post_process.h
@@ -49,6 +49,7 @@ private:
     GLint loc_edge_thresh_ = -1;
     GLint loc_focus_str_   = -1;
     GLint loc_focus_sens_  = -1;
+    GLint loc_gate_scale_  = -1;
 
     int w_ = 0, h_ = 0;
 };


### PR DESCRIPTION
The Sobel operator is a local operator with no sense of object size. Introduce a confirmatory coarse Sobel at u_gate_scale × the current step (default 2×) and multiply the two magnitudes together. A small object or noise speck that disappears at the wider scale contributes edge2≈0 and cancels the fine-scale edge. A large object stays visible at both scales and passes through.

- New Size Filter menu: Off / Medium (2×) / Strong (3×)
- Default edge_gate_scale=2.0 (active out of the box)
- Adds 8 extra texture samples when enabled; Off restores old cost
- edge_gate_scale persists in config

https://claude.ai/code/session_01LH94rdjztXGergQJDGJ3sV