### PR TITLE
Move all glow controls to Glow menu under Color Options

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -673,9 +673,6 @@ static std::vector<MenuItem> build_menu(
         submenu("Tagged Radio Colors", std::move(tagged_radio_colors_menu)),
         submenu("Background Options",  std::move(compass_bg_options_menu)),
         submenu("Color Options",       std::move(compass_color_options_menu)),
-        toggle("Tick Glow",
-            [hud_cfg]{ return hud_cfg->compass_tick_glow; },
-            [hud_cfg](bool v){ hud_cfg->compass_tick_glow = v; }),
     };
 
     // ── Clock & Timers ────────────────────────────────────────────────────────
@@ -899,6 +896,12 @@ static std::vector<MenuItem> build_menu(
         toggle("Text Glow",
             [hud_cfg]{ return hud_cfg->glow_enabled; },
             [hud_cfg](bool v){ hud_cfg->glow_enabled = v; }),
+        toggle("Tick Glow",
+            [hud_cfg]{ return hud_cfg->compass_tick_glow; },
+            [hud_cfg](bool v){ hud_cfg->compass_tick_glow = v; }),
+        slider("Glow Intensity", 0.f, 2.f, 0.05f, "",
+            [hud_cfg]{ return hud_cfg->glow_intensity; },
+            [hud_cfg](float v){ hud_cfg->glow_intensity = v; }),
         submenu("Glow Color", std::move(glow_color_menu)),
     };
 


### PR DESCRIPTION
Tick Glow toggle moved from Compass menu into Color Options > Glow, alongside the existing Text Glow toggle and Glow Color submenu. Also adds a Glow Intensity slider (0.0–2.0) which was in config but had no menu control.

https://claude.ai/code/session_01LH94rdjztXGergQJDGJ3sV