### PR TITLE
Enhance vision assistance: silhouette outlines, bg desaturation, USB brightness

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -30,13 +30,15 @@
       "device": "/dev/video17",
       "width": 1280,
       "height": 720,
-      "fps": 30
+      "fps": 30,
+      "brightness": 1.5
     },
     "usb_cam_2": {
       "device": "/dev/video36",
       "width": 1280,
       "height": 720,
-      "fps": 30
+      "fps": 30,
+      "brightness": 1.0
     }
   },
   "serial": {

--- a/src/camera/camera_manager.cpp
+++ b/src/camera/camera_manager.cpp
@@ -65,6 +65,7 @@ static bool open_v4l2(cv::VideoCapture& cap, const UsbCamConfig& cfg,
     cap.set(cv::CAP_PROP_FRAME_WIDTH,  cfg.width);
     cap.set(cv::CAP_PROP_FRAME_HEIGHT, cfg.height);
     cap.set(cv::CAP_PROP_FPS,          cfg.fps);
+    cap.set(cv::CAP_PROP_AUTO_EXPOSURE, 0.75);  // request auto-exposure (driver best-effort)
     int aw = static_cast<int>(cap.get(cv::CAP_PROP_FRAME_WIDTH));
     int ah = static_cast<int>(cap.get(cv::CAP_PROP_FRAME_HEIGHT));
     int af = static_cast<int>(cap.get(cv::CAP_PROP_FPS));
@@ -104,6 +105,8 @@ bool CameraManager::init(const CamConfig& left, const CamConfig& right,
     // ── USB cameras (OpenCV) ──────────────────────────────────────────────────
     usb1_cfg_ = usb1;
     usb2_cfg_ = usb2;
+    usb1_brightness_ = usb1.brightness;
+    usb2_brightness_ = usb2.brightness;
 
     // Scan /dev/video0-63 and list non-ISP capture nodes
     std::cerr << "[cam] USB cameras found:\n";
@@ -212,6 +215,7 @@ void CameraManager::usb_capture_thread() {
     auto capture = [&](cv::VideoCapture& cap, std::mutex& cap_mtx,
                        TexSlot& slot, std::atomic<bool>& ok_flag,
                        int& good, int& bad, int& consec,
+                       std::atomic<float>& brightness_ref,
                        const char* name) -> bool {
         bool got_frame = false;
         {
@@ -219,6 +223,9 @@ void CameraManager::usb_capture_thread() {
             if (!cap.isOpened()) { ok_flag = false; return false; }
             cap.read(frame);
             if (!frame.empty()) {
+                float b = brightness_ref.load();
+                if (b != 1.0f)
+                    frame.convertTo(frame, -1, static_cast<double>(b), 0.0);
                 cv::cvtColor(frame, rgba, cv::COLOR_BGR2RGBA);
                 got_frame = true;
                 consec = 0;
@@ -253,9 +260,9 @@ void CameraManager::usb_capture_thread() {
 
     while (running_) {
         bool any = capture(usb_cap1_, usb1_cap_mtx_, usb1_slot_, usb1_ok_,
-                           frames1, empty1, consec1, "usb1");
+                           frames1, empty1, consec1, usb1_brightness_, "usb1");
         any      |= capture(usb_cap2_, usb2_cap_mtx_, usb2_slot_, usb2_ok_,
-                            frames2, empty2, consec2, "usb2");
+                            frames2, empty2, consec2, usb2_brightness_, "usb2");
 
         // Auto-reconnect: periodically reopen disconnected cameras when enabled.
         auto now = std::chrono::steady_clock::now();

--- a/src/camera/camera_manager.h
+++ b/src/camera/camera_manager.h
@@ -24,9 +24,10 @@ struct CamConfig {
 
 struct UsbCamConfig {
     std::string device;
-    int width  = 1280;
-    int height = 720;
-    int fps    = 30;
+    int   width      = 1280;
+    int   height     = 720;
+    int   fps        = 30;
+    float brightness = 1.0f;  // software multiplier: 1.0=normal, 2.0=double, 0.5=half
 };
 
 // CameraManager owns:
@@ -102,6 +103,12 @@ public:
     void set_usb2_reconnect(bool v) { usb2_reconnect_ = v; }
     bool usb1_reconnect_enabled() const { return usb1_reconnect_; }
     bool usb2_reconnect_enabled() const { return usb2_reconnect_; }
+
+    // ── USB brightness (software multiplier, safe to call from any thread) ────
+    void  set_usb1_brightness(float v) { usb1_brightness_ = v; }
+    void  set_usb2_brightness(float v) { usb2_brightness_ = v; }
+    float usb1_brightness()      const { return usb1_brightness_.load(); }
+    float usb2_brightness()      const { return usb2_brightness_.load(); }
 
 private:
     void usb_capture_thread();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -402,6 +402,13 @@ static std::vector<MenuItem> build_menu(
         submenu("Position", make_position_items(pip_cfg1)),
         make_size_slider("Size", pip_cfg1),
     };
+    std::vector<MenuItem> usb1_brightness_menu = {
+        leaf("50%",  [cameras]{ if (cameras) cameras->set_usb1_brightness(0.5f); }),
+        leaf("100%", [cameras]{ if (cameras) cameras->set_usb1_brightness(1.0f); }),
+        leaf("150%", [cameras]{ if (cameras) cameras->set_usb1_brightness(1.5f); }),
+        leaf("200%", [cameras]{ if (cameras) cameras->set_usb1_brightness(2.0f); }),
+        leaf("300%", [cameras]{ if (cameras) cameras->set_usb1_brightness(3.0f); }),
+    };
     std::vector<MenuItem> usb_cam1_menu = {
         toggle("Open Stream",
             [cameras]{ return cameras && cameras->usb1_ok(); },
@@ -417,7 +424,8 @@ static std::vector<MenuItem> build_menu(
                     *pip_cam1_overlay = false;
                 }
             }),
-        submenu("Overlay", std::move(cam1_overlay_menu)),
+        submenu("Overlay",     std::move(cam1_overlay_menu)),
+        submenu("Brightness",  std::move(usb1_brightness_menu)),
         leaf("Scan for Camera", [cameras, &state]{
             if (cameras) {
                 bool ok = cameras->scan_usb1();
@@ -434,6 +442,13 @@ static std::vector<MenuItem> build_menu(
         submenu("Position", make_position_items(pip_cfg2)),
         make_size_slider("Size", pip_cfg2),
     };
+    std::vector<MenuItem> usb2_brightness_menu = {
+        leaf("50%",  [cameras]{ if (cameras) cameras->set_usb2_brightness(0.5f); }),
+        leaf("100%", [cameras]{ if (cameras) cameras->set_usb2_brightness(1.0f); }),
+        leaf("150%", [cameras]{ if (cameras) cameras->set_usb2_brightness(1.5f); }),
+        leaf("200%", [cameras]{ if (cameras) cameras->set_usb2_brightness(2.0f); }),
+        leaf("300%", [cameras]{ if (cameras) cameras->set_usb2_brightness(3.0f); }),
+    };
     std::vector<MenuItem> usb_cam2_menu = {
         toggle("Open Stream",
             [cameras]{ return cameras && cameras->usb2_ok(); },
@@ -449,7 +464,8 @@ static std::vector<MenuItem> build_menu(
                     *pip_cam2_overlay = false;
                 }
             }),
-        submenu("Overlay", std::move(cam2_overlay_menu)),
+        submenu("Overlay",    std::move(cam2_overlay_menu)),
+        submenu("Brightness", std::move(usb2_brightness_menu)),
         leaf("Scan for Camera", [cameras, &state]{
             if (cameras) {
                 bool ok = cameras->scan_usb2();
@@ -904,16 +920,18 @@ int main(int argc, char* argv[]) {
 
     UsbCamConfig usb1_cfg, usb2_cfg;
     if (jcam.contains("usb_cam_1")) {
-        usb1_cfg.device = jcam["usb_cam_1"].value("device", "/dev/video2");
-        usb1_cfg.width  = jcam["usb_cam_1"].value("width",  1280);
-        usb1_cfg.height = jcam["usb_cam_1"].value("height",  720);
-        usb1_cfg.fps    = jcam["usb_cam_1"].value("fps",      30);
+        usb1_cfg.device     = jcam["usb_cam_1"].value("device",     "/dev/video2");
+        usb1_cfg.width      = jcam["usb_cam_1"].value("width",       1280);
+        usb1_cfg.height     = jcam["usb_cam_1"].value("height",       720);
+        usb1_cfg.fps        = jcam["usb_cam_1"].value("fps",           30);
+        usb1_cfg.brightness = jcam["usb_cam_1"].value("brightness",   1.0f);
     }
     if (jcam.contains("usb_cam_2")) {
-        usb2_cfg.device = jcam["usb_cam_2"].value("device", "/dev/video3");
-        usb2_cfg.width  = jcam["usb_cam_2"].value("width",  1280);
-        usb2_cfg.height = jcam["usb_cam_2"].value("height",  720);
-        usb2_cfg.fps    = jcam["usb_cam_2"].value("fps",      30);
+        usb2_cfg.device     = jcam["usb_cam_2"].value("device",     "/dev/video3");
+        usb2_cfg.width      = jcam["usb_cam_2"].value("width",       1280);
+        usb2_cfg.height     = jcam["usb_cam_2"].value("height",       720);
+        usb2_cfg.fps        = jcam["usb_cam_2"].value("fps",           30);
+        usb2_cfg.brightness = jcam["usb_cam_2"].value("brightness",   1.0f);
     }
 
     HudConfig hud_cfg;
@@ -1522,6 +1540,9 @@ int main(int argc, char* argv[]) {
         jpp["edge_threshold"]     = state.pp_cfg.edge_threshold;
         jpp["focus_str"]          = state.pp_cfg.focus_str;
         jpp["edge_gate_scale"]    = state.pp_cfg.edge_gate_scale;
+
+        cfg["cameras"]["usb_cam_1"]["brightness"] = cameras.usb1_brightness();
+        cfg["cameras"]["usb_cam_2"]["brightness"] = cameras.usb2_brightness();
 
         auto& jm = cfg["menu_style"];
         jm["accent_color"] = color_to_json(menu.accent_color());


### PR DESCRIPTION
## Summary

- **Silhouette-only outlines**: Wide-baseline Sobel (`u_edge_scale`) averages out fine texture, retaining only structural boundaries. Edge magnitude threshold (`u_edge_thresh`) suppresses weak interior edges.
- **Dual-scale size gate** (`u_gate_scale`): Second Sobel at a coarser step — small objects/noise average out and the product cancels their edge; large objects pass both tests. Prevents tiny specks from getting outlines.
- **Full-color foreground preservation**: Desaturation is coupled to the edge signal (`bg_weight * (1 - edge * edge_str)`), so outlined objects stay in full color while flat background desaturates.
- **Focus-blend bg detection** (`u_focus_str`): Laplacian sharpness at each pixel blended with the contrast-proxy background weight, using live AF lens position to scale sensitivity.
- **Sobel amplification fix**: Changed `* 4.0` → `* 1.5` so Edge Detail scale and threshold controls produce visible differences instead of saturating everything to 1.0.
- **New edge color**: Black outline option added to Edge Color menu.
- **New scale option**: Wide (7x) added to Edge Detail menu.
- **USB camera brightness**: Auto-exposure enabled on open; per-camera software brightness multiplier (50%–300%) applied in the capture thread. Brightness menu under USB Cam 1/2; persisted in config.json. Default for usb_cam_1 set to 1.5x to compensate for dark HQ camera.

## Test plan

- [ ] Enable Edge Highlight; point at a person — only the body silhouette should be outlined, not shirt texture
- [ ] "Size Filter: Off" restores all edges including small objects
- [ ] "Size Filter: Strong (3x)" leaves only the largest structural outlines
- [ ] With both effects enabled, outlined regions appear in full color; flat background desaturates
- [ ] Edge Detail settings (Fine 1x → Wide 7x) produce visibly different coarseness levels
- [ ] Edge Threshold: High suppresses most interior boundaries
- [ ] USB Cam Brightness 200% noticeably brightens the HQ camera image
- [ ] Brightness setting survives restart (persisted in config.json)

https://claude.ai/code/session_01LH94rdjztXGergQJDGJ3sV

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH94rdjztXGergQJDGJ3sV)_