### PR TITLE
Vision assistance enhancements: USB cam controls, PiP polish, menu restructure

### DIFF
--- a/src/hud/hud_renderer.cpp
+++ b/src/hud/hud_renderer.cpp
@@ -247,7 +247,7 @@ static ImVec2 overlay_origin(const OverlayConfig& cfg,
     const float bottom_y = sh - ov_h - bottom_margin - kEdge;
     switch (cfg.anchor) {
         case OverlayConfig::Anchor::TOP_LEFT:      return { kEdge,                  kEdge    };
-        case OverlayConfig::Anchor::TOP_CENTER:    return { (sw - ov_w) * 0.5f,     kEdge    };
+        case OverlayConfig::Anchor::TOP_CENTER:    return { (sw - ov_w) * 0.5f,     kEdge + bottom_margin };
         case OverlayConfig::Anchor::TOP_RIGHT:     return { sw - ov_w - kEdge,      kEdge    };
         case OverlayConfig::Anchor::BOTTOM_LEFT:   return { kEdge,                  bottom_y };
         case OverlayConfig::Anchor::BOTTOM_CENTER: return { (sw - ov_w) * 0.5f,     bottom_y };
@@ -382,7 +382,7 @@ void HudRenderer::draw_pip(unsigned int tex, const char* label,
     }
 
     // 6. Chamfered border outline on top
-    dl->AddPolyline(pts, n_pts, col_.primary, ImDrawFlags_Closed, 2.f);
+    dl->AddPolyline(pts, n_pts, col_.glow_base, ImDrawFlags_Closed, 2.f);
 
     ImGui::End();
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -702,7 +702,6 @@ static std::vector<MenuItem> build_menu(
         slider("Tape Height", 50.f, 120.f, 5.f, "",
             [hud_cfg]{ return static_cast<float>(hud_cfg->compass_height); },
             [hud_cfg](float v){ hud_cfg->compass_height = static_cast<int>(v); }),
-        submenu("Color", std::move(compass_bg_color_menu)),
     };
 
     std::vector<MenuItem> compass_tick_color_menu = make_color_items({
@@ -855,6 +854,7 @@ static std::vector<MenuItem> build_menu(
         if (*menu_sys_pp) {
             (*menu_sys_pp)->set_accent_color(menu_accent);
             (*menu_sys_pp)->set_border_enabled(border);
+            (*menu_sys_pp)->set_border_color(menu_accent);
             (*menu_sys_pp)->set_selection_style(style);
         }
     };
@@ -864,7 +864,7 @@ static std::vector<MenuItem> build_menu(
             apply_theme(IM_COL32(255,255,255,255), IM_COL32(255,255,255,255),
                         IM_COL32(255,255,255,255),
                         IM_COL32(255,255,255,255), IM_COL32(255,255,255,180),
-                        false, SelectionStyle::FILLED_ROW,
+                        true, SelectionStyle::FILLED_ROW,
                         IM_COL32(255,255,255,255));
         }),
         leaf("Solar", [apply_theme]{
@@ -920,11 +920,6 @@ static std::vector<MenuItem> build_menu(
 
     themes_menu.push_back(submenu("Effects", std::move(effects_menu)));
 
-    std::vector<MenuItem> hud_submenu = {
-        submenu("Borders & Lines",    std::move(borders_lines_menu)),
-        submenu("Themes and Effects", std::move(themes_menu)),
-    };
-
     // Backgrounds
     std::vector<MenuItem> menu_bg_color_menu = make_color_items({
         { "Dark",   IM_COL32( 10,  15,  20, 225) },
@@ -947,13 +942,16 @@ static std::vector<MenuItem> build_menu(
     });
 
     std::vector<MenuItem> backgrounds_menu = {
-        toggle("HUD Background",
+        toggle("Indicator Background",
             [hud_cfg]{ return hud_cfg->indicator_bg_enabled; },
-            [hud_cfg, &state](bool v){
-                hud_cfg->indicator_bg_enabled = v;
+            [hud_cfg](bool v){ hud_cfg->indicator_bg_enabled = v; }),
+        toggle("Compass Background",
+            [&state]{ return state.compass_bg_enabled; },
+            [&state](bool v){
                 std::lock_guard<std::mutex> lk(state.mtx);
                 state.compass_bg_enabled = v;
             }),
+        submenu("Compass Background Color", std::move(compass_bg_color_menu)),
         toggle("Menu Background",
             [menu_sys_pp]{ return *menu_sys_pp && (*menu_sys_pp)->bg_enabled(); },
             [menu_sys_pp](bool v){ if (*menu_sys_pp) (*menu_sys_pp)->set_bg_enabled(v); }),
@@ -1023,7 +1021,8 @@ static std::vector<MenuItem> build_menu(
     };
 
     std::vector<MenuItem> color_options_menu = {
-        submenu("HUD",                std::move(hud_submenu)),
+        submenu("Borders & Lines",    std::move(borders_lines_menu)),
+        submenu("Themes and Effects", std::move(themes_menu)),
         submenu("Compass Tick Color", std::move(compass_tick_color_menu)),
         submenu("Compass Glow Color", std::move(compass_glow_color_menu)),
         submenu("Text Color",         std::move(text_color_menu)),


### PR DESCRIPTION
## Summary

- **USB camera V4L2 controls**: Auto exposure, manual exposure time, auto/manual white balance, WB temperature, and dynamic framerate can now be set per USB camera via the HUD menu and persist in config. Uses direct `VIDIOC_S_CTRL` ioctls for controls OpenCV doesn't expose (including `V4L2_CID_EXPOSURE_AUTO_PRIORITY` to fix the Arducam HQ running at 25fps instead of 30fps).
- **PiP overlay position**: TOP_CENTER anchor now places the pip below the compass tape (`kEdge + bottom_margin`) instead of at the top screen edge.
- **PiP border color**: Chamfered border now uses `col_.glow_base` (current theme color) instead of the fixed `col_.primary`.
- **Halo theme**: Border now enabled; border color set to white to match the palette. `apply_theme` also calls `set_border_color(menu_accent)` so all theme switches sync the border color.
- **Color menu restructure**: "Borders & Lines" and "Themes and Effects" promoted directly into the Color menu (removed the intermediate "HUD" wrapper submenu).
- **Backgrounds submenu**: "HUD Background" toggle split into separate "Indicator Background" and "Compass Background" toggles; "Compass Background Color" picker moved here from Compass > Background Options.

## Test plan

- [ ] Top-center PiP renders below the compass tape, not overlapping it
- [ ] PiP border color changes when switching themes
- [ ] Halo theme shows a white border around the menu
- [ ] Color menu shows "Borders & Lines" and "Themes and Effects" at top level (no "HUD" submenu)
- [ ] Backgrounds submenu has separate "Indicator Background" and "Compass Background" toggles that control independently
- [ ] Compass Background Color picker appears in Backgrounds submenu
- [ ] USB cam Exposure submenu: toggling Auto Exposure off and adjusting Exposure Time changes brightness; WB Temperature slider changes color cast
- [ ] `v4l2-ctl -d /dev/video17 -C exposure_dynamic_framerate` reads `0` after start
- [ ] Config saves and restores USB cam exposure/WB settings across restarts

https://claude.ai/code/session_01LH94rdjztXGergQJDGJ3sV

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH94rdjztXGergQJDGJ3sV)_