### PR TITLE
Move Timers/Alarm to root menu; add Menu Position anchor; inactive in…

### DIFF
--- a/src/app_state.h
+++ b/src/app_state.h
@@ -100,6 +100,9 @@ struct SystemHealth {
     bool audio_ok        = false;  // Spatial audio engine running
     bool android_mirror  = false;  // scrcpy connected and streaming
     bool mpu9250_ok      = false;  // MPU-9250 backup compass running
+    // Render-thread-only: connected AND overlay enabled
+    bool cam_usb1_overlay = false;
+    bool cam_usb2_overlay = false;
 };
 
 struct AudioState {

--- a/src/hud/hud_renderer.cpp
+++ b/src/hud/hud_renderer.cpp
@@ -525,15 +525,15 @@ void HudRenderer::draw_health_side(ImDrawList* dl, const SystemHealth& h,
     snprintf(lcam_lbl, sizeof(lcam_lbl), "L.Cam%s", focus_suffix(focus_left));
     snprintf(rcam_lbl, sizeof(rcam_lbl), "R.Cam%s", focus_suffix(focus_right));
 
-    struct Ind { const char* label; bool ok; };
+    struct Ind { const char* label; bool ok; bool inactive = false; };
     const Ind left_items[]  = {{"Proot",     h.teensy_ok},
                                 {"LoRa",      h.lora_ok},
                                 {"Interface", h.knob_ok},
                                 {"Audio",     h.audio_ok}};
-    const Ind right_items[] = {{lcam_lbl,    h.cam_owl_left},
-                                {rcam_lbl,    h.cam_owl_right},
-                                {"Cam 1",     h.cam_usb1},
-                                {"Cam 2",     h.cam_usb2}};
+    const Ind right_items[] = {{lcam_lbl,    h.cam_owl_left,  false},
+                                {rcam_lbl,    h.cam_owl_right, false},
+                                {"Cam 1",     h.cam_usb1,      h.cam_usb1 && !h.cam_usb1_overlay},
+                                {"Cam 2",     h.cam_usb2,      h.cam_usb2 && !h.cam_usb2_overlay}};
     const Ind* items   = right_side ? right_items : left_items;
     const int  n_items = 4;
 
@@ -597,7 +597,9 @@ void HudRenderer::draw_health_side(ImDrawList* dl, const SystemHealth& h,
         const float ix = anchor_x + dir_x * t;
         const float iy = anchor_y + dir_y * t;
 
-        if (items[i].ok) {
+        if (items[i].inactive) {
+            dl->AddCircleFilled({ix, iy}, DOT_R, col_.ind_inactive);
+        } else if (items[i].ok) {
             dl->AddCircleFilled({ix, iy}, DOT_R + 2.f, with_alpha(col_.ind_good, 28));
             dl->AddCircleFilled({ix, iy}, DOT_R,        col_.ind_good);
         } else {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -967,8 +967,22 @@ static std::vector<MenuItem> build_menu(
         slider("Font Size", 1.f, 3.f, 0.25f, "x",
             [&state]{ return state.clock_cfg.font_scale; },
             [&state](float v){ state.clock_cfg.font_scale = v; }),
-        submenu("Time Offset",      std::move(clock_offset_menu)),
-        submenu("Timers and Alarm", std::move(timers_alarm_menu)),
+        submenu("Time Offset", std::move(clock_offset_menu)),
+    };
+
+    std::vector<MenuItem> menu_position_menu = {
+        leaf_sel("Top Left",
+            [menu_sys_pp]{ (*menu_sys_pp)->set_anchor(MenuAnchor::TopLeft); },
+            [menu_sys_pp]{ return (*menu_sys_pp)->anchor() == MenuAnchor::TopLeft; }),
+        leaf_sel("Top Right",
+            [menu_sys_pp]{ (*menu_sys_pp)->set_anchor(MenuAnchor::TopRight); },
+            [menu_sys_pp]{ return (*menu_sys_pp)->anchor() == MenuAnchor::TopRight; }),
+        leaf_sel("Bottom Left",
+            [menu_sys_pp]{ (*menu_sys_pp)->set_anchor(MenuAnchor::BottomLeft); },
+            [menu_sys_pp]{ return (*menu_sys_pp)->anchor() == MenuAnchor::BottomLeft; }),
+        leaf_sel("Bottom Right",
+            [menu_sys_pp]{ (*menu_sys_pp)->set_anchor(MenuAnchor::BottomRight); },
+            [menu_sys_pp]{ return (*menu_sys_pp)->anchor() == MenuAnchor::BottomRight; }),
     };
 
     std::vector<MenuItem> hud_menu = {
@@ -978,9 +992,10 @@ static std::vector<MenuItem> build_menu(
         slider("Text Size", 0.7f, 2.0f, 0.1f, "x",
             [hud_cfg]{ return hud_cfg->text_scale; },
             [hud_cfg](float v){ hud_cfg->text_scale = v; }),
-        submenu("Compass", std::move(compass_menu)),
-        submenu("Clock",   std::move(clock_menu)),
-        submenu("Color",   std::move(color_options_menu)),
+        submenu("Compass",       std::move(compass_menu)),
+        submenu("Clock",         std::move(clock_menu)),
+        submenu("Color",         std::move(color_options_menu)),
+        submenu("Menu Position", std::move(menu_position_menu)),
     };
 
     // ── Vision Assist (post-processing depth cues) ────────────────────────────
@@ -1136,12 +1151,13 @@ static std::vector<MenuItem> build_menu(
     };
 
     return {
-        submenu("Cameras",       std::move(cameras_menu)),
-        submenu("Prototracer",   std::move(prototracer_menu)),
-        submenu("Settings",      std::move(settings_menu)),
-        submenu("Vision Assist", std::move(vision_menu)),
-        leaf("Request Status",   [teensy]{ teensy->request_status(); }),
-        leaf("Close Program",    [&state]{ state.quit = true; }),
+        submenu("Cameras",          std::move(cameras_menu)),
+        submenu("Prototracer",      std::move(prototracer_menu)),
+        submenu("Settings",         std::move(settings_menu)),
+        submenu("Vision Assist",    std::move(vision_menu)),
+        submenu("Timers and Alarm", std::move(timers_alarm_menu)),
+        leaf("Request Status",      [teensy]{ teensy->request_status(); }),
+        leaf("Close Program",       [&state]{ state.quit = true; }),
     };
 }
 
@@ -1617,6 +1633,13 @@ int main(int argc, char* argv[]) {
         menu.set_border_color    (jcolor(jm, "border_color",     menu.border_color()));
         menu.set_border_thickness(jval  (jm, "border_thickness", menu.border_thickness()));
         menu.set_border_enabled  (jval  (jm, "border_enabled",   menu.border_enabled()));
+        {
+            std::string a = jm.value("anchor", "top_left");
+            if      (a == "top_right")    menu.set_anchor(MenuAnchor::TopRight);
+            else if (a == "bottom_left")  menu.set_anchor(MenuAnchor::BottomLeft);
+            else if (a == "bottom_right") menu.set_anchor(MenuAnchor::BottomRight);
+            else                          menu.set_anchor(MenuAnchor::TopLeft);
+        }
     }
 
     menu.set_detent_callback([&knob, &menu](int count) {
@@ -1821,6 +1844,9 @@ int main(int argc, char* argv[]) {
             memcpy(snap.lora_node_colors, state.lora_node_colors,
                    sizeof(state.lora_node_colors));
         }
+        // Overlay-active flags are render-thread-local; inject after mutex release.
+        snap.health.cam_usb1_overlay = pip_cam1_overlay_active;
+        snap.health.cam_usb2_overlay = pip_cam2_overlay_active;
 
         // Inject live AF lens position into the snapshot (atomic read, no lock needed)
         if (cameras.owl_left())
@@ -2023,6 +2049,16 @@ int main(int argc, char* argv[]) {
         jm["border_color"]     = color_to_json(menu.border_color());
         jm["border_thickness"] = menu.border_thickness();
         jm["border_enabled"]   = menu.border_enabled();
+        {
+            const char* a = "top_left";
+            switch (menu.anchor()) {
+                case MenuAnchor::TopRight:    a = "top_right";    break;
+                case MenuAnchor::BottomLeft:  a = "bottom_left";  break;
+                case MenuAnchor::BottomRight: a = "bottom_right"; break;
+                default: break;
+            }
+            jm["anchor"] = a;
+        }
 
         // Persist MPU-9250 calibration biases so they survive a restart
         if (mpu9250.is_running() || cfg.contains("mpu9250")) {

--- a/src/menu/menu_system.cpp
+++ b/src/menu/menu_system.cpp
@@ -271,7 +271,6 @@ const std::string& MenuSystem::current_label() const {
 
 void MenuSystem::draw(int screen_w, int screen_h) {
     if (!open_ || stack_.empty()) return;
-    (void)screen_w;
     s_menu_glow = glow_enabled_;
 
     const auto& items  = stack_.back().items;
@@ -291,8 +290,15 @@ void MenuSystem::draw(int screen_w, int screen_h) {
     const float total_h = pad_y * 2.f
                         + item_h * static_cast<float>(items.size())
                         + extra;
-    const float x = 48.f;
-    const float y = 48.f;   // top-anchored: fixed distance from screen top
+    const float margin = 48.f;
+    float x, y;
+    switch (anchor_) {
+        default:
+        case MenuAnchor::TopLeft:     x = margin;                          y = margin;                          break;
+        case MenuAnchor::TopRight:    x = screen_w - width - margin;       y = margin;                          break;
+        case MenuAnchor::BottomLeft:  x = margin;                          y = screen_h - total_h - margin;     break;
+        case MenuAnchor::BottomRight: x = screen_w - width - margin;       y = screen_h - total_h - margin;     break;
+    }
 
     const bool   filled_row  = (selection_style_ == SelectionStyle::FILLED_ROW);
     const ImU32  COL_SEP     = menu_with_alpha(accent_color_, 45);

--- a/src/menu/menu_system.h
+++ b/src/menu/menu_system.h
@@ -64,6 +64,9 @@ struct MenuItem {
     ColorPickerConfig color;
 };
 
+// ── Menu anchor ───────────────────────────────────────────────────────────────
+enum class MenuAnchor { TopLeft, TopRight, BottomLeft, BottomRight };
+
 // ── Selection style ───────────────────────────────────────────────────────────
 enum class SelectionStyle {
     ACCENT_BAR,  // left colored bar + subtle header fill (default)
@@ -92,14 +95,16 @@ public:
     void set_border_color(ImU32 c)        { border_color_     = c; }
     void set_border_thickness(float t)    { border_thickness_ = t; }
     void set_selection_style(SelectionStyle s) { selection_style_ = s; }
+    void set_anchor(MenuAnchor a)              { anchor_          = a; }
 
     // Runtime style getters — for persisting user changes to config on exit.
-    ImU32 accent_color()     const { return accent_color_;     }
-    ImU32 bg_color()         const { return bg_color_;         }
-    bool  bg_enabled()       const { return bg_enabled_;       }
-    bool  border_enabled()   const { return border_enabled_;   }
-    ImU32 border_color()     const { return border_color_;     }
-    float border_thickness() const { return border_thickness_; }
+    ImU32       accent_color()     const { return accent_color_;     }
+    ImU32       bg_color()         const { return bg_color_;         }
+    bool        bg_enabled()       const { return bg_enabled_;       }
+    bool        border_enabled()   const { return border_enabled_;   }
+    ImU32       border_color()     const { return border_color_;     }
+    float       border_thickness() const { return border_thickness_; }
+    MenuAnchor  anchor()           const { return anchor_;           }
 
     // Drive from knob events
     void navigate(int direction);   // +1 = next, -1 = prev (or adjust value in edit mode)
@@ -154,4 +159,5 @@ private:
     ImU32          border_color_     = IM_COL32(255, 160,  32, 255);
     float          border_thickness_ = 1.5f;
     SelectionStyle selection_style_  = SelectionStyle::ACCENT_BAR;
+    MenuAnchor     anchor_           = MenuAnchor::TopLeft;
 };


### PR DESCRIPTION
…dicators for USB cams

- Timers and Alarm submenu moved from Clock submenu to the main root menu so it is directly accessible without going into HUD > Clock
- Menu Position submenu added under HUD with Top Left/Right, Bottom Left/Right options; MenuAnchor enum + anchor_ field in MenuSystem; draw() uses screen dimensions to position the window at the correct corner; persisted in config
- USB camera indicators now show ind_inactive (gray) when the camera is connected but its PiP overlay is disabled; cam_usb1_overlay/cam_usb2_overlay fields added to SystemHealth and set from render-thread-local flags after the mutex-protected snapshot block

https://claude.ai/code/session_01LH94rdjztXGergQJDGJ3sV