### PR TITLE
Vision assist: motion highlight via temporal frame-difference

### DIFF
--- a/assets/shaders/postprocess.fs
+++ b/assets/shaders/postprocess.fs
@@ -28,6 +28,11 @@ uniform float     u_edge_thresh;// minimum edge magnitude (0.0–0.6); suppresse
 uniform float     u_focus_str;  // 0.0=contrast proxy only, 1.0=Laplacian sharpness only for bg_weight
 uniform float     u_focus_sens; // Laplacian sensitivity (scales with lens proximity)
 uniform float     u_gate_scale; // 0.0=off, else=step multiplier for confirmatory coarse Sobel (size filter)
+uniform sampler2D u_prev_frame;    // unit 2: previous raw frame (RGBA8) for motion detection
+uniform float     u_motion_str;    // 0.0=off; motion highlight intensity
+uniform float     u_motion_thresh; // min luma delta to count as motion (0.01–0.15)
+uniform float     u_motion_radius; // dilation radius in texels; connects nearby motion blobs
+uniform vec3      u_motion_col;    // motion highlight colour (normalised RGB)
 
 varying vec2 v_uv;
 
@@ -110,6 +115,30 @@ void main() {
 
     // ── Overlay edges ─────────────────────────────────────────────────────────
     color = mix(color, u_edge_col, edge * u_edge_str);
+
+    // ── Motion highlight (temporal frame diff + blob dilation) ────────────────
+    // Compares current luma to previous frame at center + 4 diagonal neighbors.
+    // Taking the max means any pixel within u_motion_radius texels of a moving
+    // pixel also lights up, connecting scattered detections into visible blobs.
+    // Works regardless of local contrast — detects low-contrast moving objects
+    // that Sobel and the contrast proxy miss entirely.
+    if (u_motion_str > 0.0) {
+        vec2 mstep = u_texel * u_motion_radius;
+        float p11 = luma(texture2D(u_prev_frame, v_uv).rgb);
+        float p00 = luma(texture2D(u_prev_frame, v_uv + vec2(-1.0,-1.0)*mstep).rgb);
+        float p20 = luma(texture2D(u_prev_frame, v_uv + vec2( 1.0,-1.0)*mstep).rgb);
+        float p02 = luma(texture2D(u_prev_frame, v_uv + vec2(-1.0, 1.0)*mstep).rgb);
+        float p22 = luma(texture2D(u_prev_frame, v_uv + vec2( 1.0, 1.0)*mstep).rgb);
+        float s00 = luma(texture2D(u_scene, v_uv + vec2(-1.0,-1.0)*mstep).rgb);
+        float s20 = luma(texture2D(u_scene, v_uv + vec2( 1.0,-1.0)*mstep).rgb);
+        float s02 = luma(texture2D(u_scene, v_uv + vec2(-1.0, 1.0)*mstep).rgb);
+        float s22 = luma(texture2D(u_scene, v_uv + vec2( 1.0, 1.0)*mstep).rgb);
+        float motion = max(abs(l11 - p11),
+                       max(max(abs(s00-p00), abs(s20-p20)),
+                           max(abs(s02-p02), abs(s22-p22))));
+        float mw = clamp((motion - u_motion_thresh) / (1.0 - u_motion_thresh + 0.001), 0.0, 1.0);
+        color = mix(color, u_motion_col, mw * u_motion_str);
+    }
 
     gl_FragColor = vec4(color, 1.0);
 }

--- a/config/config.json
+++ b/config/config.json
@@ -152,7 +152,12 @@
     "edge_scale": 3.0,
     "edge_threshold": 0.15,
     "focus_str": 0.0,
-    "edge_gate_scale": 2.0
+    "edge_gate_scale": 2.0,
+    "motion_enabled": false,
+    "motion_strength": 0.9,
+    "motion_thresh": 0.04,
+    "motion_radius": 10.0,
+    "motion_color": [0, 255, 100, 255]
   },
   "colors": {
     "hud_primary":    [0, 220, 180, 220],

--- a/src/app_state.h
+++ b/src/app_state.h
@@ -24,6 +24,13 @@ struct PostProcessConfig {
     float focus_str          = 0.0f;   // 0.0–1.0; blend Laplacian sharpness into bg_weight
     int   focus_lens_pos     = 500;    // 0–1000 from AF; set each frame — not persisted
     float edge_gate_scale    = 2.0f;   // 0.0=off, else=step multiplier for coarse confirmatory Sobel
+
+    // Motion highlight (temporal frame-difference)
+    bool  motion_enabled  = false;
+    float motion_strength = 0.9f;
+    float motion_thresh   = 0.04f;   // min luma delta to count as motion (~4%); noise ~1-2%
+    float motion_radius   = 10.0f;   // dilation radius in texels for blob connection
+    ImU32 motion_color    = IM_COL32(0, 255, 100, 255);
 };
 
 // ── Overlay layout config (PiP and Android mirror) ───────────────────────────

--- a/src/gl_utils.h
+++ b/src/gl_utils.h
@@ -69,6 +69,12 @@ inline GLuint build_program(const char* vs_path, const char* fs_path) {
     return link_program(vs, fs);
 }
 
+inline GLuint build_program_from_strings(const char* vs_src, const char* fs_src) {
+    GLuint vs = compile_shader(GL_VERTEX_SHADER,   vs_src);
+    GLuint fs = compile_shader(GL_FRAGMENT_SHADER, fs_src);
+    return link_program(vs, fs);
+}
+
 // ── Fullscreen quad VBO ───────────────────────────────────────────────────────
 // Positions in NDC [-1,1], UVs in [0,1]. Layout: {x, y, u, v}.
 // Draw with GL_TRIANGLE_STRIP, 4 vertices.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -767,6 +767,28 @@ static std::vector<MenuItem> build_menu(
         leaf("Strong (3x)",[&state]{ state.pp_cfg.edge_gate_scale = 3.0f; }),
     };
 
+    std::vector<MenuItem> motion_sensitivity_menu = {
+        leaf("Low",       [&state]{ state.pp_cfg.motion_thresh = 0.10f; }),
+        leaf("Medium",    [&state]{ state.pp_cfg.motion_thresh = 0.04f; }),
+        leaf("High",      [&state]{ state.pp_cfg.motion_thresh = 0.02f; }),
+        leaf("Very High", [&state]{ state.pp_cfg.motion_thresh = 0.01f; }),
+    };
+
+    std::vector<MenuItem> motion_spread_menu = {
+        leaf("None (1px)",    [&state]{ state.pp_cfg.motion_radius =  1.0f; }),
+        leaf("Small (5px)",   [&state]{ state.pp_cfg.motion_radius =  5.0f; }),
+        leaf("Medium (10px)", [&state]{ state.pp_cfg.motion_radius = 10.0f; }),
+        leaf("Large (20px)",  [&state]{ state.pp_cfg.motion_radius = 20.0f; }),
+    };
+
+    std::vector<MenuItem> motion_color_menu = {
+        leaf("Green",  [&state]{ state.pp_cfg.motion_color = IM_COL32(  0, 255, 100, 255); }),
+        leaf("Cyan",   [&state]{ state.pp_cfg.motion_color = IM_COL32(  0, 200, 255, 255); }),
+        leaf("Yellow", [&state]{ state.pp_cfg.motion_color = IM_COL32(255, 220,   0, 255); }),
+        leaf("White",  [&state]{ state.pp_cfg.motion_color = IM_COL32(255, 255, 255, 255); }),
+        leaf("Orange", [&state]{ state.pp_cfg.motion_color = IM_COL32(255, 140,   0, 255); }),
+    };
+
     std::vector<MenuItem> vision_menu = {
         toggle("Edge Highlight",
             [&state]{ return state.pp_cfg.edge_enabled; },
@@ -776,6 +798,12 @@ static std::vector<MenuItem> build_menu(
         submenu("Edge Detail",    std::move(edge_detail_menu)),
         submenu("Edge Threshold", std::move(edge_threshold_menu)),
         submenu("Size Filter",    std::move(size_filter_menu)),
+        toggle("Motion Highlight",
+            [&state]{ return state.pp_cfg.motion_enabled; },
+            [&state](bool v){ state.pp_cfg.motion_enabled = v; }),
+        submenu("Motion Sensitivity", std::move(motion_sensitivity_menu)),
+        submenu("Motion Spread",      std::move(motion_spread_menu)),
+        submenu("Motion Color",       std::move(motion_color_menu)),
         toggle("Bg Desaturate",
             [&state]{ return state.pp_cfg.desat_enabled; },
             [&state](bool v){ state.pp_cfg.desat_enabled = v; }),
@@ -1024,6 +1052,17 @@ int main(int argc, char* argv[]) {
             uint8_t a = jpp["edge_color"].size() >= 4 ? (uint8_t)jc[3] : 255;
             state.pp_cfg.edge_color = IM_COL32(r, g, b, a);
         }
+        state.pp_cfg.motion_enabled  = jpp.value("motion_enabled",  false);
+        state.pp_cfg.motion_strength = jpp.value("motion_strength", 0.9f);
+        state.pp_cfg.motion_thresh   = jpp.value("motion_thresh",   0.04f);
+        state.pp_cfg.motion_radius   = jpp.value("motion_radius",   10.0f);
+        if (jpp.contains("motion_color") && jpp["motion_color"].is_array() &&
+            jpp["motion_color"].size() >= 3) {
+            auto& jc = jpp["motion_color"];
+            uint8_t r = jc[0], g = jc[1], b = jc[2];
+            uint8_t a = jpp["motion_color"].size() >= 4 ? (uint8_t)jc[3] : 255;
+            state.pp_cfg.motion_color = IM_COL32(r, g, b, a);
+        }
     }
 
     // Seed resolution state from whatever the OWLsight config says
@@ -1095,13 +1134,16 @@ int main(int argc, char* argv[]) {
 
     PostProcessor post_proc;
     gl::Fbo pp_fbo_left, pp_fbo_right;
+    gl::Fbo pp_prev_left, pp_prev_right;
     const bool pp_ok = post_proc.init(
         xr.eye_width(), xr.eye_height(),
         res("assets/shaders/postprocess.vs").c_str(),
         res("assets/shaders/postprocess.fs").c_str());
     if (pp_ok) {
-        pp_fbo_left  = gl::make_fbo(xr.eye_width(), xr.eye_height());
-        pp_fbo_right = gl::make_fbo(xr.eye_width(), xr.eye_height());
+        pp_fbo_left   = gl::make_fbo(xr.eye_width(), xr.eye_height());
+        pp_fbo_right  = gl::make_fbo(xr.eye_width(), xr.eye_height());
+        pp_prev_left  = gl::make_fbo(xr.eye_width(), xr.eye_height());
+        pp_prev_right = gl::make_fbo(xr.eye_width(), xr.eye_height());
     } else {
         std::cerr << "[main] post-process shader unavailable — Vision Assist disabled\n";
     }
@@ -1449,8 +1491,8 @@ int main(int argc, char* argv[]) {
         GLuint right_src = xr.eye_right().tex;
         if (pp_ok && post_proc.any_enabled(snap.pp_cfg) &&
                 pp_fbo_left.valid() && pp_fbo_right.valid()) {
-            post_proc.process(xr.eye_left().tex,  pp_fbo_left,  snap.pp_cfg);
-            post_proc.process(xr.eye_right().tex, pp_fbo_right, snap.pp_cfg);
+            post_proc.process(xr.eye_left().tex,  pp_prev_left,  pp_fbo_left,  snap.pp_cfg);
+            post_proc.process(xr.eye_right().tex, pp_prev_right, pp_fbo_right, snap.pp_cfg);
             left_src  = pp_fbo_left.tex;
             right_src = pp_fbo_right.tex;
         }
@@ -1540,6 +1582,11 @@ int main(int argc, char* argv[]) {
         jpp["edge_threshold"]     = state.pp_cfg.edge_threshold;
         jpp["focus_str"]          = state.pp_cfg.focus_str;
         jpp["edge_gate_scale"]    = state.pp_cfg.edge_gate_scale;
+        jpp["motion_enabled"]     = state.pp_cfg.motion_enabled;
+        jpp["motion_strength"]    = state.pp_cfg.motion_strength;
+        jpp["motion_thresh"]      = state.pp_cfg.motion_thresh;
+        jpp["motion_radius"]      = state.pp_cfg.motion_radius;
+        jpp["motion_color"]       = color_to_json(state.pp_cfg.motion_color);
 
         cfg["cameras"]["usb_cam_1"]["brightness"] = cameras.usb1_brightness();
         cfg["cameras"]["usb_cam_2"]["brightness"] = cameras.usb2_brightness();
@@ -1588,6 +1635,8 @@ int main(int argc, char* argv[]) {
 
     pp_fbo_left.destroy();
     pp_fbo_right.destroy();
+    pp_prev_left.destroy();
+    pp_prev_right.destroy();
     post_proc.shutdown();
 
     xr.shutdown();

--- a/src/post_process.cpp
+++ b/src/post_process.cpp
@@ -12,18 +12,36 @@ bool PostProcessor::init(int w, int h, const char* vs_path, const char* fs_path)
         return false;
     }
 
-    loc_scene_       = glGetUniformLocation(prog_, "u_scene");
-    loc_texel_       = glGetUniformLocation(prog_, "u_texel");
-    loc_edge_str_    = glGetUniformLocation(prog_, "u_edge_str");
-    loc_desat_str_   = glGetUniformLocation(prog_, "u_desat_str");
-    loc_edge_col_    = glGetUniformLocation(prog_, "u_edge_col");
-    loc_threshold_   = glGetUniformLocation(prog_, "u_threshold");
-    loc_has_depth_   = glGetUniformLocation(prog_, "u_has_depth");
-    loc_edge_scale_  = glGetUniformLocation(prog_, "u_edge_scale");
-    loc_edge_thresh_ = glGetUniformLocation(prog_, "u_edge_thresh");
-    loc_focus_str_   = glGetUniformLocation(prog_, "u_focus_str");
-    loc_focus_sens_  = glGetUniformLocation(prog_, "u_focus_sens");
-    loc_gate_scale_  = glGetUniformLocation(prog_, "u_gate_scale");
+    loc_scene_         = glGetUniformLocation(prog_, "u_scene");
+    loc_texel_         = glGetUniformLocation(prog_, "u_texel");
+    loc_edge_str_      = glGetUniformLocation(prog_, "u_edge_str");
+    loc_desat_str_     = glGetUniformLocation(prog_, "u_desat_str");
+    loc_edge_col_      = glGetUniformLocation(prog_, "u_edge_col");
+    loc_threshold_     = glGetUniformLocation(prog_, "u_threshold");
+    loc_has_depth_     = glGetUniformLocation(prog_, "u_has_depth");
+    loc_edge_scale_    = glGetUniformLocation(prog_, "u_edge_scale");
+    loc_edge_thresh_   = glGetUniformLocation(prog_, "u_edge_thresh");
+    loc_focus_str_     = glGetUniformLocation(prog_, "u_focus_str");
+    loc_focus_sens_    = glGetUniformLocation(prog_, "u_focus_sens");
+    loc_gate_scale_    = glGetUniformLocation(prog_, "u_gate_scale");
+    loc_prev_frame_    = glGetUniformLocation(prog_, "u_prev_frame");
+    loc_motion_str_    = glGetUniformLocation(prog_, "u_motion_str");
+    loc_motion_thresh_ = glGetUniformLocation(prog_, "u_motion_thresh");
+    loc_motion_radius_ = glGetUniformLocation(prog_, "u_motion_radius");
+    loc_motion_col_    = glGetUniformLocation(prog_, "u_motion_col");
+
+    static const char* kBlitVs =
+        "attribute vec2 a_pos; attribute vec2 a_uv;"
+        "varying vec2 v_uv;"
+        "void main(){ v_uv = a_uv; gl_Position = vec4(a_pos, 0.0, 1.0); }";
+    static const char* kBlitFs =
+        "precision mediump float;"
+        "uniform sampler2D u_tex;"
+        "varying vec2 v_uv;"
+        "void main(){ gl_FragColor = texture2D(u_tex, v_uv); }";
+    blit_prog_ = gl::build_program_from_strings(kBlitVs, kBlitFs);
+    if (!blit_prog_)
+        std::cerr << "[post_process] blit shader build failed — motion prev-frame copy disabled\n";
 
     vbo_ = gl::make_quad_vbo();
     if (!vbo_) {
@@ -36,11 +54,12 @@ bool PostProcessor::init(int w, int h, const char* vs_path, const char* fs_path)
 }
 
 void PostProcessor::shutdown() {
-    if (prog_) { glDeleteProgram(prog_); prog_ = 0; }
-    if (vbo_)  { glDeleteBuffers(1, &vbo_); vbo_ = 0; }
+    if (prog_)      { glDeleteProgram(prog_);       prog_      = 0; }
+    if (blit_prog_) { glDeleteProgram(blit_prog_);  blit_prog_ = 0; }
+    if (vbo_)       { glDeleteBuffers(1, &vbo_);    vbo_       = 0; }
 }
 
-void PostProcessor::process(GLuint src_tex, const gl::Fbo& dst,
+void PostProcessor::process(GLuint src_tex, gl::Fbo& prev_fbo, const gl::Fbo& dst,
                              const PostProcessConfig& cfg) {
     dst.bind();
     glClearColor(0.f, 0.f, 0.f, 1.f);
@@ -51,6 +70,11 @@ void PostProcessor::process(GLuint src_tex, const gl::Fbo& dst,
     glActiveTexture(GL_TEXTURE0);
     glBindTexture(GL_TEXTURE_2D, src_tex);
     glUniform1i(loc_scene_, 0);
+
+    // Bind previous frame for motion detection (unit 2; stays black until second frame)
+    glActiveTexture(GL_TEXTURE2);
+    glBindTexture(GL_TEXTURE_2D, prev_fbo.valid() ? prev_fbo.tex : 0);
+    glUniform1i(loc_prev_frame_, 2);
 
     glUniform2f(loc_texel_, 1.f / static_cast<float>(w_),
                              1.f / static_cast<float>(h_));
@@ -75,10 +99,33 @@ void PostProcessor::process(GLuint src_tex, const gl::Fbo& dst,
     glUniform1f(loc_focus_sens_, 1.0f + focus_norm * 3.0f);
     glUniform1f(loc_gate_scale_, cfg.edge_gate_scale);
 
+    // Motion highlight uniforms
+    const float mr = ((cfg.motion_color >>  0) & 0xFF) / 255.f;
+    const float mg = ((cfg.motion_color >>  8) & 0xFF) / 255.f;
+    const float mb = ((cfg.motion_color >> 16) & 0xFF) / 255.f;
+    glUniform1f(loc_motion_str_,    cfg.motion_enabled ? cfg.motion_strength : 0.f);
+    glUniform1f(loc_motion_thresh_, cfg.motion_thresh);
+    glUniform1f(loc_motion_radius_, cfg.motion_radius);
+    glUniform3f(loc_motion_col_,    mr, mg, mb);
+
     gl::bind_quad(vbo_);
     gl::draw_quad();
     gl::unbind_quad();
 
     glUseProgram(0);
     dst.unbind();
+
+    // Copy src_tex → prev_fbo so next frame can compare against this one.
+    if (prev_fbo.valid() && blit_prog_) {
+        prev_fbo.bind();
+        glUseProgram(blit_prog_);
+        glActiveTexture(GL_TEXTURE0);
+        glBindTexture(GL_TEXTURE_2D, src_tex);
+        glUniform1i(glGetUniformLocation(blit_prog_, "u_tex"), 0);
+        gl::bind_quad(vbo_);
+        gl::draw_quad();
+        gl::unbind_quad();
+        glUseProgram(0);
+        prev_fbo.unbind();
+    }
 }

--- a/src/post_process.h
+++ b/src/post_process.h
@@ -26,30 +26,38 @@ public:
     void shutdown();
 
     // Apply the post-process pass: read src_tex, write result to dst.
+    // prev_fbo holds the previous raw frame for motion detection; updated each call.
     // dst must be a valid gl::Fbo with matching dimensions.
-    void process(GLuint src_tex, const gl::Fbo& dst, const PostProcessConfig& cfg);
+    void process(GLuint src_tex, gl::Fbo& prev_fbo, const gl::Fbo& dst,
+                 const PostProcessConfig& cfg);
 
     bool any_enabled(const PostProcessConfig& cfg) const {
-        return cfg.edge_enabled || cfg.desat_enabled;
+        return cfg.edge_enabled || cfg.desat_enabled || cfg.motion_enabled;
     }
 
 private:
-    GLuint prog_ = 0;
-    GLuint vbo_  = 0;
+    GLuint prog_      = 0;
+    GLuint blit_prog_ = 0;   // trivial src→prev blit shader (inline GLSL)
+    GLuint vbo_       = 0;
 
     // Cached uniform locations (set at init time)
-    GLint loc_scene_      = -1;
-    GLint loc_texel_      = -1;
-    GLint loc_edge_str_   = -1;
-    GLint loc_desat_str_  = -1;
-    GLint loc_edge_col_   = -1;
-    GLint loc_threshold_  = -1;
-    GLint loc_has_depth_  = -1;
-    GLint loc_edge_scale_  = -1;
-    GLint loc_edge_thresh_ = -1;
-    GLint loc_focus_str_   = -1;
-    GLint loc_focus_sens_  = -1;
-    GLint loc_gate_scale_  = -1;
+    GLint loc_scene_         = -1;
+    GLint loc_texel_         = -1;
+    GLint loc_edge_str_      = -1;
+    GLint loc_desat_str_     = -1;
+    GLint loc_edge_col_      = -1;
+    GLint loc_threshold_     = -1;
+    GLint loc_has_depth_     = -1;
+    GLint loc_edge_scale_    = -1;
+    GLint loc_edge_thresh_   = -1;
+    GLint loc_focus_str_     = -1;
+    GLint loc_focus_sens_    = -1;
+    GLint loc_gate_scale_    = -1;
+    GLint loc_prev_frame_    = -1;
+    GLint loc_motion_str_    = -1;
+    GLint loc_motion_thresh_ = -1;
+    GLint loc_motion_radius_ = -1;
+    GLint loc_motion_col_    = -1;
 
     int w_ = 0, h_ = 0;
 };


### PR DESCRIPTION
Adds a temporal motion detection layer to the post-processing pass that works regardless of local contrast — detects low-contrast moving objects (grey on grey, shadow detail) that the spatial Sobel completely misses.

How it works:
- Each frame, the raw camera texture is blitted into a ping-pong FBO (pp_prev_left/right) after the main effect pass
- The fragment shader compares current-frame luma to the stored previous frame at the center pixel + 4 diagonal neighbors at u_motion_radius step
- Taking the max motion across all 5 points dilates detections into blobs, connecting nearby highlights so moving objects appear as solid regions
- Threshold remap (same pattern as edge) suppresses camera noise

New menu items under Vision Assist:
  Motion Highlight (toggle), Motion Sensitivity, Motion Spread, Motion Color

New uniforms: u_prev_frame (unit 2), u_motion_str, u_motion_thresh,
  u_motion_radius, u_motion_col

Added gl::build_program_from_strings() for the inline blit shader. All settings persisted in config.json.

https://claude.ai/code/session_01LH94rdjztXGergQJDGJ3sV