### PR TITLE
Fix: use V4L2_CID_EXPOSURE_AUTO_PRIORITY (kernel name for dynamic fra…

### DIFF
--- a/src/camera/camera_manager.cpp
+++ b/src/camera/camera_manager.cpp
@@ -76,7 +76,7 @@ static bool open_v4l2(cv::VideoCapture& cap, const UsbCamConfig& cfg,
                 ioctl(fd, VIDIOC_S_CTRL, &c);
             };
             // Disable dynamic framerate throttle (keeps fps at configured rate).
-            set_ctrl(V4L2_CID_EXPOSURE_DYNAMIC_FRAMERATE, cfg.dynamic_framerate ? 1 : 0);
+            set_ctrl(V4L2_CID_EXPOSURE_AUTO_PRIORITY, cfg.dynamic_framerate ? 1 : 0);
             set_ctrl(V4L2_CID_EXPOSURE_AUTO, cfg.auto_exposure ? 3 : 1);  // 3=AP, 1=Manual
             if (!cfg.auto_exposure)
                 set_ctrl(V4L2_CID_EXPOSURE_ABSOLUTE, cfg.exposure_time);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -463,7 +463,7 @@ static std::vector<MenuItem> build_menu(
                 if (!cameras) return;
                 UsbCamConfig c = cameras->usb1_cfg(); c.dynamic_framerate = v;
                 cameras->update_usb1_cfg(c);
-                cameras->set_usb1_ctrl(V4L2_CID_EXPOSURE_DYNAMIC_FRAMERATE, v ? 1 : 0);
+                cameras->set_usb1_ctrl(V4L2_CID_EXPOSURE_AUTO_PRIORITY, v ? 1 : 0);
             }),
     };
     std::vector<MenuItem> usb_cam1_menu = {
@@ -546,7 +546,7 @@ static std::vector<MenuItem> build_menu(
                 if (!cameras) return;
                 UsbCamConfig c = cameras->usb2_cfg(); c.dynamic_framerate = v;
                 cameras->update_usb2_cfg(c);
-                cameras->set_usb2_ctrl(V4L2_CID_EXPOSURE_DYNAMIC_FRAMERATE, v ? 1 : 0);
+                cameras->set_usb2_ctrl(V4L2_CID_EXPOSURE_AUTO_PRIORITY, v ? 1 : 0);
             }),
     };
     std::vector<MenuItem> usb_cam2_menu = {


### PR DESCRIPTION
…merate ctrl)

V4L2_CID_EXPOSURE_DYNAMIC_FRAMERATE is the v4l2-ctl display name; the kernel header defines it as V4L2_CID_EXPOSURE_AUTO_PRIORITY

https://claude.ai/code/session_01LH94rdjztXGergQJDGJ3sV