### PR TITLE
Fix prototracer HUD section: faces, colors, animations, release control

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -44,7 +44,17 @@
   "serial": {
     "teensy": {
       "port": "/dev/ttyACM0",
-      "baud": 115200
+      "baud": 115200,
+      "gif_names": [
+        "GIF #0",
+        "GIF #1",
+        "GIF #2",
+        "GIF #3",
+        "GIF #4",
+        "GIF #5",
+        "GIF #6",
+        "GIF #7"
+      ]
     },
     "lora": {
       "port": "/dev/ttyACM2",

--- a/src/app_state.h
+++ b/src/app_state.h
@@ -56,6 +56,7 @@ struct FaceState {
     uint8_t  palette_id   = 0;
     bool     playing_gif  = false;
     bool     connected    = false;
+    bool     hud_control  = false;  // true = HUD has taken manual control; false = Teensy autonomous
 };
 
 struct LoRaNode {

--- a/src/hud/hud_renderer.cpp
+++ b/src/hud/hud_renderer.cpp
@@ -580,7 +580,7 @@ void HudRenderer::draw_face_indicator(ImDrawList* dl, const FaceState& f,
     constexpr float SEG_W   = 75.f;
     constexpr float ARM_EXT = 140.f;
     constexpr float ANGLE   = 130.f * 3.14159265f / 180.f;
-    constexpr int   N_ITEMS = 5;
+    constexpr int   N_ITEMS = 6;
 
     const float tape_w        = fw / 3.f;
     const float tape_x        = fw / 2.f - tape_w / 2.f;
@@ -620,6 +620,7 @@ void HudRenderer::draw_face_indicator(ImDrawList* dl, const FaceState& f,
         snprintf(mode_lbl, sizeof(mode_lbl), "Pal #%d", f.palette_id);
     snprintf(rgb_lbl, sizeof(rgb_lbl), "R%d G%d B%d", f.r, f.g, f.b);
     snprintf(brt_lbl, sizeof(brt_lbl), "Brt %d%%", (f.brightness * 100) / 255);
+    const char* ctrl_lbl = f.hud_control ? "HUD" : "AUTO";
 
     struct Ind { const char* label; bool ok; };
     const Ind items[N_ITEMS] = {
@@ -628,6 +629,7 @@ void HudRenderer::draw_face_indicator(ImDrawList* dl, const FaceState& f,
         {mode_lbl,    f.connected},
         {rgb_lbl,     f.connected},
         {brt_lbl,     f.connected},
+        {ctrl_lbl,    f.connected},
     };
 
     if (font_mono_) ImGui::PushFont(font_mono_);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -107,7 +107,8 @@ static std::vector<MenuItem> build_menu(
         bool* pip_cam1_overlay, bool* pip_cam2_overlay,
         OverlayConfig* android_cfg,
         HudColors* hud_col, HudConfig* hud_cfg, MenuSystem** menu_sys_pp,
-        Mpu9250* mpu9250)
+        Mpu9250* mpu9250,
+        const std::vector<std::string>& gif_names)
 {
     (void)lora; (void)knob;
 
@@ -178,15 +179,15 @@ static std::vector<MenuItem> build_menu(
 
     // ── Face colors (presets + custom picker) ─────────────────────────────────
     std::vector<MenuItem> colors;
-    colors.push_back(leaf("Teal",   [teensy]{ teensy->set_color(0,220,180);   }));
-    colors.push_back(leaf("Cyan",   [teensy]{ teensy->set_color(0,180,255);   }));
-    colors.push_back(leaf("Red",    [teensy]{ teensy->set_color(220,30,30);   }));
-    colors.push_back(leaf("Green",  [teensy]{ teensy->set_color(30,220,60);   }));
-    colors.push_back(leaf("Purple", [teensy]{ teensy->set_color(180,30,220);  }));
-    colors.push_back(leaf("White",  [teensy]{ teensy->set_color(255,255,255); }));
+    colors.push_back(leaf("Teal",   [teensy]{ teensy->set_color(0,220,180,1);   }));
+    colors.push_back(leaf("Cyan",   [teensy]{ teensy->set_color(0,180,255,1);   }));
+    colors.push_back(leaf("Red",    [teensy]{ teensy->set_color(220,30,30,1);   }));
+    colors.push_back(leaf("Green",  [teensy]{ teensy->set_color(30,220,60,1);   }));
+    colors.push_back(leaf("Purple", [teensy]{ teensy->set_color(180,30,220,1);  }));
+    colors.push_back(leaf("White",  [teensy]{ teensy->set_color(255,255,255,1); }));
     colors.push_back(color_picker(
         "Custom Color",
-        [teensy](uint8_t r, uint8_t g, uint8_t b){ teensy->set_color(r, g, b); },
+        [teensy](uint8_t r, uint8_t g, uint8_t b){ teensy->set_color(r, g, b, 1); },
         [&state]() -> std::tuple<uint8_t,uint8_t,uint8_t> {
             return { state.face.r, state.face.g, state.face.b };
         }
@@ -195,7 +196,9 @@ static std::vector<MenuItem> build_menu(
     // ── GIFs ─────────────────────────────────────────────────────────────────
     std::vector<MenuItem> gifs;
     for (uint8_t i = 0; i < 8; i++) {
-        char lbl[16]; snprintf(lbl, sizeof(lbl), "GIF #%d", i);
+        std::string lbl = (i < gif_names.size() && !gif_names[i].empty())
+                          ? gif_names[i]
+                          : "GIF #" + std::to_string(i);
         gifs.push_back(leaf(lbl, [teensy, i]{ teensy->play_gif(i); }));
     }
 
@@ -511,9 +514,9 @@ static std::vector<MenuItem> build_menu(
 
     // ── Prototracer (face controller) submenu ─────────────────────────────────
     std::vector<MenuItem> prototracer_menu = {
-        submenu("Effects",  std::move(effects)),
-        submenu("Color",    std::move(colors)),
-        submenu("Play GIF", std::move(gifs)),
+        submenu("Faces",      std::move(effects)),
+        submenu("Color",      std::move(colors)),
+        submenu("Animations", std::move(gifs)),
         slider("Brightness", 0.f, 255.f, 1.f, "%",
             [&state]{ return static_cast<float>(state.face.brightness); },
             [teensy](float v){ teensy->set_brightness(static_cast<uint8_t>(v)); }),
@@ -523,6 +526,7 @@ static std::vector<MenuItem> build_menu(
                 state.xr_brightness = static_cast<int>(v);
                 if (xr) xr->set_brightness(static_cast<int>(v));
             }),
+        leaf("Release Control", [teensy]{ teensy->release_control(); }),
     };
 
     // ── HUD settings ──────────────────────────────────────────────────────────
@@ -1280,6 +1284,16 @@ int main(int argc, char* argv[]) {
     bool pip_cam1_overlay_active = false;
     bool pip_cam2_overlay_active = false;
 
+    std::vector<std::string> gif_names;
+    if (jser.contains("teensy")) {
+        const auto& jt = jser["teensy"];
+        if (jt.contains("gif_names") && jt["gif_names"].is_array()) {
+            for (const auto& n : jt["gif_names"])
+                gif_names.push_back(n.get<std::string>());
+        }
+    }
+    gif_names.resize(8);
+
     // menu_ptr is set to &menu after construction so HUD menu lambdas can call
     // into MenuSystem without a circular dependency at build time.
     MenuSystem* menu_ptr = nullptr;
@@ -1289,7 +1303,7 @@ int main(int argc, char* argv[]) {
                                &pip_cam1_overlay_active, &pip_cam2_overlay_active,
                                &android_overlay_cfg,
                                &hud.colors(), &hud.config(), &menu_ptr,
-                               &mpu9250));
+                               &mpu9250, gif_names));
     menu_ptr = &menu;
 
     // Restore menu style from a previous session.

--- a/src/protocols.h
+++ b/src/protocols.h
@@ -47,6 +47,7 @@ namespace TeensyCmd {
     static constexpr uint8_t SET_BRIGHTNESS  = 0x04;  // brightness(1)
     static constexpr uint8_t SET_PALETTE     = 0x05;  // palette_id(1)
     static constexpr uint8_t REQ_STATUS      = 0x06;  // no payload
+    static constexpr uint8_t RELEASE_CONTROL = 0x07;  // no payload — return Teensy to autonomous mode
 
     // Teensy → CM5
     static constexpr uint8_t STATUS          = 0x81;  // see FaceStatusPayload

--- a/src/serial/teensy_controller.cpp
+++ b/src/serial/teensy_controller.cpp
@@ -1,6 +1,8 @@
 #include "teensy_controller.h"
 #include "../protocols.h"
+#include <chrono>
 #include <cstring>
+#include <thread>
 
 TeensyController::TeensyController(const std::string& port, int baud, AppState& state)
     : port_(port, baud), state_(state) {}
@@ -16,10 +18,23 @@ bool TeensyController::start() {
         state_.health.teensy_ok = ok;
         state_.face.connected   = ok;
     }
+    if (ok) {
+        poll_running_ = true;
+        poll_thread_ = std::thread([this] {
+            while (poll_running_) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(200));
+                if (poll_running_) request_status();
+            }
+        });
+    }
     return ok;
 }
 
-void TeensyController::stop() { port_.close(); }
+void TeensyController::stop() {
+    poll_running_ = false;
+    if (poll_thread_.joinable()) poll_thread_.join();
+    port_.close();
+}
 
 bool TeensyController::connected() const { return port_.is_open(); }
 
@@ -27,18 +42,24 @@ void TeensyController::set_color(uint8_t r, uint8_t g, uint8_t b, uint8_t layer)
     TeensyColorPayload p { r, g, b, layer };
     port_.send(TeensyCmd::SET_COLOR,
                reinterpret_cast<const uint8_t*>(&p), sizeof(p));
+    std::lock_guard<std::mutex> lk(state_.mtx);
+    state_.face.hud_control = true;
 }
 
 void TeensyController::set_effect(uint8_t effect_id, uint8_t p1, uint8_t p2) {
     TeensyEffectPayload p { effect_id, p1, p2 };
     port_.send(TeensyCmd::SET_EFFECT,
                reinterpret_cast<const uint8_t*>(&p), sizeof(p));
+    std::lock_guard<std::mutex> lk(state_.mtx);
+    state_.face.hud_control = true;
 }
 
 void TeensyController::play_gif(uint8_t gif_id) {
     TeensyGifPayload p { gif_id };
     port_.send(TeensyCmd::PLAY_GIF,
                reinterpret_cast<const uint8_t*>(&p), sizeof(p));
+    std::lock_guard<std::mutex> lk(state_.mtx);
+    state_.face.hud_control = true;
 }
 
 void TeensyController::set_brightness(uint8_t value) {
@@ -53,6 +74,12 @@ void TeensyController::set_palette(uint8_t palette_id) {
 
 void TeensyController::request_status() {
     port_.send(TeensyCmd::REQ_STATUS);
+}
+
+void TeensyController::release_control() {
+    port_.send(TeensyCmd::RELEASE_CONTROL);
+    std::lock_guard<std::mutex> lk(state_.mtx);
+    state_.face.hud_control = false;
 }
 
 void TeensyController::on_frame(uint8_t cmd, const uint8_t* payload, uint8_t len) {

--- a/src/serial/teensy_controller.h
+++ b/src/serial/teensy_controller.h
@@ -1,7 +1,9 @@
 #pragma once
 #include "serial_port.h"
 #include "../app_state.h"
+#include <atomic>
 #include <string>
+#include <thread>
 
 // Manages bidirectional communication with the Teensy 4.0 running Prototracer.
 // Reads status frames and updates AppState::face.
@@ -21,10 +23,13 @@ public:
     void set_brightness(uint8_t value);
     void set_palette(uint8_t palette_id);
     void request_status();
+    void release_control();
 
 private:
     void on_frame(uint8_t cmd, const uint8_t* payload, uint8_t len);
 
-    SerialPort port_;
-    AppState&  state_;
+    SerialPort           port_;
+    AppState&            state_;
+    std::thread          poll_thread_;
+    std::atomic<bool>    poll_running_ { false };
 };


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Rename "Effects" → "Faces"** — the submenu contains facial expressions (Idle, Blink, Angry, etc.), not generic effects
- **Rename "Play GIF" → "Animations"** — clearer label for the animation submenu
- **Fix colors not changing the face** — color presets and the custom picker were sending `layer=0` (background); changed to `layer=1` to target the face foreground shader
- **Add configurable animation names** — `config.json` now has a `serial.teensy.gif_names` array (8 entries); menu labels fall back to `"GIF #N"` when empty
- **Add "Release Control"** — new menu item sends `RELEASE_CONTROL (0x07)` to the Teensy, returning it to autonomous mode (button/boop sensor/audio-reactive) after HUD commands have taken over
- **Track HUD control state** — `set_effect`, `set_color`, and `play_gif` set `FaceState::hud_control = true`; `release_control()` clears it
- **200ms status poll** — `TeensyController::start()` launches a background thread that sends `REQ_STATUS` every 200ms so the HUD face indicator stays current when the Teensy changes state autonomously
- **6th HUD indicator row** — shows "HUD" or "AUTO" to indicate whether the CM5 or the Teensy is currently in control

## Test plan

- [ ] Open Prototracer submenu → verify labels: "Faces", "Color", "Animations", "Brightness", "Lens Brightness", "Release Control"
- [ ] Select a face (e.g. "Angry") → Teensy shows angry expression; HUD 6th row shows "HUD"
- [ ] Select a color preset (e.g. "Red") → face color changes; HUD RGB row updates
- [ ] Open Animations submenu → verify names from `config.json` appear (or "GIF #N" fallback)
- [ ] Select "Release Control" → HUD 6th row flips to "AUTO"; Teensy responds to physical buttons and audio again
- [ ] Verify HUD face indicator updates within ~200ms when Teensy changes state autonomously (button press on helmet)

https://claude.ai/code/session_01Bd9xYsxj11qWadHTQUCc2P
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bd9xYsxj11qWadHTQUCc2P)_