### PR TITLE
USB camera exposure/WB controls and dynamic framerate fix

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -31,14 +31,24 @@
       "width": 1280,
       "height": 720,
       "fps": 30,
-      "brightness": 1.5
+      "brightness": 1.5,
+      "dynamic_framerate": false,
+      "auto_exposure": true,
+      "exposure_time": 157,
+      "auto_wb": true,
+      "wb_temp": 4600
     },
     "usb_cam_2": {
       "device": "/dev/video36",
       "width": 1280,
       "height": 720,
       "fps": 30,
-      "brightness": 1.0
+      "brightness": 1.0,
+      "dynamic_framerate": false,
+      "auto_exposure": true,
+      "exposure_time": 157,
+      "auto_wb": true,
+      "wb_temp": 4600
     }
   },
   "serial": {

--- a/src/camera/camera_manager.cpp
+++ b/src/camera/camera_manager.cpp
@@ -66,6 +66,27 @@ static bool open_v4l2(cv::VideoCapture& cap, const UsbCamConfig& cfg,
     cap.set(cv::CAP_PROP_FRAME_HEIGHT, cfg.height);
     cap.set(cv::CAP_PROP_FPS,          cfg.fps);
     cap.set(cv::CAP_PROP_AUTO_EXPOSURE, 0.75);  // request auto-exposure (driver best-effort)
+
+    // Apply UVC controls not exposed by OpenCV via direct V4L2 ioctl.
+    {
+        int fd = open(cfg.device.c_str(), O_RDWR);
+        if (fd >= 0) {
+            auto set_ctrl = [&](uint32_t id, int32_t val) {
+                v4l2_control c{}; c.id = id; c.value = val;
+                ioctl(fd, VIDIOC_S_CTRL, &c);
+            };
+            // Disable dynamic framerate throttle (keeps fps at configured rate).
+            set_ctrl(V4L2_CID_EXPOSURE_DYNAMIC_FRAMERATE, cfg.dynamic_framerate ? 1 : 0);
+            set_ctrl(V4L2_CID_EXPOSURE_AUTO, cfg.auto_exposure ? 3 : 1);  // 3=AP, 1=Manual
+            if (!cfg.auto_exposure)
+                set_ctrl(V4L2_CID_EXPOSURE_ABSOLUTE, cfg.exposure_time);
+            set_ctrl(V4L2_CID_AUTO_WHITE_BALANCE, cfg.auto_wb ? 1 : 0);
+            if (!cfg.auto_wb)
+                set_ctrl(V4L2_CID_WHITE_BALANCE_TEMPERATURE, cfg.wb_temp);
+            close(fd);
+        }
+    }
+
     int aw = static_cast<int>(cap.get(cv::CAP_PROP_FRAME_WIDTH));
     int ah = static_cast<int>(cap.get(cv::CAP_PROP_FRAME_HEIGHT));
     int af = static_cast<int>(cap.get(cv::CAP_PROP_FPS));
@@ -400,6 +421,16 @@ bool CameraManager::scan_usb(cv::VideoCapture& cap, std::atomic<bool>& ok,
 
 bool CameraManager::scan_usb1() { return scan_usb(usb_cap1_, usb1_ok_, usb1_cfg_); }
 bool CameraManager::scan_usb2() { return scan_usb(usb_cap2_, usb2_ok_, usb2_cfg_); }
+
+static void v4l2_set_ctrl(const std::string& dev, uint32_t id, int32_t val) {
+    int fd = open(dev.c_str(), O_RDWR);
+    if (fd < 0) return;
+    v4l2_control c{}; c.id = id; c.value = val;
+    ioctl(fd, VIDIOC_S_CTRL, &c);
+    close(fd);
+}
+void CameraManager::set_usb1_ctrl(uint32_t id, int32_t val) { v4l2_set_ctrl(usb1_cfg_.device, id, val); }
+void CameraManager::set_usb2_ctrl(uint32_t id, int32_t val) { v4l2_set_ctrl(usb2_cfg_.device, id, val); }
 
 bool CameraManager::get_usb1(GLuint& out) {
     std::lock_guard<std::mutex> lk(usb1_slot_.mtx);

--- a/src/camera/camera_manager.h
+++ b/src/camera/camera_manager.h
@@ -24,10 +24,17 @@ struct CamConfig {
 
 struct UsbCamConfig {
     std::string device;
-    int   width      = 1280;
-    int   height     = 720;
-    int   fps        = 30;
-    float brightness = 1.0f;  // software multiplier: 1.0=normal, 2.0=double, 0.5=half
+    int   width             = 1280;
+    int   height            = 720;
+    int   fps               = 30;
+    float brightness        = 1.0f;  // software multiplier: 1.0=normal, 2.0=double, 0.5=half
+    // Exposure / framerate
+    bool  dynamic_framerate = false;  // false = disable fps throttle from long exposures
+    bool  auto_exposure     = true;   // false = manual exposure
+    int   exposure_time     = 157;    // 1-5000 (100µs units), used when auto_exposure=false
+    // White balance
+    bool  auto_wb           = true;   // false = manual white balance
+    int   wb_temp           = 4600;   // 2800-6500 K, used when auto_wb=false
 };
 
 // CameraManager owns:
@@ -109,6 +116,16 @@ public:
     void  set_usb2_brightness(float v) { usb2_brightness_ = v; }
     float usb1_brightness()      const { return usb1_brightness_.load(); }
     float usb2_brightness()      const { return usb2_brightness_.load(); }
+
+    // ── USB V4L2 control (applies ioctl live; camera may briefly drop frames) ─
+    void set_usb1_ctrl(uint32_t id, int32_t value);
+    void set_usb2_ctrl(uint32_t id, int32_t value);
+
+    // ── USB config access (for menu read-back and config-save persistence) ────
+    void                update_usb1_cfg(const UsbCamConfig& c) { usb1_cfg_ = c; }
+    void                update_usb2_cfg(const UsbCamConfig& c) { usb2_cfg_ = c; }
+    const UsbCamConfig& usb1_cfg() const { return usb1_cfg_; }
+    const UsbCamConfig& usb2_cfg() const { return usb2_cfg_; }
 
 private:
     void usb_capture_thread();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,6 +9,7 @@
 
 #include <GLFW/glfw3.h>
 #include <GLES2/gl2.h>
+#include <linux/videodev2.h>
 #include <imgui.h>
 #include <nlohmann/json.hpp>
 
@@ -423,6 +424,48 @@ static std::vector<MenuItem> build_menu(
         leaf("200%", [cameras]{ if (cameras) cameras->set_usb1_brightness(2.0f); }),
         leaf("300%", [cameras]{ if (cameras) cameras->set_usb1_brightness(3.0f); }),
     };
+    std::vector<MenuItem> usb1_exposure_menu = {
+        toggle("Auto Exposure",
+            [cameras]{ return !cameras || cameras->usb1_cfg().auto_exposure; },
+            [cameras](bool v){
+                if (!cameras) return;
+                UsbCamConfig c = cameras->usb1_cfg(); c.auto_exposure = v;
+                cameras->update_usb1_cfg(c);
+                cameras->set_usb1_ctrl(V4L2_CID_EXPOSURE_AUTO, v ? 3 : 1);
+            }),
+        slider("Exposure Time", 1.f, 5000.f, 10.f, "",
+            [cameras]{ return cameras ? (float)cameras->usb1_cfg().exposure_time : 157.f; },
+            [cameras](float v){
+                if (!cameras) return;
+                UsbCamConfig c = cameras->usb1_cfg(); c.exposure_time = (int)v;
+                cameras->update_usb1_cfg(c);
+                cameras->set_usb1_ctrl(V4L2_CID_EXPOSURE_ABSOLUTE, (int)v);
+            }),
+        toggle("Auto White Balance",
+            [cameras]{ return !cameras || cameras->usb1_cfg().auto_wb; },
+            [cameras](bool v){
+                if (!cameras) return;
+                UsbCamConfig c = cameras->usb1_cfg(); c.auto_wb = v;
+                cameras->update_usb1_cfg(c);
+                cameras->set_usb1_ctrl(V4L2_CID_AUTO_WHITE_BALANCE, v ? 1 : 0);
+            }),
+        slider("WB Temperature", 2800.f, 6500.f, 100.f, "K",
+            [cameras]{ return cameras ? (float)cameras->usb1_cfg().wb_temp : 4600.f; },
+            [cameras](float v){
+                if (!cameras) return;
+                UsbCamConfig c = cameras->usb1_cfg(); c.wb_temp = (int)v;
+                cameras->update_usb1_cfg(c);
+                cameras->set_usb1_ctrl(V4L2_CID_WHITE_BALANCE_TEMPERATURE, (int)v);
+            }),
+        toggle("Dynamic Framerate",
+            [cameras]{ return cameras && cameras->usb1_cfg().dynamic_framerate; },
+            [cameras](bool v){
+                if (!cameras) return;
+                UsbCamConfig c = cameras->usb1_cfg(); c.dynamic_framerate = v;
+                cameras->update_usb1_cfg(c);
+                cameras->set_usb1_ctrl(V4L2_CID_EXPOSURE_DYNAMIC_FRAMERATE, v ? 1 : 0);
+            }),
+    };
     std::vector<MenuItem> usb_cam1_menu = {
         toggle("Open Stream",
             [cameras]{ return cameras && cameras->usb1_ok(); },
@@ -440,6 +483,7 @@ static std::vector<MenuItem> build_menu(
             }),
         submenu("Overlay",     std::move(cam1_overlay_menu)),
         submenu("Brightness",  std::move(usb1_brightness_menu)),
+        submenu("Exposure",    std::move(usb1_exposure_menu)),
         leaf("Scan for Camera", [cameras, &state]{
             if (cameras) {
                 bool ok = cameras->scan_usb1();
@@ -463,6 +507,48 @@ static std::vector<MenuItem> build_menu(
         leaf("200%", [cameras]{ if (cameras) cameras->set_usb2_brightness(2.0f); }),
         leaf("300%", [cameras]{ if (cameras) cameras->set_usb2_brightness(3.0f); }),
     };
+    std::vector<MenuItem> usb2_exposure_menu = {
+        toggle("Auto Exposure",
+            [cameras]{ return !cameras || cameras->usb2_cfg().auto_exposure; },
+            [cameras](bool v){
+                if (!cameras) return;
+                UsbCamConfig c = cameras->usb2_cfg(); c.auto_exposure = v;
+                cameras->update_usb2_cfg(c);
+                cameras->set_usb2_ctrl(V4L2_CID_EXPOSURE_AUTO, v ? 3 : 1);
+            }),
+        slider("Exposure Time", 1.f, 5000.f, 10.f, "",
+            [cameras]{ return cameras ? (float)cameras->usb2_cfg().exposure_time : 157.f; },
+            [cameras](float v){
+                if (!cameras) return;
+                UsbCamConfig c = cameras->usb2_cfg(); c.exposure_time = (int)v;
+                cameras->update_usb2_cfg(c);
+                cameras->set_usb2_ctrl(V4L2_CID_EXPOSURE_ABSOLUTE, (int)v);
+            }),
+        toggle("Auto White Balance",
+            [cameras]{ return !cameras || cameras->usb2_cfg().auto_wb; },
+            [cameras](bool v){
+                if (!cameras) return;
+                UsbCamConfig c = cameras->usb2_cfg(); c.auto_wb = v;
+                cameras->update_usb2_cfg(c);
+                cameras->set_usb2_ctrl(V4L2_CID_AUTO_WHITE_BALANCE, v ? 1 : 0);
+            }),
+        slider("WB Temperature", 2800.f, 6500.f, 100.f, "K",
+            [cameras]{ return cameras ? (float)cameras->usb2_cfg().wb_temp : 4600.f; },
+            [cameras](float v){
+                if (!cameras) return;
+                UsbCamConfig c = cameras->usb2_cfg(); c.wb_temp = (int)v;
+                cameras->update_usb2_cfg(c);
+                cameras->set_usb2_ctrl(V4L2_CID_WHITE_BALANCE_TEMPERATURE, (int)v);
+            }),
+        toggle("Dynamic Framerate",
+            [cameras]{ return cameras && cameras->usb2_cfg().dynamic_framerate; },
+            [cameras](bool v){
+                if (!cameras) return;
+                UsbCamConfig c = cameras->usb2_cfg(); c.dynamic_framerate = v;
+                cameras->update_usb2_cfg(c);
+                cameras->set_usb2_ctrl(V4L2_CID_EXPOSURE_DYNAMIC_FRAMERATE, v ? 1 : 0);
+            }),
+    };
     std::vector<MenuItem> usb_cam2_menu = {
         toggle("Open Stream",
             [cameras]{ return cameras && cameras->usb2_ok(); },
@@ -480,6 +566,7 @@ static std::vector<MenuItem> build_menu(
             }),
         submenu("Overlay",    std::move(cam2_overlay_menu)),
         submenu("Brightness", std::move(usb2_brightness_menu)),
+        submenu("Exposure",   std::move(usb2_exposure_menu)),
         leaf("Scan for Camera", [cameras, &state]{
             if (cameras) {
                 bool ok = cameras->scan_usb2();
@@ -1280,18 +1367,30 @@ int main(int argc, char* argv[]) {
 
     UsbCamConfig usb1_cfg, usb2_cfg;
     if (jcam.contains("usb_cam_1")) {
-        usb1_cfg.device     = jcam["usb_cam_1"].value("device",     "/dev/video2");
-        usb1_cfg.width      = jcam["usb_cam_1"].value("width",       1280);
-        usb1_cfg.height     = jcam["usb_cam_1"].value("height",       720);
-        usb1_cfg.fps        = jcam["usb_cam_1"].value("fps",           30);
-        usb1_cfg.brightness = jcam["usb_cam_1"].value("brightness",   1.0f);
+        auto& j1 = jcam["usb_cam_1"];
+        usb1_cfg.device             = j1.value("device",             "/dev/video2");
+        usb1_cfg.width              = j1.value("width",               1280);
+        usb1_cfg.height             = j1.value("height",               720);
+        usb1_cfg.fps                = j1.value("fps",                   30);
+        usb1_cfg.brightness         = j1.value("brightness",           1.0f);
+        usb1_cfg.dynamic_framerate  = j1.value("dynamic_framerate",    false);
+        usb1_cfg.auto_exposure      = j1.value("auto_exposure",        true);
+        usb1_cfg.exposure_time      = j1.value("exposure_time",        157);
+        usb1_cfg.auto_wb            = j1.value("auto_wb",              true);
+        usb1_cfg.wb_temp            = j1.value("wb_temp",              4600);
     }
     if (jcam.contains("usb_cam_2")) {
-        usb2_cfg.device     = jcam["usb_cam_2"].value("device",     "/dev/video3");
-        usb2_cfg.width      = jcam["usb_cam_2"].value("width",       1280);
-        usb2_cfg.height     = jcam["usb_cam_2"].value("height",       720);
-        usb2_cfg.fps        = jcam["usb_cam_2"].value("fps",           30);
-        usb2_cfg.brightness = jcam["usb_cam_2"].value("brightness",   1.0f);
+        auto& j2 = jcam["usb_cam_2"];
+        usb2_cfg.device             = j2.value("device",             "/dev/video3");
+        usb2_cfg.width              = j2.value("width",               1280);
+        usb2_cfg.height             = j2.value("height",               720);
+        usb2_cfg.fps                = j2.value("fps",                   30);
+        usb2_cfg.brightness         = j2.value("brightness",           1.0f);
+        usb2_cfg.dynamic_framerate  = j2.value("dynamic_framerate",    false);
+        usb2_cfg.auto_exposure      = j2.value("auto_exposure",        true);
+        usb2_cfg.exposure_time      = j2.value("exposure_time",        157);
+        usb2_cfg.auto_wb            = j2.value("auto_wb",              true);
+        usb2_cfg.wb_temp            = j2.value("wb_temp",              4600);
     }
 
     HudConfig hud_cfg;
@@ -2074,8 +2173,18 @@ int main(int argc, char* argv[]) {
         jpp["motion_update_rate"] = state.pp_cfg.motion_update_rate;
         jpp["motion_color"]       = color_to_json(state.pp_cfg.motion_color);
 
-        cfg["cameras"]["usb_cam_1"]["brightness"] = cameras.usb1_brightness();
-        cfg["cameras"]["usb_cam_2"]["brightness"] = cameras.usb2_brightness();
+        cfg["cameras"]["usb_cam_1"]["brightness"]        = cameras.usb1_brightness();
+        cfg["cameras"]["usb_cam_1"]["dynamic_framerate"] = cameras.usb1_cfg().dynamic_framerate;
+        cfg["cameras"]["usb_cam_1"]["auto_exposure"]     = cameras.usb1_cfg().auto_exposure;
+        cfg["cameras"]["usb_cam_1"]["exposure_time"]     = cameras.usb1_cfg().exposure_time;
+        cfg["cameras"]["usb_cam_1"]["auto_wb"]           = cameras.usb1_cfg().auto_wb;
+        cfg["cameras"]["usb_cam_1"]["wb_temp"]           = cameras.usb1_cfg().wb_temp;
+        cfg["cameras"]["usb_cam_2"]["brightness"]        = cameras.usb2_brightness();
+        cfg["cameras"]["usb_cam_2"]["dynamic_framerate"] = cameras.usb2_cfg().dynamic_framerate;
+        cfg["cameras"]["usb_cam_2"]["auto_exposure"]     = cameras.usb2_cfg().auto_exposure;
+        cfg["cameras"]["usb_cam_2"]["exposure_time"]     = cameras.usb2_cfg().exposure_time;
+        cfg["cameras"]["usb_cam_2"]["auto_wb"]           = cameras.usb2_cfg().auto_wb;
+        cfg["cameras"]["usb_cam_2"]["wb_temp"]           = cameras.usb2_cfg().wb_temp;
 
         auto& jm = cfg["menu_style"];
         jm["accent_color"]     = color_to_json(menu.accent_color());


### PR DESCRIPTION
- Disable exposure_dynamic_framerate by default: prevents UVC driver from throttling fps to accommodate long exposures (was causing 30fps→25fps)
- Apply all exposure/WB controls via direct V4L2 ioctl at camera open time (OpenCV does not expose these UVC controls)
- Add live-control methods set_usb1/2_ctrl(); menu items apply ioctls immediately without requiring stream restart
- New Exposure submenu under each USB camera: Auto Exposure toggle (aperture priority vs manual) Exposure Time slider (1-5000 in 100µs units) Auto White Balance toggle WB Temperature slider (2800-6500 K) Dynamic Framerate toggle
- All settings persist in config.json and are restored on startup

https://claude.ai/code/session_01LH94rdjztXGergQJDGJ3sV