### PR TITLE
Fix build: add missing usb1/2_brightness_ private member declarations

### DIFF
--- a/src/camera/camera_manager.h
+++ b/src/camera/camera_manager.h
@@ -149,6 +149,9 @@ private:
     };
     TexSlot usb1_slot_, usb2_slot_;
 
+    std::atomic<float> usb1_brightness_ { 1.0f };
+    std::atomic<float> usb2_brightness_ { 1.0f };
+
     std::atomic<bool> running_ { false };
     std::thread       usb_thread_;
 };


### PR DESCRIPTION
The atomic<float> members were referenced in the inline public methods and in camera_manager.cpp but never declared in the private section.

https://claude.ai/code/session_01LH94rdjztXGergQJDGJ3sV