### PR TITLE
Fix flip-to-top arm alignment and enable compass bg by default

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -79,7 +79,7 @@
   "hud": {
     "compass_height_px": 80,
     "compass_bottom_margin_px": 20,
-    "compass_bg": false,
+    "compass_bg": true,
     "compass_bg_opacity": 0.75,
     "compass_bg_side_fade_px": 80,
     "panel_width_px": 320,

--- a/src/app_state.h
+++ b/src/app_state.h
@@ -186,7 +186,7 @@ struct AppState {
 
     // Heading used for the HUD compass. Updated by LoRa or IMU.
     float compass_heading    = 0.0f;
-    bool  compass_bg_enabled = false;
+    bool  compass_bg_enabled = true;
 
     // Latest IMU pose (NWU coordinates). Updated by XRDisplay IMU callback.
     ImuPose imu_pose;

--- a/src/hud/hud_renderer.cpp
+++ b/src/hud/hud_renderer.cpp
@@ -506,7 +506,7 @@ void HudRenderer::draw_health_side(ImDrawList* dl, const SystemHealth& h,
     const float c_margin = static_cast<float>(cfg_.compass_bottom_margin);
     const float ch       = static_cast<float>(cfg_.compass_height);
     const bool  flip     = cfg_.hud_flip_vertical;
-    const float anchor_y = flip ? c_margin + ch : fh - c_margin;
+    const float anchor_y = flip ? c_margin : fh - c_margin;
     const float anchor_x = right_side ? tape_x + tape_w + fade_w
                                        : tape_x - fade_w;
 
@@ -1470,7 +1470,7 @@ void HudRenderer::fx_update(ImDrawList* dl, const AppState& s,
         // Arms are at fixed angles: face ~210°, lora ~270°, clock ~330° (left side)
         // and mirrored on right side for health.
         // Use the same anchor_y the draw helpers use.
-        const float anchor_y = flip ? c_margin + ch : fh - c_margin;
+        const float anchor_y = flip ? c_margin : fh - c_margin;
 
         // Each indicator arm: left-center is ~ fw/3 wide; right ~2fw/3
         struct ArmDef { float ax; float angle_deg; };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1322,7 +1322,7 @@ int main(int argc, char* argv[]) {
 
     AppState state;
     state.max_messages        = jval(jhud, "lora_message_history", 50);
-    state.compass_bg_enabled  = jhud.value("compass_bg", false);
+    state.compass_bg_enabled  = jhud.value("compass_bg", true);
 
     if (jhud.contains("effects")) {
         auto& jfx = jhud["effects"];


### PR DESCRIPTION
Arm anchor_y in flipped mode was c_margin+ch (compass bottom), causing arms to hang below the compass. Changed to c_margin (compass top) so arms extend downward through the tape, mirroring the normal-mode layout where arms extend upward from the compass bottom edge.

Also enables compass background by default in app_state.h, config.json, and the main.cpp fallback value.

https://claude.ai/code/session_01LH94rdjztXGergQJDGJ3sV