### PR TITLE
Add menu border toggle, color, and thickness controls

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -896,12 +896,34 @@ static std::vector<MenuItem> build_menu(
         { "Purple", IM_COL32(180,  30, 220, 255) },
     }, [menu_sys_pp](ImU32 c){ if (*menu_sys_pp) (*menu_sys_pp)->set_accent_color(c); });
 
+    std::vector<MenuItem> menu_border_color_menu = make_color_items({
+        { "Orange", IM_COL32(255, 160,  32, 255) },
+        { "Teal",   IM_COL32(  0, 220, 180, 255) },
+        { "Cyan",   IM_COL32(  0, 180, 255, 255) },
+        { "Green",  IM_COL32( 30, 220,  60, 255) },
+        { "Yellow", IM_COL32(255, 240,  50, 255) },
+        { "Purple", IM_COL32(180,  30, 220, 255) },
+        { "White",  IM_COL32(255, 255, 255, 255) },
+        { "Red",    IM_COL32(255,  50,  50, 255) },
+    }, [menu_sys_pp](ImU32 c){ if (*menu_sys_pp) (*menu_sys_pp)->set_border_color(c); });
+
+    std::vector<MenuItem> menu_border_menu = {
+        toggle("Border",
+            [menu_sys_pp]{ return *menu_sys_pp && (*menu_sys_pp)->border_enabled(); },
+            [menu_sys_pp](bool v){ if (*menu_sys_pp) (*menu_sys_pp)->set_border_enabled(v); }),
+        slider("Thickness", 0.5f, 8.f, 0.5f, "px",
+            [menu_sys_pp]{ return *menu_sys_pp ? (*menu_sys_pp)->border_thickness() : 1.5f; },
+            [menu_sys_pp](float v){ if (*menu_sys_pp) (*menu_sys_pp)->set_border_thickness(v); }),
+        submenu("Border Color", std::move(menu_border_color_menu)),
+    };
+
     std::vector<MenuItem> color_options_menu = {
         submenu("HUD",                std::move(hud_submenu)),
         submenu("Compass Tick Color", std::move(compass_tick_color_menu)),
         submenu("Compass Glow Color", std::move(compass_glow_color_menu)),
         submenu("Text Color",         std::move(text_color_menu)),
         submenu("Menu Color",         std::move(menu_color_menu)),
+        submenu("Menu Border",        std::move(menu_border_menu)),
         submenu("Backgrounds",        std::move(backgrounds_menu)),
         submenu("Indicators",         std::move(indicators_menu)),
         submenu("Glow",               std::move(glow_menu)),
@@ -1571,9 +1593,12 @@ int main(int argc, char* argv[]) {
     // Restore menu style from a previous session.
     if (cfg.contains("menu_style")) {
         auto& jm = cfg["menu_style"];
-        menu.set_accent_color(jcolor(jm, "accent_color", menu.accent_color()));
-        menu.set_bg_color    (jcolor(jm, "bg_color",     menu.bg_color()));
-        menu.set_bg_enabled  (jval  (jm, "bg_enabled",   menu.bg_enabled()));
+        menu.set_accent_color    (jcolor(jm, "accent_color",     menu.accent_color()));
+        menu.set_bg_color        (jcolor(jm, "bg_color",         menu.bg_color()));
+        menu.set_bg_enabled      (jval  (jm, "bg_enabled",       menu.bg_enabled()));
+        menu.set_border_color    (jcolor(jm, "border_color",     menu.border_color()));
+        menu.set_border_thickness(jval  (jm, "border_thickness", menu.border_thickness()));
+        menu.set_border_enabled  (jval  (jm, "border_enabled",   menu.border_enabled()));
     }
 
     menu.set_detent_callback([&knob, &menu](int count) {
@@ -1974,9 +1999,12 @@ int main(int argc, char* argv[]) {
         cfg["cameras"]["usb_cam_2"]["brightness"] = cameras.usb2_brightness();
 
         auto& jm = cfg["menu_style"];
-        jm["accent_color"] = color_to_json(menu.accent_color());
-        jm["bg_color"]     = color_to_json(menu.bg_color());
-        jm["bg_enabled"]   = menu.bg_enabled();
+        jm["accent_color"]     = color_to_json(menu.accent_color());
+        jm["bg_color"]         = color_to_json(menu.bg_color());
+        jm["bg_enabled"]       = menu.bg_enabled();
+        jm["border_color"]     = color_to_json(menu.border_color());
+        jm["border_thickness"] = menu.border_thickness();
+        jm["border_enabled"]   = menu.border_enabled();
 
         // Persist MPU-9250 calibration biases so they survive a restart
         if (mpu9250.is_running() || cfg.contains("mpu9250")) {

--- a/src/menu/menu_system.cpp
+++ b/src/menu/menu_system.cpp
@@ -325,8 +325,12 @@ void MenuSystem::draw(int screen_w, int screen_h) {
 
     // ── Chamfered background + border ────────────────────────────────────────
     {
-        constexpr float C   = 8.f;   // chamfer distance (corner cut)
-        constexpr float GAP = 3.f;   // transparent strip between bg fill and border
+        constexpr float C = 8.f;  // chamfer distance (corner cut)
+        // GAP keeps exactly 3px of transparent strip between the inner edge of
+        // the border line and the outer edge of the bg fill, regardless of
+        // border thickness (border line is centered on the window edge, so its
+        // inner edge is at thickness/2 inward; bg fill is inset by GAP).
+        const float GAP = 3.f + border_thickness_ * 0.5f;
 
         const ImVec2 wp = ImGui::GetWindowPos();
         const ImVec2 ws = ImGui::GetWindowSize();
@@ -353,8 +357,8 @@ void MenuSystem::draw(int screen_w, int screen_h) {
                 {emax.x - C, emax.y}, {emin.x + C, emax.y},
                 {emin.x, emax.y - C}, {emin.x, emin.y + C},
             };
-            dl->AddPolyline(bdr_pts, 8, menu_with_alpha(accent_color_, 220),
-                            ImDrawFlags_Closed, 1.5f);
+            dl->AddPolyline(bdr_pts, 8, menu_with_alpha(border_color_, 220),
+                            ImDrawFlags_Closed, border_thickness_);
         }
     }
 

--- a/src/menu/menu_system.h
+++ b/src/menu/menu_system.h
@@ -84,17 +84,22 @@ public:
     void set_detent_callback(DetentCallback cb) { detent_cb_ = std::move(cb); }
 
     // Runtime style setters — take effect immediately on the next draw() call.
-    void set_accent_color(ImU32 c)       { accent_color_    = c; }
-    void set_bg_enabled(bool e)          { bg_enabled_      = e; }
-    void set_bg_color(ImU32 c)           { bg_color_        = c; }
-    void set_glow_enabled(bool e)        { glow_enabled_    = e; }
-    void set_border_enabled(bool e)      { border_enabled_  = e; }
+    void set_accent_color(ImU32 c)        { accent_color_     = c; }
+    void set_bg_enabled(bool e)           { bg_enabled_       = e; }
+    void set_bg_color(ImU32 c)            { bg_color_         = c; }
+    void set_glow_enabled(bool e)         { glow_enabled_     = e; }
+    void set_border_enabled(bool e)       { border_enabled_   = e; }
+    void set_border_color(ImU32 c)        { border_color_     = c; }
+    void set_border_thickness(float t)    { border_thickness_ = t; }
     void set_selection_style(SelectionStyle s) { selection_style_ = s; }
 
     // Runtime style getters — for persisting user changes to config on exit.
-    ImU32 accent_color() const { return accent_color_; }
-    ImU32 bg_color()     const { return bg_color_;     }
-    bool  bg_enabled()   const { return bg_enabled_;   }
+    ImU32 accent_color()     const { return accent_color_;     }
+    ImU32 bg_color()         const { return bg_color_;         }
+    bool  bg_enabled()       const { return bg_enabled_;       }
+    bool  border_enabled()   const { return border_enabled_;   }
+    ImU32 border_color()     const { return border_color_;     }
+    float border_thickness() const { return border_thickness_; }
 
     // Drive from knob events
     void navigate(int direction);   // +1 = next, -1 = prev (or adjust value in edit mode)
@@ -141,10 +146,12 @@ private:
     DetentCallback         detent_cb_;
 
     // Runtime style
-    ImU32          accent_color_    = IM_COL32(255, 160,  32, 255);
-    bool           bg_enabled_      = true;
-    ImU32          bg_color_        = IM_COL32( 10,  15,  20, 225);
-    bool           glow_enabled_    = true;
-    bool           border_enabled_  = true;
-    SelectionStyle selection_style_ = SelectionStyle::ACCENT_BAR;
+    ImU32          accent_color_     = IM_COL32(255, 160,  32, 255);
+    bool           bg_enabled_       = true;
+    ImU32          bg_color_         = IM_COL32( 10,  15,  20, 225);
+    bool           glow_enabled_     = true;
+    bool           border_enabled_   = true;
+    ImU32          border_color_     = IM_COL32(255, 160,  32, 255);
+    float          border_thickness_ = 1.5f;
+    SelectionStyle selection_style_  = SelectionStyle::ACCENT_BAR;
 };


### PR DESCRIPTION
MenuSystem gains set_border_color / set_border_thickness / border_color / border_thickness / border_enabled getters and setters.

The bg fill inset is computed as 3 + thickness/2 so the inner edge of the border line is always exactly 3px from the bg fill, regardless of thickness.

Color > Menu Border submenu exposes: Border toggle, Thickness slider (0.5–8px, 0.5 step), Border Color presets (8 colours). Border color and thickness persist in menu_style config block.

https://claude.ai/code/session_01LH94rdjztXGergQJDGJ3sV