### PR TITLE
Vision assist: fine-line motion, 0.5x edge scale, granular size filter

### DIFF
--- a/assets/shaders/postprocess.fs
+++ b/assets/shaders/postprocess.fs
@@ -31,8 +31,9 @@ uniform float     u_gate_scale; // 0.0=off, else=step multiplier for confirmator
 uniform sampler2D u_prev_frame;    // unit 2: previous raw frame (RGBA8) for motion detection
 uniform float     u_motion_str;    // 0.0=off; motion highlight intensity
 uniform float     u_motion_thresh; // min luma delta to count as motion (0.01–0.15)
-uniform float     u_motion_radius; // dilation radius in texels; connects nearby motion blobs
+uniform float     u_motion_radius; // sampling step in texels (controls detection tightness)
 uniform vec3      u_motion_col;    // motion highlight colour (normalised RGB)
+uniform float     u_motion_line;   // 0.0=filled blob, 1.0=fine boundary line
 
 varying vec2 v_uv;
 
@@ -116,12 +117,11 @@ void main() {
     // ── Overlay edges ─────────────────────────────────────────────────────────
     color = mix(color, u_edge_col, edge * u_edge_str);
 
-    // ── Motion highlight (temporal frame diff + blob dilation) ────────────────
-    // Compares current luma to previous frame at center + 4 diagonal neighbors.
-    // Taking the max means any pixel within u_motion_radius texels of a moving
-    // pixel also lights up, connecting scattered detections into visible blobs.
-    // Works regardless of local contrast — detects low-contrast moving objects
-    // that Sobel and the contrast proxy miss entirely.
+    // ── Motion highlight (temporal frame diff) ────────────────────────────────
+    // Fine-line mode (u_motion_line=1): uses the RANGE of motion values across
+    // the 5-sample neighborhood — high range means this pixel is at the boundary
+    // between moving and still regions, giving a 1-2px line hugging the silhouette.
+    // Fill mode (u_motion_line=0): uses the MAX (dilation), floods the whole region.
     if (u_motion_str > 0.0) {
         vec2 mstep = u_texel * u_motion_radius;
         float p11 = luma(texture2D(u_prev_frame, v_uv).rgb);
@@ -133,9 +133,15 @@ void main() {
         float s20 = luma(texture2D(u_scene, v_uv + vec2( 1.0,-1.0)*mstep).rgb);
         float s02 = luma(texture2D(u_scene, v_uv + vec2(-1.0, 1.0)*mstep).rgb);
         float s22 = luma(texture2D(u_scene, v_uv + vec2( 1.0, 1.0)*mstep).rgb);
-        float motion = max(abs(l11 - p11),
-                       max(max(abs(s00-p00), abs(s20-p20)),
-                           max(abs(s02-p02), abs(s22-p22))));
+        float mc   = abs(l11  - p11);
+        float mn00 = abs(s00  - p00);
+        float mn20 = abs(s20  - p20);
+        float mn02 = abs(s02  - p02);
+        float mn22 = abs(s22  - p22);
+        float m_max = max(mc, max(max(mn00, mn20), max(mn02, mn22)));
+        float m_min = min(mc, min(min(mn00, mn20), min(mn02, mn22)));
+        // Fine-line: only pixels at the motion boundary (range = max - min is large)
+        float motion = mix(m_max, m_max - m_min, u_motion_line);
         float mw = clamp((motion - u_motion_thresh) / (1.0 - u_motion_thresh + 0.001), 0.0, 1.0);
         color = mix(color, u_motion_col, mw * u_motion_str);
     }

--- a/config/config.json
+++ b/config/config.json
@@ -156,7 +156,8 @@
     "motion_enabled": false,
     "motion_strength": 0.9,
     "motion_thresh": 0.04,
-    "motion_radius": 10.0,
+    "motion_radius": 3.0,
+    "motion_line": 1.0,
     "motion_color": [0, 255, 100, 255]
   },
   "colors": {

--- a/src/app_state.h
+++ b/src/app_state.h
@@ -29,8 +29,9 @@ struct PostProcessConfig {
     bool  motion_enabled  = false;
     float motion_strength = 0.9f;
     float motion_thresh   = 0.04f;   // min luma delta to count as motion (~4%); noise ~1-2%
-    float motion_radius   = 10.0f;   // dilation radius in texels for blob connection
+    float motion_radius   = 3.0f;    // sampling step in texels (smaller = tighter line)
     ImU32 motion_color    = IM_COL32(0, 255, 100, 255);
+    float motion_line     = 1.0f;    // 0.0=filled blob, 1.0=fine boundary line
 };
 
 // ── Overlay layout config (PiP and Android mirror) ───────────────────────────

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -727,11 +727,11 @@ static std::vector<MenuItem> build_menu(
     };
 
     std::vector<MenuItem> edge_detail_menu = {
-        leaf("Fine (1x)",       [&state]{ state.pp_cfg.edge_scale = 1.0f; }),
-        leaf("Standard (2x)",   [&state]{ state.pp_cfg.edge_scale = 2.0f; }),
-        leaf("Coarse (3x)",     [&state]{ state.pp_cfg.edge_scale = 3.0f; }),
-        leaf("Silhouette (5x)", [&state]{ state.pp_cfg.edge_scale = 5.0f; }),
-        leaf("Wide (7x)",       [&state]{ state.pp_cfg.edge_scale = 7.0f; }),
+        leaf("Ultra Fine (0.5x)", [&state]{ state.pp_cfg.edge_scale = 0.5f; }),
+        leaf("Fine (1x)",         [&state]{ state.pp_cfg.edge_scale = 1.0f; }),
+        leaf("Standard (2x)",     [&state]{ state.pp_cfg.edge_scale = 2.0f; }),
+        leaf("Coarse (3x)",       [&state]{ state.pp_cfg.edge_scale = 3.0f; }),
+        leaf("Silhouette (5x)",   [&state]{ state.pp_cfg.edge_scale = 5.0f; }),
     };
 
     std::vector<MenuItem> edge_threshold_menu = {
@@ -762,9 +762,11 @@ static std::vector<MenuItem> build_menu(
     };
 
     std::vector<MenuItem> size_filter_menu = {
-        leaf("Off",        [&state]{ state.pp_cfg.edge_gate_scale = 0.0f; }),
-        leaf("Medium (2x)",[&state]{ state.pp_cfg.edge_gate_scale = 2.0f; }),
-        leaf("Strong (3x)",[&state]{ state.pp_cfg.edge_gate_scale = 3.0f; }),
+        leaf("Off",          [&state]{ state.pp_cfg.edge_gate_scale = 0.0f; }),
+        leaf("Light (1.5x)", [&state]{ state.pp_cfg.edge_gate_scale = 1.5f; }),
+        leaf("Medium (2x)",  [&state]{ state.pp_cfg.edge_gate_scale = 2.0f; }),
+        leaf("Strong (3x)",  [&state]{ state.pp_cfg.edge_gate_scale = 3.0f; }),
+        leaf("Heavy (4x)",   [&state]{ state.pp_cfg.edge_gate_scale = 4.0f; }),
     };
 
     std::vector<MenuItem> motion_sensitivity_menu = {
@@ -774,11 +776,16 @@ static std::vector<MenuItem> build_menu(
         leaf("Very High", [&state]{ state.pp_cfg.motion_thresh = 0.01f; }),
     };
 
+    std::vector<MenuItem> motion_mode_menu = {
+        leaf("Fine Line", [&state]{ state.pp_cfg.motion_line = 1.0f; }),
+        leaf("Fill",      [&state]{ state.pp_cfg.motion_line = 0.0f; }),
+    };
+
     std::vector<MenuItem> motion_spread_menu = {
-        leaf("None (1px)",    [&state]{ state.pp_cfg.motion_radius =  1.0f; }),
-        leaf("Small (5px)",   [&state]{ state.pp_cfg.motion_radius =  5.0f; }),
-        leaf("Medium (10px)", [&state]{ state.pp_cfg.motion_radius = 10.0f; }),
-        leaf("Large (20px)",  [&state]{ state.pp_cfg.motion_radius = 20.0f; }),
+        leaf("Tight (2px)",  [&state]{ state.pp_cfg.motion_radius =  2.0f; }),
+        leaf("Close (4px)",  [&state]{ state.pp_cfg.motion_radius =  4.0f; }),
+        leaf("Medium (8px)", [&state]{ state.pp_cfg.motion_radius =  8.0f; }),
+        leaf("Wide (16px)",  [&state]{ state.pp_cfg.motion_radius = 16.0f; }),
     };
 
     std::vector<MenuItem> motion_color_menu = {
@@ -801,6 +808,7 @@ static std::vector<MenuItem> build_menu(
         toggle("Motion Highlight",
             [&state]{ return state.pp_cfg.motion_enabled; },
             [&state](bool v){ state.pp_cfg.motion_enabled = v; }),
+        submenu("Motion Mode",        std::move(motion_mode_menu)),
         submenu("Motion Sensitivity", std::move(motion_sensitivity_menu)),
         submenu("Motion Spread",      std::move(motion_spread_menu)),
         submenu("Motion Color",       std::move(motion_color_menu)),
@@ -1055,7 +1063,8 @@ int main(int argc, char* argv[]) {
         state.pp_cfg.motion_enabled  = jpp.value("motion_enabled",  false);
         state.pp_cfg.motion_strength = jpp.value("motion_strength", 0.9f);
         state.pp_cfg.motion_thresh   = jpp.value("motion_thresh",   0.04f);
-        state.pp_cfg.motion_radius   = jpp.value("motion_radius",   10.0f);
+        state.pp_cfg.motion_radius   = jpp.value("motion_radius",   3.0f);
+        state.pp_cfg.motion_line     = jpp.value("motion_line",     1.0f);
         if (jpp.contains("motion_color") && jpp["motion_color"].is_array() &&
             jpp["motion_color"].size() >= 3) {
             auto& jc = jpp["motion_color"];
@@ -1586,6 +1595,7 @@ int main(int argc, char* argv[]) {
         jpp["motion_strength"]    = state.pp_cfg.motion_strength;
         jpp["motion_thresh"]      = state.pp_cfg.motion_thresh;
         jpp["motion_radius"]      = state.pp_cfg.motion_radius;
+        jpp["motion_line"]        = state.pp_cfg.motion_line;
         jpp["motion_color"]       = color_to_json(state.pp_cfg.motion_color);
 
         cfg["cameras"]["usb_cam_1"]["brightness"] = cameras.usb1_brightness();

--- a/src/post_process.cpp
+++ b/src/post_process.cpp
@@ -29,6 +29,7 @@ bool PostProcessor::init(int w, int h, const char* vs_path, const char* fs_path)
     loc_motion_thresh_ = glGetUniformLocation(prog_, "u_motion_thresh");
     loc_motion_radius_ = glGetUniformLocation(prog_, "u_motion_radius");
     loc_motion_col_    = glGetUniformLocation(prog_, "u_motion_col");
+    loc_motion_line_   = glGetUniformLocation(prog_, "u_motion_line");
 
     static const char* kBlitVs =
         "attribute vec2 a_pos; attribute vec2 a_uv;"
@@ -107,6 +108,7 @@ void PostProcessor::process(GLuint src_tex, gl::Fbo& prev_fbo, const gl::Fbo& ds
     glUniform1f(loc_motion_thresh_, cfg.motion_thresh);
     glUniform1f(loc_motion_radius_, cfg.motion_radius);
     glUniform3f(loc_motion_col_,    mr, mg, mb);
+    glUniform1f(loc_motion_line_,   cfg.motion_line);
 
     gl::bind_quad(vbo_);
     gl::draw_quad();

--- a/src/post_process.h
+++ b/src/post_process.h
@@ -58,6 +58,7 @@ private:
     GLint loc_motion_thresh_ = -1;
     GLint loc_motion_radius_ = -1;
     GLint loc_motion_col_    = -1;
+    GLint loc_motion_line_   = -1;
 
     int w_ = 0, h_ = 0;
 };


### PR DESCRIPTION
Motion highlight fine-line mode (default):
- Changed from max-dilation (blob fill) to range-based boundary detection. Range = max(motion across 5 samples) - min(motion across 5 samples). Pixels at the edge of a moving region have high range (one side moving, other side still); interior pixels have low range (all uniformly moving). Result: a 1-2px line that hugs the silhouette of moving objects.
- Added u_motion_line uniform (1.0=fine line default, 0.0=fill/blob).
- Default motion_radius reduced to 3px (tight line, less spread).
- Motion Mode menu: Fine Line / Fill.
- Motion Spread labels updated to reflect tighter defaults.

Edge highlight:
- Added Ultra Fine (0.5x) to Edge Detail menu — finer than 1x by sampling at sub-texel offsets, picking up only the steepest gradient transitions.
- Removed Wide (7x) from menu (1x–2x is the useful precision range).

Size filter (adjustable threshold for small-object suppression):
- Added Light (1.5x) and Heavy (4x) options for more granular control. Off → Light (1.5x) → Medium (2x) → Strong (3x) → Heavy (4x).

https://claude.ai/code/session_01LH94rdjztXGergQJDGJ3sV