### PR TITLE
Fix night vision: add AeEnable, only apply on state change

### DIFF
--- a/src/camera/dma_camera.cpp
+++ b/src/camera/dma_camera.cpp
@@ -531,6 +531,11 @@ void DmaCamera::apply_pending_controls(ControlList& ctrls) {
     if (af >= 0)
         ctrls.set(controls::AfMode, af);
 
+    // AeEnable must be applied before ExposureTime so manual shutter takes effect.
+    int ae = pending_ae_enable_.exchange(-1);
+    if (ae >= 0)
+        ctrls.set(controls::AeEnable, ae == 1);
+
     float ev = pending_ev_.exchange(-9999.0f);
     if (ev > -9998.0f)
         ctrls.set(controls::ExposureValue, ev);
@@ -593,4 +598,10 @@ void DmaCamera::set_shutter_speed_us(int us) {
     if (!camera_) return;
     if (camera_->controls().count(&controls::ExposureTime))
         pending_shutter_us_.store(us);
+}
+
+void DmaCamera::set_ae_enable(bool ae_on) {
+    if (!camera_) return;
+    if (camera_->controls().count(&controls::AeEnable))
+        pending_ae_enable_.store(ae_on ? 1 : 0);
 }

--- a/src/camera/dma_camera.h
+++ b/src/camera/dma_camera.h
@@ -75,8 +75,9 @@ public:
     int  get_focus_position() const;
     bool is_af_locked() const;
     bool is_af_scanning() const;
-    void set_exposure_ev(float ev);     // -3.0 to +3.0
-    void set_shutter_speed_us(int us);  // microseconds
+    void set_exposure_ev(float ev);     // -3.0 to +3.0 (AE compensation; requires AE on)
+    void set_shutter_speed_us(int us);  // microseconds (requires AE off / manual mode)
+    void set_ae_enable(bool ae_on);     // true = auto-exposure, false = manual shutter
 
     bool is_ok()  const { return ok_; }
     int  width()  const { return cfg_.width; }
@@ -147,6 +148,7 @@ private:
     std::atomic<int>   pending_af_mode_    { -1 };       // AfModeEnum value, -1 = no-op
     std::atomic<float> pending_ev_         { -9999.0f }; // ExposureValue, sentinel = no-op
     std::atomic<int>   pending_shutter_us_ { -1 };       // ExposureTime µs, -1 = no-op
+    std::atomic<int>   pending_ae_enable_  { -1 };       // 1=on 0=off -1=no-op
     std::atomic<float> pending_lens_pos_   { -1.0f };    // LensPosition diopters, -1 = no-op
 
     // ── Latest camera metadata (written by capture thread via atomics) ────────

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1343,14 +1343,31 @@ int main(int argc, char* argv[]) {
         // Record render-time pose for timewarp
         timewarp.begin_frame(snap.imu_pose);
 
-        // ── Apply camera settings (exposure, shutter) ─────────────────────────
-        if (cameras.owl_left()) {
-            cameras.owl_left()->set_exposure_ev(state.night_vision.exposure_ev);
-            cameras.owl_left()->set_shutter_speed_us(state.night_vision.shutter_us);
-        }
-        if (cameras.owl_right()) {
-            cameras.owl_right()->set_exposure_ev(state.night_vision.exposure_ev);
-            cameras.owl_right()->set_shutter_speed_us(state.night_vision.shutter_us);
+        // ── Apply camera settings (exposure, shutter) — only on change ────────
+        // NV mode off: AE enabled + ExposureValue compensation.
+        // NV mode on:  AE disabled + manual ExposureTime (shutter speed).
+        // AeEnable must be sent before ExposureTime or it is silently ignored.
+        {
+            static NightVisionState s_last_nv{};
+            static bool s_first = true;
+            const auto& nv = snap.night_vision;
+            if (s_first ||
+                nv.nv_enabled  != s_last_nv.nv_enabled  ||
+                nv.exposure_ev != s_last_nv.exposure_ev  ||
+                nv.shutter_us  != s_last_nv.shutter_us) {
+                auto apply = [&](DmaCamera* cam) {
+                    if (!cam) return;
+                    cam->set_ae_enable(!nv.nv_enabled);
+                    if (nv.nv_enabled)
+                        cam->set_shutter_speed_us(nv.shutter_us);
+                    else
+                        cam->set_exposure_ev(nv.exposure_ev);
+                };
+                apply(cameras.owl_left());
+                apply(cameras.owl_right());
+                s_last_nv = nv;
+                s_first   = false;
+            }
         }
 
         // ── Render cameras into per-eye FBOs ──────────────────────────────────


### PR DESCRIPTION
ExposureTime (manual shutter speed) requires AeEnable=false in libcamera; without it every shutter speed selection is silently ignored. Add set_ae_enable() to DmaCamera, apply it in apply_pending_controls() before ExposureTime, and switch based on nv_enabled:
  - NV on:  AeEnable=false + ExposureTime (manual shutter)
  - NV off: AeEnable=true  + ExposureValue (AE compensation)

Also stop hammering camera controls every frame — apply only when the NightVisionState actually changes using a static last-applied tracker.

https://claude.ai/code/session_015j43TJeFSwHS9qzpNYTFzZ