### PR TITLE
Add clock arm to HUD right side, RTC battery README note

### DIFF
--- a/README.md
+++ b/README.md
@@ -924,6 +924,38 @@ Recalibrate any time the helmet's magnetic environment changes significantly (ne
 
 ---
 
+## Clock & RTC Battery
+
+The HUD clock arm reads the CM5 system clock via `std::time()` — no extra hardware is required. However, **the CM5 has no RTC battery by default**, which means:
+
+- On every cold boot without a network / NTP server, the clock resets to **1970-01-01 00:00:00**.
+- Once the system reaches NTP it syncs automatically, but in the field you may have no internet.
+
+**Fix: install a CR2032 coin cell** into the RTC battery connector on your carrier board:
+
+| Carrier board | Connector | Notes |
+|---------------|-----------|-------|
+| Official CM5 IO Board | J9 (2-pin, near USB-C) | Polarity marked on silkscreen |
+| Custom / third-party boards | Varies — check schematic | Typically a BAT+ / GND footprint |
+
+Verify the RTC is holding time after power-off:
+```bash
+timedatectl status          # look for "System clock synchronized: yes"
+hwclock --show              # reads directly from the hardware RTC
+```
+
+### In-HUD Clock Options (Menu → Settings → HUD → Clock)
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| 24-Hour | on | Toggle 12 / 24-hour format |
+| Seconds | on | Show or hide the seconds field |
+| Show Date | off | Add a date row (e.g., `Wed 30 Apr`) below the time |
+| Font Size | 1.5× | Scale the clock text relative to the standard HUD mono font |
+| Time Offset → +1h / -1h / +1m / -1m / Reset | 0 | Shift displayed time without touching the system clock — useful for timezone differences in the field |
+
+---
+
 ## Configuration Reference
 
 Full `config/config.json` layout:

--- a/config/config.json
+++ b/config/config.json
@@ -154,5 +154,12 @@
     "hud_warn":       [255, 180, 0,  255],
     "hud_danger":     [255, 60,  60, 255],
     "hud_background": [10,  15,  20, 180]
+  },
+  "clock": {
+    "use_24h":         true,
+    "show_seconds":    true,
+    "show_date":       false,
+    "font_scale":      1.5,
+    "manual_offset_s": 0
   }
 }

--- a/src/app_state.h
+++ b/src/app_state.h
@@ -109,6 +109,14 @@ struct NightVisionState {
     bool  nv_enabled  = false; // night vision preset active (HUD indicator + apply flag)
 };
 
+struct ClockConfig {
+    bool  use_24h         = true;
+    bool  show_seconds    = true;
+    bool  show_date       = false;
+    float font_scale      = 1.5f;  // multiplied against font_mono_->FontSize at draw time
+    int   manual_offset_s = 0;     // seconds added to system time; 0 = pure system clock
+};
+
 struct CameraResolutionState {
     int width  = 1280;
     int height = 800;
@@ -147,6 +155,7 @@ struct AppState {
     // Camera focus, night vision, and resolution control
     CameraFocusState     focus_left, focus_right;
     NightVisionState     night_vision;
+    ClockConfig          clock_cfg;
     CameraResolutionState camera_resolution;
 
     // Post-processing (edge highlight + background desaturation)

--- a/src/hud/hud_renderer.cpp
+++ b/src/hud/hud_renderer.cpp
@@ -67,6 +67,20 @@ static void hud_glow_text(ImDrawList* dl, ImVec2 pos, const char* text,
     dl->AddText(pos, fill, text);
 }
 
+// Font-size-explicit overload for scaled text (e.g., clock arm).
+// Respects s_glow and uses caller-supplied palette colors.
+static void hud_glow_text(ImDrawList* dl, ImVec2 pos, const char* text,
+                           ImFont* font, float font_size,
+                           ImU32 glow_col, ImU32 fill_col) {
+    if (s_glow) {
+        const ImU32 glow = with_alpha(glow_col, 72);
+        constexpr int D[8][2] = {{-1,-1},{0,-1},{1,-1},{-1,0},{1,0},{-1,1},{0,1},{1,1}};
+        for (auto& o : D)
+            dl->AddText(font, font_size, {pos.x + o[0], pos.y + o[1]}, glow, text);
+    }
+    dl->AddText(font, font_size, pos, fill_col, text);
+}
+
 // ── Construction ──────────────────────────────────────────────────────────────
 
 HudRenderer::HudRenderer(const HudConfig& cfg, const HudColors& colors)
@@ -177,6 +191,7 @@ void HudRenderer::draw_frame(const AppState& s, int w, int h) {
     // Arm indicators drawn on top of the health-side background.
     draw_face_indicator  (dl, s.face, fw, fh);
     draw_lora_indicator  (dl, s,      fw, fh);
+    draw_clock_indicator (dl, s,      fw, fh);
 }
 
 // ── Shared overlay layout helper ──────────────────────────────────────────────
@@ -452,7 +467,7 @@ void HudRenderer::draw_health_side(ImDrawList* dl, const SystemHealth& h,
     constexpr float DOT_R   = 4.f;
     constexpr float ANGLE   = 130.f * 3.14159265f / 180.f;
     constexpr float H_LEN   = 150.f;  // health horiz line (SEG_W * 2; SEG_W=75)
-    constexpr float BG_FULL = 290.f;  // H_LEN + ARM_EXT; covers FACE/LoRa arm area too
+    constexpr float BG_FULL = 440.f;  // H_LEN + ARM_EXT*2 + SEG_W*2; covers health + LoRa + clock
 
     const float dir_x    = std::cos(ANGLE) * (right_side ? 1.f : -1.f);
     const float dir_y    = -std::sin(ANGLE);
@@ -717,6 +732,91 @@ void HudRenderer::draw_lora_indicator(ImDrawList* dl, const AppState& s,
                       col_.text_fill, col_.text_fill);
     }
     if (font_mono_) ImGui::PopFont();
+}
+
+// ── Clock arm (right side, outboard of LoRa arm) ─────────────────────────────
+// Parallel diagonal arm at 130°. No dots — time and date rendered at font_scale.
+// clock_anchor_x = lora_anchor_x + SEG_W*2 (another 150px right of LoRa anchor).
+
+void HudRenderer::draw_clock_indicator(ImDrawList* dl, const AppState& s,
+                                        float fw, float fh) {
+    constexpr float ROW_H   = 18.f;
+    constexpr float DOT_R   = 4.f;   // x-offset reference kept consistent with other arms
+    constexpr float SEG_W   = 75.f;
+    constexpr float ARM_EXT = 140.f;
+    constexpr float ANGLE   = 130.f * 3.14159265f / 180.f;
+
+    const float tape_w         = fw / 3.f;
+    const float tape_x         = fw / 2.f - tape_w / 2.f;
+    const float fade_w         = static_cast<float>(cfg_.compass_bg_side_fade);
+    const float c_margin       = static_cast<float>(cfg_.compass_bottom_margin);
+    const float anchor_y       = fh - c_margin;
+    const float ind_anchor_x   = tape_x + tape_w + fade_w;
+    const float lora_anchor_x  = ind_anchor_x   + SEG_W * 2.f;
+    const float clock_anchor_x = lora_anchor_x  + SEG_W * 2.f;
+
+    const float dir_x = std::cos(ANGLE);
+    const float dir_y = -std::sin(ANGLE);
+
+    const float scale     = std::max(0.5f, s.clock_cfg.font_scale);
+    const float eff_row_h = ROW_H * scale;
+    const int   n_rows    = s.clock_cfg.show_date ? 2 : 1;
+    const float diag_len  = static_cast<float>(n_rows + 1) * eff_row_h;
+
+    const ImU32 COL_MAJ  = col_.glow_base;
+    const ImU32 COL_GLW1 = with_alpha(col_.glow_base, 70);
+    const ImU32 COL_GLW2 = with_alpha(col_.glow_base, 28);
+
+    // Horizontal extension rightward
+    const float h_ext_x = clock_anchor_x + ARM_EXT;
+    dl->AddLine({clock_anchor_x, anchor_y}, {h_ext_x, anchor_y}, COL_GLW2, 5.f);
+    dl->AddLine({clock_anchor_x, anchor_y}, {h_ext_x, anchor_y}, COL_GLW1, 2.5f);
+    dl->AddLine({clock_anchor_x, anchor_y}, {h_ext_x, anchor_y}, COL_MAJ,  1.f);
+
+    // Diagonal
+    const ImVec2 clk_end = {clock_anchor_x + dir_x * diag_len,
+                              anchor_y      + dir_y * diag_len};
+    dl->AddLine({clock_anchor_x, anchor_y}, clk_end, COL_GLW2, 5.f);
+    dl->AddLine({clock_anchor_x, anchor_y}, clk_end, COL_GLW1, 2.5f);
+    dl->AddLine({clock_anchor_x, anchor_y}, clk_end, COL_MAJ,  1.f);
+
+    // Build time / date strings
+    time_t now = std::time(nullptr) + static_cast<time_t>(s.clock_cfg.manual_offset_s);
+    struct tm tm_buf = {};
+    localtime_r(&now, &tm_buf);
+
+    char time_str[24], date_str[24];
+    if (s.clock_cfg.use_24h) {
+        if (s.clock_cfg.show_seconds)
+            snprintf(time_str, sizeof(time_str), "%02d:%02d:%02d",
+                     tm_buf.tm_hour, tm_buf.tm_min, tm_buf.tm_sec);
+        else
+            snprintf(time_str, sizeof(time_str), "%02d:%02d",
+                     tm_buf.tm_hour, tm_buf.tm_min);
+    } else {
+        int h12 = tm_buf.tm_hour % 12;
+        if (h12 == 0) h12 = 12;
+        snprintf(time_str, sizeof(time_str), "%d:%02d %s",
+                 h12, tm_buf.tm_min, tm_buf.tm_hour < 12 ? "AM" : "PM");
+    }
+
+    static const char* dow[] = {"Sun","Mon","Tue","Wed","Thu","Fri","Sat"};
+    static const char* mon[] = {"Jan","Feb","Mar","Apr","May","Jun",
+                                  "Jul","Aug","Sep","Oct","Nov","Dec"};
+    snprintf(date_str, sizeof(date_str), "%s %d %s",
+             dow[tm_buf.tm_wday], tm_buf.tm_mday, mon[tm_buf.tm_mon]);
+
+    // Render rows using explicit font size — respects global glow flag + palette
+    const float font_size = font_mono_ ? font_mono_->FontSize * scale
+                                       : ImGui::GetFontSize() * scale;
+    const char* rows[2] = { time_str, date_str };
+    for (int i = 0; i < n_rows; ++i) {
+        const float t  = static_cast<float>(i + 1) * eff_row_h;
+        const float ix = clock_anchor_x + dir_x * t;
+        const float iy = anchor_y       + dir_y * t;
+        hud_glow_text(dl, {ix + DOT_R + 6.f, iy - font_size * 0.5f}, rows[i],
+                      font_mono_, font_size, col_.glow_base, col_.text_fill);
+    }
 }
 
 // ── LoRa messages panel ───────────────────────────────────────────────────────

--- a/src/hud/hud_renderer.h
+++ b/src/hud/hud_renderer.h
@@ -115,6 +115,7 @@ private:
     void draw_audio_strip    (ImDrawList* dl, const AudioState& a, ImVec2 origin, float w);
     void draw_face_indicator (ImDrawList* dl, const FaceState& f, float fw, float fh);
     void draw_lora_indicator (ImDrawList* dl, const AppState& s,  float fw, float fh);
+    void draw_clock_indicator(ImDrawList* dl, const AppState& s,  float fw, float fh);
     void draw_lora_messages  (ImDrawList* dl, const AppState& s,
                             ImVec2 origin, float pw, float ph);
     void draw_compass_tape (ImDrawList* dl, const AppState& s,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -678,6 +678,29 @@ static std::vector<MenuItem> build_menu(
             [menu_sys_pp](bool v){ if (*menu_sys_pp) (*menu_sys_pp)->set_bg_enabled(v); }),
     };
 
+    std::vector<MenuItem> clock_offset_menu = {
+        leaf("+1 hour",   [&state]{ state.clock_cfg.manual_offset_s += 3600; }),
+        leaf("-1 hour",   [&state]{ state.clock_cfg.manual_offset_s -= 3600; }),
+        leaf("+1 minute", [&state]{ state.clock_cfg.manual_offset_s +=   60; }),
+        leaf("-1 minute", [&state]{ state.clock_cfg.manual_offset_s -=   60; }),
+        leaf("Reset",     [&state]{ state.clock_cfg.manual_offset_s  =    0; }),
+    };
+    std::vector<MenuItem> clock_menu = {
+        toggle("24-Hour",
+            [&state]{ return state.clock_cfg.use_24h; },
+            [&state](bool v){ state.clock_cfg.use_24h = v; }),
+        toggle("Seconds",
+            [&state]{ return state.clock_cfg.show_seconds; },
+            [&state](bool v){ state.clock_cfg.show_seconds = v; }),
+        toggle("Show Date",
+            [&state]{ return state.clock_cfg.show_date; },
+            [&state](bool v){ state.clock_cfg.show_date = v; }),
+        slider("Font Size", 1.f, 3.f, 0.25f, "x",
+            [&state]{ return state.clock_cfg.font_scale; },
+            [&state](float v){ state.clock_cfg.font_scale = v; }),
+        submenu("Time Offset", std::move(clock_offset_menu)),
+    };
+
     std::vector<MenuItem> hud_menu = {
         toggle("Show Backgrounds",
             [hud_cfg, &state]{ return hud_cfg->indicator_bg_enabled && state.compass_bg_enabled; },
@@ -689,6 +712,7 @@ static std::vector<MenuItem> build_menu(
         submenu("Text Options",      std::move(text_options_menu)),
         submenu("Indicator Options", std::move(indicator_options_menu)),
         submenu("Compass",           std::move(compass_menu)),
+        submenu("Clock",             std::move(clock_menu)),
         submenu("Menu Options",      std::move(menu_options_menu)),
     };
 
@@ -954,6 +978,15 @@ int main(int argc, char* argv[]) {
         auto& jnv = cfg["night_vision"];
         state.night_vision.exposure_ev = jnv.value("exposure_ev",  0.0f);
         state.night_vision.shutter_us  = jnv.value("shutter_us",  33333);
+    }
+
+    if (cfg.contains("clock")) {
+        auto& jck = cfg["clock"];
+        state.clock_cfg.use_24h         = jck.value("use_24h",         true);
+        state.clock_cfg.show_seconds    = jck.value("show_seconds",     true);
+        state.clock_cfg.show_date       = jck.value("show_date",        false);
+        state.clock_cfg.font_scale      = jck.value("font_scale",       1.5f);
+        state.clock_cfg.manual_offset_s = jck.value("manual_offset_s",  0);
     }
 
     if (cfg.contains("post_process")) {
@@ -1337,6 +1370,7 @@ int main(int argc, char* argv[]) {
             snap.focus_left         = state.focus_left;
             snap.focus_right        = state.focus_right;
             snap.night_vision       = state.night_vision;
+            snap.clock_cfg          = state.clock_cfg;
             snap.pp_cfg             = state.pp_cfg;
         }
 
@@ -1488,6 +1522,12 @@ int main(int argc, char* argv[]) {
 
         cfg["hud"]["indicator_bg_enabled"] = hud.config().indicator_bg_enabled;
         cfg["hud"]["compass_bg"]           = state.compass_bg_enabled;
+
+        cfg["clock"]["use_24h"]         = state.clock_cfg.use_24h;
+        cfg["clock"]["show_seconds"]    = state.clock_cfg.show_seconds;
+        cfg["clock"]["show_date"]       = state.clock_cfg.show_date;
+        cfg["clock"]["font_scale"]      = state.clock_cfg.font_scale;
+        cfg["clock"]["manual_offset_s"] = state.clock_cfg.manual_offset_s;
 
         auto& jpp = cfg["post_process"];
         jpp["edge_enabled"]       = state.pp_cfg.edge_enabled;


### PR DESCRIPTION
- New draw_clock_indicator(): parallel diagonal arm to the right of the LoRa arm (clock_anchor = lora_anchor + SEG_W*2 ≈ x1660). Draws time and optionally date along the diagonal with no header row and no dots. Uses a new hud_glow_text overload that accepts explicit font+size so the clock scales without reloading fonts.
- ClockConfig struct: use_24h, show_seconds, show_date, font_scale (1.5× default), manual_offset_s — added to AppState and snapped each frame.
- HUD → Clock submenu: 24-Hour toggle, Seconds toggle, Show Date toggle, Font Size slider (1–3×), Time Offset ±1h/±1m/Reset.
- BG_FULL: 290 → 440px so the parallelogram background covers the clock arm.
- Config load/save and config.json default clock section added.
- README: new "Clock & RTC Battery" section with CR2032 install guide, verification steps, and in-HUD options table.

https://claude.ai/code/session_015j43TJeFSwHS9qzpNYTFzZ