### PR TITLE
Motion highlight: EMA trail, adjustable persistence, ping-pong FBOs

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -158,6 +158,7 @@
     "motion_thresh": 0.04,
     "motion_radius": 3.0,
     "motion_line": 1.0,
+    "motion_update_rate": 0.5,
     "motion_color": [0, 255, 100, 255]
   },
   "colors": {

--- a/src/app_state.h
+++ b/src/app_state.h
@@ -31,7 +31,8 @@ struct PostProcessConfig {
     float motion_thresh   = 0.04f;   // min luma delta to count as motion (~4%); noise ~1-2%
     float motion_radius   = 3.0f;    // sampling step in texels (smaller = tighter line)
     ImU32 motion_color    = IM_COL32(0, 255, 100, 255);
-    float motion_line     = 1.0f;    // 0.0=filled blob, 1.0=fine boundary line
+    float motion_line        = 1.0f;    // 0.0=filled blob, 1.0=fine boundary line
+    float motion_update_rate = 0.5f;   // EMA blend rate: 1.0=instant (1 frame), lower=longer trail
 };
 
 // ── Overlay layout config (PiP and Android mirror) ───────────────────────────

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -796,6 +796,16 @@ static std::vector<MenuItem> build_menu(
         leaf("Orange", [&state]{ state.pp_cfg.motion_color = IM_COL32(255, 140,   0, 255); }),
     };
 
+    // EMA update rate: how fast the reference frame tracks the scene.
+    // Lower = reference lags further behind = outline lingers longer after motion stops.
+    std::vector<MenuItem> motion_trail_menu = {
+        leaf("Instant (1 frame)",  [&state]{ state.pp_cfg.motion_update_rate = 1.00f; }),
+        leaf("Short  (~3 frames)", [&state]{ state.pp_cfg.motion_update_rate = 0.50f; }),
+        leaf("Medium (~8 frames)", [&state]{ state.pp_cfg.motion_update_rate = 0.20f; }),
+        leaf("Long   (~15 frames)",[&state]{ state.pp_cfg.motion_update_rate = 0.08f; }),
+        leaf("Extended (~30fr)",   [&state]{ state.pp_cfg.motion_update_rate = 0.03f; }),
+    };
+
     std::vector<MenuItem> vision_menu = {
         toggle("Edge Highlight",
             [&state]{ return state.pp_cfg.edge_enabled; },
@@ -811,6 +821,7 @@ static std::vector<MenuItem> build_menu(
         submenu("Motion Mode",        std::move(motion_mode_menu)),
         submenu("Motion Sensitivity", std::move(motion_sensitivity_menu)),
         submenu("Motion Spread",      std::move(motion_spread_menu)),
+        submenu("Motion Trail",       std::move(motion_trail_menu)),
         submenu("Motion Color",       std::move(motion_color_menu)),
         toggle("Bg Desaturate",
             [&state]{ return state.pp_cfg.desat_enabled; },
@@ -1064,7 +1075,8 @@ int main(int argc, char* argv[]) {
         state.pp_cfg.motion_strength = jpp.value("motion_strength", 0.9f);
         state.pp_cfg.motion_thresh   = jpp.value("motion_thresh",   0.04f);
         state.pp_cfg.motion_radius   = jpp.value("motion_radius",   3.0f);
-        state.pp_cfg.motion_line     = jpp.value("motion_line",     1.0f);
+        state.pp_cfg.motion_line        = jpp.value("motion_line",        1.0f);
+        state.pp_cfg.motion_update_rate = jpp.value("motion_update_rate", 0.5f);
         if (jpp.contains("motion_color") && jpp["motion_color"].is_array() &&
             jpp["motion_color"].size() >= 3) {
             auto& jc = jpp["motion_color"];
@@ -1143,7 +1155,10 @@ int main(int argc, char* argv[]) {
 
     PostProcessor post_proc;
     gl::Fbo pp_fbo_left, pp_fbo_right;
-    gl::Fbo pp_prev_left, pp_prev_right;
+    // Ping-pong pairs for motion EMA reference frames (GLES 2.0 can't read+write same FBO)
+    gl::Fbo pp_prev_left[2], pp_prev_right[2];
+    bool    pp_ping_left  = false;   // index of the current READ buffer (0 or 1)
+    bool    pp_ping_right = false;
     const bool pp_ok = post_proc.init(
         xr.eye_width(), xr.eye_height(),
         res("assets/shaders/postprocess.vs").c_str(),
@@ -1151,8 +1166,10 @@ int main(int argc, char* argv[]) {
     if (pp_ok) {
         pp_fbo_left   = gl::make_fbo(xr.eye_width(), xr.eye_height());
         pp_fbo_right  = gl::make_fbo(xr.eye_width(), xr.eye_height());
-        pp_prev_left  = gl::make_fbo(xr.eye_width(), xr.eye_height());
-        pp_prev_right = gl::make_fbo(xr.eye_width(), xr.eye_height());
+        pp_prev_left[0]  = gl::make_fbo(xr.eye_width(), xr.eye_height());
+        pp_prev_left[1]  = gl::make_fbo(xr.eye_width(), xr.eye_height());
+        pp_prev_right[0] = gl::make_fbo(xr.eye_width(), xr.eye_height());
+        pp_prev_right[1] = gl::make_fbo(xr.eye_width(), xr.eye_height());
     } else {
         std::cerr << "[main] post-process shader unavailable — Vision Assist disabled\n";
     }
@@ -1500,8 +1517,14 @@ int main(int argc, char* argv[]) {
         GLuint right_src = xr.eye_right().tex;
         if (pp_ok && post_proc.any_enabled(snap.pp_cfg) &&
                 pp_fbo_left.valid() && pp_fbo_right.valid()) {
-            post_proc.process(xr.eye_left().tex,  pp_prev_left,  pp_fbo_left,  snap.pp_cfg);
-            post_proc.process(xr.eye_right().tex, pp_prev_right, pp_fbo_right, snap.pp_cfg);
+            post_proc.process(xr.eye_left().tex,
+                              pp_prev_left[pp_ping_left],   pp_prev_left[!pp_ping_left],
+                              pp_fbo_left,  snap.pp_cfg);
+            pp_ping_left = !pp_ping_left;
+            post_proc.process(xr.eye_right().tex,
+                              pp_prev_right[pp_ping_right], pp_prev_right[!pp_ping_right],
+                              pp_fbo_right, snap.pp_cfg);
+            pp_ping_right = !pp_ping_right;
             left_src  = pp_fbo_left.tex;
             right_src = pp_fbo_right.tex;
         }
@@ -1596,6 +1619,7 @@ int main(int argc, char* argv[]) {
         jpp["motion_thresh"]      = state.pp_cfg.motion_thresh;
         jpp["motion_radius"]      = state.pp_cfg.motion_radius;
         jpp["motion_line"]        = state.pp_cfg.motion_line;
+        jpp["motion_update_rate"] = state.pp_cfg.motion_update_rate;
         jpp["motion_color"]       = color_to_json(state.pp_cfg.motion_color);
 
         cfg["cameras"]["usb_cam_1"]["brightness"] = cameras.usb1_brightness();
@@ -1645,8 +1669,8 @@ int main(int argc, char* argv[]) {
 
     pp_fbo_left.destroy();
     pp_fbo_right.destroy();
-    pp_prev_left.destroy();
-    pp_prev_right.destroy();
+    pp_prev_left[0].destroy();  pp_prev_left[1].destroy();
+    pp_prev_right[0].destroy(); pp_prev_right[1].destroy();
     post_proc.shutdown();
 
     xr.shutdown();

--- a/src/post_process.cpp
+++ b/src/post_process.cpp
@@ -31,18 +31,31 @@ bool PostProcessor::init(int w, int h, const char* vs_path, const char* fs_path)
     loc_motion_col_    = glGetUniformLocation(prog_, "u_motion_col");
     loc_motion_line_   = glGetUniformLocation(prog_, "u_motion_line");
 
+    // EMA blit: blends current frame with previous EMA reference.
+    // update_rate=1.0 → hard copy (1-frame trail), lower → longer exponential trail.
     static const char* kBlitVs =
         "attribute vec2 a_pos; attribute vec2 a_uv;"
         "varying vec2 v_uv;"
         "void main(){ v_uv = a_uv; gl_Position = vec4(a_pos, 0.0, 1.0); }";
     static const char* kBlitFs =
         "precision mediump float;"
-        "uniform sampler2D u_tex;"
+        "uniform sampler2D u_cur;"
+        "uniform sampler2D u_prev;"
+        "uniform float u_rate;"
         "varying vec2 v_uv;"
-        "void main(){ gl_FragColor = texture2D(u_tex, v_uv); }";
+        "void main(){"
+        "    vec4 c = texture2D(u_cur,  v_uv);"
+        "    vec4 p = texture2D(u_prev, v_uv);"
+        "    gl_FragColor = mix(p, c, u_rate);"
+        "}";
     blit_prog_ = gl::build_program_from_strings(kBlitVs, kBlitFs);
-    if (!blit_prog_)
-        std::cerr << "[post_process] blit shader build failed — motion prev-frame copy disabled\n";
+    if (!blit_prog_) {
+        std::cerr << "[post_process] blit shader build failed — motion trail disabled\n";
+    } else {
+        loc_blit_cur_  = glGetUniformLocation(blit_prog_, "u_cur");
+        loc_blit_prev_ = glGetUniformLocation(blit_prog_, "u_prev");
+        loc_blit_rate_ = glGetUniformLocation(blit_prog_, "u_rate");
+    }
 
     vbo_ = gl::make_quad_vbo();
     if (!vbo_) {
@@ -60,8 +73,11 @@ void PostProcessor::shutdown() {
     if (vbo_)       { glDeleteBuffers(1, &vbo_);    vbo_       = 0; }
 }
 
-void PostProcessor::process(GLuint src_tex, gl::Fbo& prev_fbo, const gl::Fbo& dst,
+void PostProcessor::process(GLuint src_tex,
+                             const gl::Fbo& prev_read, gl::Fbo& prev_write,
+                             const gl::Fbo& dst,
                              const PostProcessConfig& cfg) {
+    // ── Main effect pass ──────────────────────────────────────────────────────
     dst.bind();
     glClearColor(0.f, 0.f, 0.f, 1.f);
     glClear(GL_COLOR_BUFFER_BIT);
@@ -72,9 +88,9 @@ void PostProcessor::process(GLuint src_tex, gl::Fbo& prev_fbo, const gl::Fbo& ds
     glBindTexture(GL_TEXTURE_2D, src_tex);
     glUniform1i(loc_scene_, 0);
 
-    // Bind previous frame for motion detection (unit 2; stays black until second frame)
+    // Bind EMA reference frame for motion detection (unit 2)
     glActiveTexture(GL_TEXTURE2);
-    glBindTexture(GL_TEXTURE_2D, prev_fbo.valid() ? prev_fbo.tex : 0);
+    glBindTexture(GL_TEXTURE_2D, prev_read.valid() ? prev_read.tex : 0);
     glUniform1i(loc_prev_frame_, 2);
 
     glUniform2f(loc_texel_, 1.f / static_cast<float>(w_),
@@ -94,13 +110,11 @@ void PostProcessor::process(GLuint src_tex, gl::Fbo& prev_fbo, const gl::Fbo& ds
     glUniform1f(loc_edge_scale_,  cfg.edge_scale);
     glUniform1f(loc_edge_thresh_, cfg.edge_threshold);
 
-    // Focus-based sharpness: sensitivity scales with lens proximity (close = narrow DoF = stronger separation)
     const float focus_norm = static_cast<float>(cfg.focus_lens_pos) / 1000.0f;
     glUniform1f(loc_focus_str_,  cfg.focus_str);
     glUniform1f(loc_focus_sens_, 1.0f + focus_norm * 3.0f);
     glUniform1f(loc_gate_scale_, cfg.edge_gate_scale);
 
-    // Motion highlight uniforms
     const float mr = ((cfg.motion_color >>  0) & 0xFF) / 255.f;
     const float mg = ((cfg.motion_color >>  8) & 0xFF) / 255.f;
     const float mb = ((cfg.motion_color >> 16) & 0xFF) / 255.f;
@@ -117,17 +131,24 @@ void PostProcessor::process(GLuint src_tex, gl::Fbo& prev_fbo, const gl::Fbo& ds
     glUseProgram(0);
     dst.unbind();
 
-    // Copy src_tex → prev_fbo so next frame can compare against this one.
-    if (prev_fbo.valid() && blit_prog_) {
-        prev_fbo.bind();
+    // ── EMA blit: blend src_tex into prev_write using prev_read as old value ──
+    // prev_write becomes the new reference frame for next frame's motion detection.
+    // update_rate=1.0 → hard copy (crisp, 1-frame trail)
+    // update_rate<1.0 → exponential moving average → smooth, longer trail
+    if (prev_write.valid() && blit_prog_) {
+        prev_write.bind();
         glUseProgram(blit_prog_);
         glActiveTexture(GL_TEXTURE0);
         glBindTexture(GL_TEXTURE_2D, src_tex);
-        glUniform1i(glGetUniformLocation(blit_prog_, "u_tex"), 0);
+        glUniform1i(loc_blit_cur_, 0);
+        glActiveTexture(GL_TEXTURE1);
+        glBindTexture(GL_TEXTURE_2D, prev_read.valid() ? prev_read.tex : src_tex);
+        glUniform1i(loc_blit_prev_, 1);
+        glUniform1f(loc_blit_rate_, cfg.motion_update_rate);
         gl::bind_quad(vbo_);
         gl::draw_quad();
         gl::unbind_quad();
         glUseProgram(0);
-        prev_fbo.unbind();
+        prev_write.unbind();
     }
 }

--- a/src/post_process.h
+++ b/src/post_process.h
@@ -26,9 +26,12 @@ public:
     void shutdown();
 
     // Apply the post-process pass: read src_tex, write result to dst.
-    // prev_fbo holds the previous raw frame for motion detection; updated each call.
-    // dst must be a valid gl::Fbo with matching dimensions.
-    void process(GLuint src_tex, gl::Fbo& prev_fbo, const gl::Fbo& dst,
+    // prev_read: EMA-smoothed reference frame used for motion detection.
+    // prev_write: receives the new EMA frame (prev_read blended with src_tex).
+    // Use a ping-pong pair per eye; swap read/write each frame.
+    void process(GLuint src_tex,
+                 const gl::Fbo& prev_read, gl::Fbo& prev_write,
+                 const gl::Fbo& dst,
                  const PostProcessConfig& cfg);
 
     bool any_enabled(const PostProcessConfig& cfg) const {
@@ -37,8 +40,13 @@ public:
 
 private:
     GLuint prog_      = 0;
-    GLuint blit_prog_ = 0;   // trivial src→prev blit shader (inline GLSL)
+    GLuint blit_prog_ = 0;   // EMA blit: blends src_tex with prev to produce new reference
     GLuint vbo_       = 0;
+
+    // Cached blit uniform locations
+    GLint  loc_blit_cur_  = -1;
+    GLint  loc_blit_prev_ = -1;
+    GLint  loc_blit_rate_ = -1;
 
     // Cached uniform locations (set at init time)
     GLint loc_scene_         = -1;


### PR DESCRIPTION
The motion reference frame is now an exponential moving average (EMA) rather than a hard 1-frame snapshot. This eliminates ghosting:

  Old: compare current to exactly 1 frame ago → outline snaps on/off,
       floats because the reference jumps one full frame forward each tick.
  New: compare current to EMA(previous frames) → reference smoothly
       tracks the scene, so the outline appears right where motion is
       and fades naturally as the EMA catches up after motion stops.

The EMA update rate (u_rate in blit shader) controls trail length:
  1.00 = instant (1 frame, crisp, old behavior)
  0.50 = ~3 frames  (~50ms at 60fps)
  0.20 = ~8 frames  (~130ms)
  0.08 = ~15 frames (~250ms)
  0.03 = ~30 frames (~500ms)

Architecture change: prev FBOs are now a ping-pong pair per eye because GLES 2.0 cannot read and write the same texture simultaneously. The blit shader blends src_tex (unit 0) + prev_read (unit 1) → prev_write. prev_read/write swap each frame via a bool toggle in main.cpp.

New menu: Vision Assist → Motion Trail with five options. motion_update_rate persisted in config.json.

https://claude.ai/code/session_01LH94rdjztXGergQJDGJ3sV