### PR TITLE
Menu UX: custom timer, slider color inversion, highlight clip

### DIFF
--- a/src/app_state.h
+++ b/src/app_state.h
@@ -166,6 +166,8 @@ struct TimerAlarmState {
     bool   timer_triggered = false;   // true → timer-expired popup is shown
     int    alarm_hour      = 0;       // picker working value (0–23)
     int    alarm_minute    = 0;       // picker working value (0–59)
+    int    custom_timer_min = 0;      // custom timer minutes (0–99)
+    int    custom_timer_sec = 0;      // custom timer seconds (0–59)
 };
 
 // ── Master state ──────────────────────────────────────────────────────────────

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -986,11 +986,11 @@ static std::vector<MenuItem> build_menu(
     // ── Vision Assist (post-processing depth cues) ────────────────────────────
 
     std::vector<MenuItem> edge_strength_menu = {
-        leaf("10%",  [&state]{ state.pp_cfg.edge_strength = 0.10f; }),
-        leaf("30%",  [&state]{ state.pp_cfg.edge_strength = 0.30f; }),
-        leaf("50%",  [&state]{ state.pp_cfg.edge_strength = 0.50f; }),
-        leaf("70%",  [&state]{ state.pp_cfg.edge_strength = 0.70f; }),
-        leaf("100%", [&state]{ state.pp_cfg.edge_strength = 1.00f; }),
+        leaf_sel("10%",  [&state]{ state.pp_cfg.edge_strength = 0.10f; }, [&state]{ return state.pp_cfg.edge_strength == 0.10f; }),
+        leaf_sel("30%",  [&state]{ state.pp_cfg.edge_strength = 0.30f; }, [&state]{ return state.pp_cfg.edge_strength == 0.30f; }),
+        leaf_sel("50%",  [&state]{ state.pp_cfg.edge_strength = 0.50f; }, [&state]{ return state.pp_cfg.edge_strength == 0.50f; }),
+        leaf_sel("70%",  [&state]{ state.pp_cfg.edge_strength = 0.70f; }, [&state]{ return state.pp_cfg.edge_strength == 0.70f; }),
+        leaf_sel("100%", [&state]{ state.pp_cfg.edge_strength = 1.00f; }, [&state]{ return state.pp_cfg.edge_strength == 1.00f; }),
     };
 
     std::vector<MenuItem> edge_color_menu = {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -670,7 +670,25 @@ static std::vector<MenuItem> build_menu(
     };
 
     // ── Clock & Timers ────────────────────────────────────────────────────────
+    std::vector<MenuItem> custom_timer_menu = {
+        slider("Minutes", 0.f, 99.f, 1.f, "",
+            [&state]{ return static_cast<float>(state.timer_alarm.custom_timer_min); },
+            [&state](float v){ state.timer_alarm.custom_timer_min = static_cast<int>(v); }),
+        slider("Seconds", 0.f, 59.f, 1.f, "",
+            [&state]{ return static_cast<float>(state.timer_alarm.custom_timer_sec); },
+            [&state](float v){ state.timer_alarm.custom_timer_sec = static_cast<int>(v); }),
+        leaf("Start", [&state]{
+            int secs = state.timer_alarm.custom_timer_min * 60
+                     + state.timer_alarm.custom_timer_sec;
+            if (secs > 0) {
+                state.timer_alarm.timer_active = true;
+                state.timer_alarm.timer_end    = time(nullptr) + secs;
+            }
+        }),
+    };
+
     std::vector<MenuItem> timer_presets_menu = {
+        submenu("Custom", std::move(custom_timer_menu)),
         leaf_sel("5 min",  [&state]{ state.timer_alarm.timer_active = true;
                                       state.timer_alarm.timer_end = time(nullptr) + 300; },
                  [&state]{ return state.timer_alarm.timer_active

--- a/src/menu/menu_system.cpp
+++ b/src/menu/menu_system.cpp
@@ -324,16 +324,12 @@ void MenuSystem::draw(int screen_w, int screen_h) {
     ImDrawList* dl = ImGui::GetWindowDrawList();
 
     // ── Chamfered background + border ────────────────────────────────────────
+    // wp/ws/GAP hoisted so the item loop can use them for highlight clipping.
+    const ImVec2 wp  = ImGui::GetWindowPos();
+    const ImVec2 ws  = ImGui::GetWindowSize();
+    const float  GAP = 3.f + border_thickness_ * 0.5f;
     {
         constexpr float C = 8.f;  // chamfer distance (corner cut)
-        // GAP keeps exactly 3px of transparent strip between the inner edge of
-        // the border line and the outer edge of the bg fill, regardless of
-        // border thickness (border line is centered on the window edge, so its
-        // inner edge is at thickness/2 inward; bg fill is inset by GAP).
-        const float GAP = 3.f + border_thickness_ * 0.5f;
-
-        const ImVec2 wp = ImGui::GetWindowPos();
-        const ImVec2 ws = ImGui::GetWindowSize();
 
         // Background fill inset by GAP — chamfered octagon
         const ImVec2 bmin = {wp.x + GAP,        wp.y + GAP};
@@ -399,8 +395,8 @@ void MenuSystem::draw(int screen_w, int screen_h) {
         // Selection highlight: filled white row (Halo) or left accent bar (default)
         if (selected) {
             if (filled_row)
-                dl->AddRectFilled({rmin.x - pad_x, rmin.y},
-                                  {rmax.x + pad_x, rmax.y}, IM_COL32(255, 255, 255, 235));
+                dl->AddRectFilled({wp.x + GAP,        rmin.y},
+                                  {wp.x + ws.x - GAP, rmax.y}, IM_COL32(255, 255, 255, 235));
             else
                 dl->AddRectFilled({rmin.x - pad_x,       rmin.y},
                                   {rmin.x - pad_x + 4.f, rmax.y}, accent_color_);
@@ -452,21 +448,24 @@ void MenuSystem::draw(int screen_w, int screen_h) {
 
             draw_item_text({rmin.x + 4.f, ty}, to_upper(item.label).c_str(), selected);
 
+            const bool inv = (filled_row && selected);
+
             if (editing) {
                 float bx = rmin.x + 4.f;
                 float by = rmin.y + item_h - 2.f;
                 float bw = (rmax.x - rmin.x) - 64.f;
                 float bh = 10.f;
                 dl->AddRectFilled({bx, by}, {bx + bw, by + bh},
-                                  menu_with_alpha(accent_color_, 60), 3.f);
+                                  inv ? IM_COL32(0,0,0,60) : menu_with_alpha(accent_color_, 60), 3.f);
                 dl->AddRectFilled({bx, by}, {bx + bw * fill, by + bh},
-                                  menu_with_alpha(accent_color_, 220), 3.f);
+                                  inv ? IM_COL32(0,0,0,220) : menu_with_alpha(accent_color_, 220), 3.f);
                 float tick_x = bx + bw * fill;
                 dl->AddLine({tick_x, by - 2.f}, {tick_x, by + bh + 2.f},
-                            IM_COL32(255, 255, 255, 200), 2.f);
-                dl->AddText({bx + bw + 6.f, by}, IM_COL32(255, 255, 255, 255), val_str);
+                            inv ? IM_COL32(0,0,0,200) : IM_COL32(255, 255, 255, 200), 2.f);
+                dl->AddText({bx + bw + 6.f, by},
+                            inv ? IM_COL32(0,0,0,255) : IM_COL32(255, 255, 255, 255), val_str);
                 dl->AddText({bx, by - 14.f},
-                            menu_with_alpha(accent_color_, 180),
+                            inv ? IM_COL32(0,0,0,180) : menu_with_alpha(accent_color_, 180),
                             "knob  \xC2\xB7  select=confirm  \xC2\xB7  back=cancel");
             } else {
                 float win_w = rmax.x - rmin.x;
@@ -475,12 +474,12 @@ void MenuSystem::draw(int screen_w, int screen_h) {
                 float bw = win_w * 0.30f;
                 float bh = 7.f;
                 dl->AddRectFilled({bx, by}, {bx + bw, by + bh},
-                                  menu_with_alpha(accent_color_, 50), 2.f);
+                                  inv ? IM_COL32(0,0,0,50) : menu_with_alpha(accent_color_, 50), 2.f);
                 dl->AddRectFilled({bx, by}, {bx + bw * fill, by + bh},
-                                  menu_with_alpha(accent_color_, 180), 2.f);
+                                  inv ? IM_COL32(0,0,0,180) : menu_with_alpha(accent_color_, 180), 2.f);
                 ImVec2 vsz = ImGui::CalcTextSize(val_str);
                 dl->AddText({rmax.x - vsz.x - 4.f, by - 1.f},
-                            menu_with_alpha(accent_color_, 200), val_str);
+                            inv ? IM_COL32(0,0,0,200) : menu_with_alpha(accent_color_, 200), val_str);
             }
 
         // ── COLOR_PICKER ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Custom timer**: adds a "Custom" submenu to Set Timer with minute (0–99) and second (0–59) sliders plus a Start action; stores working values as `custom_timer_min`/`custom_timer_sec` in `TimerAlarmState`
- **Slider color inversion**: in FILLED_ROW (Halo) theme, selected slider elements — bar background, bar fill, tick line, value text, and hint text — now render in black instead of accent color so they're legible on the white highlight
- **Highlight clip**: hoisted `wp`/`ws`/`GAP` out of the chamfered-bg block; FILLED_ROW white highlight is now clipped to the bg-fill boundary (`wp.x + GAP` … `wp.x + ws.x - GAP`) instead of extending to the full window width

## Test plan

- [ ] Open Set Timer → "Custom" appears as first item; adjust minutes/seconds sliders → Start → HUD arm shows countdown
- [ ] With Halo theme selected, highlight any slider — bar and value text are black on white, legible
- [ ] Enter edit mode on a slider (knob confirm) in Halo theme — expanded bar, tick, value, and hint text all black
- [ ] With default theme — slider colors and highlight are unchanged (ACCENT_BAR path untouched)
- [ ] FILLED_ROW selection highlight is clipped to the chamfered bg-fill edge, no white extending past the border

https://claude.ai/code/session_01LH94rdjztXGergQJDGJ3sV

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH94rdjztXGergQJDGJ3sV)_