### PR TITLE
Vision assist: fix Edge Detail visibility, add black outline, add 7x …

### DIFF
--- a/assets/shaders/postprocess.fs
+++ b/assets/shaders/postprocess.fs
@@ -56,7 +56,7 @@ void main() {
     // ── Sobel edge detection ──────────────────────────────────────────────────
     float gx = -l00 - 2.0*l01 - l02 + l20 + 2.0*l21 + l22;
     float gy = -l00 - 2.0*l10 - l20 + l02 + 2.0*l12 + l22;
-    float raw_edge = clamp(sqrt(gx*gx + gy*gy) * 4.0, 0.0, 1.0);
+    float raw_edge = clamp(sqrt(gx*gx + gy*gy) * 1.5, 0.0, 1.0);
     // Remap so edges below u_edge_thresh vanish and strong edges stay at 1.0
     float edge = clamp((raw_edge - u_edge_thresh) / (1.0 - u_edge_thresh + 0.001), 0.0, 1.0);
 
@@ -76,7 +76,7 @@ void main() {
         float g22 = luma(texture2D(u_scene, v_uv + vec2( 1.0, 1.0)*step2).rgb);
         float gx2 = -g00 - 2.0*g01 - g02 + g20 + 2.0*g21 + g22;
         float gy2 = -g00 - 2.0*g10 - g20 + g02 + 2.0*g12 + g22;
-        float edge2 = clamp(sqrt(gx2*gx2 + gy2*gy2) * 4.0, 0.0, 1.0);
+        float edge2 = clamp(sqrt(gx2*gx2 + gy2*gy2) * 1.5, 0.0, 1.0);
         edge = edge * edge2;
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -707,6 +707,7 @@ static std::vector<MenuItem> build_menu(
         leaf("Cyan",   [&state]{ state.pp_cfg.edge_color = IM_COL32(  0, 180, 255, 255); }),
         leaf("Green",  [&state]{ state.pp_cfg.edge_color = IM_COL32( 30, 220,  60, 255); }),
         leaf("White",  [&state]{ state.pp_cfg.edge_color = IM_COL32(255, 255, 255, 255); }),
+        leaf("Black",  [&state]{ state.pp_cfg.edge_color = IM_COL32(  0,   0,   0, 255); }),
     };
 
     std::vector<MenuItem> edge_detail_menu = {
@@ -714,6 +715,7 @@ static std::vector<MenuItem> build_menu(
         leaf("Standard (2x)",   [&state]{ state.pp_cfg.edge_scale = 2.0f; }),
         leaf("Coarse (3x)",     [&state]{ state.pp_cfg.edge_scale = 3.0f; }),
         leaf("Silhouette (5x)", [&state]{ state.pp_cfg.edge_scale = 5.0f; }),
+        leaf("Wide (7x)",       [&state]{ state.pp_cfg.edge_scale = 7.0f; }),
     };
 
     std::vector<MenuItem> edge_threshold_menu = {


### PR DESCRIPTION
…scale

The * 4.0 Sobel amplification caused all edges — fine texture and object boundaries alike — to saturate at 1.0, making scale/threshold controls produce no visible change. Reduced to * 1.5 so weak texture sits at 0.2–0.4 (below the default 0.15 threshold at coarser scales) while strong object boundaries still saturate to 1.0. Same fix applied to the dual-scale gate Sobel.

Also adds:
- Black to Edge Color options (useful with desaturated background)
- Wide (7x) to Edge Detail (for scenes with coarse-texture subjects)

https://claude.ai/code/session_01LH94rdjztXGergQJDGJ3sV