### PR TITLE
Halo as default theme; border size 5; bold text when background off

### DIFF
--- a/src/hud/hud_renderer.cpp
+++ b/src/hud/hud_renderer.cpp
@@ -607,13 +607,16 @@ void HudRenderer::draw_health_side(ImDrawList* dl, const SystemHealth& h,
         }
 
         const char* lbl = items[i].label;
+        const bool  bold = !cfg_.indicator_bg_enabled;
         if (right_side) {
-            hud_glow_text(dl, {ix + DOT_R + 6.f, iy - 7.f}, lbl, items[i].ok,
-                          col_.text_fill, col_.text_fill);
+            const ImVec2 lp = {ix + DOT_R + 6.f, iy - 7.f};
+            if (bold) dl->AddText({lp.x + 0.7f, lp.y}, items[i].ok ? col_.text_fill : with_alpha(col_.text_fill, 160), lbl);
+            hud_glow_text(dl, lp, lbl, items[i].ok, col_.text_fill, col_.text_fill);
         } else {
             float tw = ImGui::CalcTextSize(lbl).x;
-            hud_glow_text(dl, {ix - DOT_R - 6.f - tw, iy - 7.f}, lbl, items[i].ok,
-                          col_.text_fill, col_.text_fill);
+            const ImVec2 lp = {ix - DOT_R - 6.f - tw, iy - 7.f};
+            if (bold) dl->AddText({lp.x + 0.7f, lp.y}, items[i].ok ? col_.text_fill : with_alpha(col_.text_fill, 160), lbl);
+            hud_glow_text(dl, lp, lbl, items[i].ok, col_.text_fill, col_.text_fill);
         }
     }
     if (font_mono_) ImGui::PopFont();

--- a/src/hud/hud_renderer.h
+++ b/src/hud/hud_renderer.h
@@ -33,14 +33,14 @@ struct HudColors {
     ImU32 orange_glow = IM_COL32(255, 160,  32,  70);
     ImU32 orange_dim  = IM_COL32(255, 160,  32,  28);
     // Runtime-configurable HUD palette (full RGB, alpha=255; glow alphas derived at draw time)
-    ImU32 glow_base       = IM_COL32(255, 160,  32, 255); // line/outline base color
-    ImU32 glow_color      = IM_COL32(255, 160,  32, 255); // text glow halo color (independent)
+    ImU32 glow_base       = IM_COL32(255, 255, 255, 255); // line/outline base color (Halo default)
+    ImU32 glow_color      = IM_COL32(255, 255, 255, 255); // text glow halo color (Halo default)
     ImU32 text_fill       = IM_COL32(255, 255, 255, 255); // main text fill
     ImU32 ind_good        = IM_COL32(255, 160,  32, 255); // indicator OK dot
     ImU32 ind_inactive    = IM_COL32(120, 120, 120, 255); // indicator inactive/disconnected dot
     ImU32 ind_fail        = IM_COL32(255,  60,  60, 255); // indicator failure dot
-    ImU32 compass_tick    = IM_COL32(255, 160,  32, 255); // compass major tick
-    ImU32 compass_glow    = IM_COL32(255, 160,  32, 255); // compass glow (alphas derived at draw time)
+    ImU32 compass_tick    = IM_COL32(255, 255, 255, 255); // compass major tick (Halo default)
+    ImU32 compass_glow    = IM_COL32(255, 255, 255, 180); // compass glow (Halo default)
     ImU32 compass_bg_color= IM_COL32(  8,  12,  18, 255); // compass bg RGB (alpha from opacity cfg)
 };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -858,7 +858,7 @@ static std::vector<MenuItem> build_menu(
     auto apply_theme = [hud_col, menu_sys_pp](
             ImU32 glow, ImU32 glow_col, ImU32 text,
             ImU32 tick, ImU32 tick_glow,
-            bool border, SelectionStyle style, ImU32 menu_accent) {
+            bool border, float thickness, SelectionStyle style, ImU32 menu_accent) {
         hud_col->glow_base    = glow;
         hud_col->glow_color   = glow_col;
         hud_col->text_fill    = text;
@@ -868,6 +868,7 @@ static std::vector<MenuItem> build_menu(
             (*menu_sys_pp)->set_accent_color(menu_accent);
             (*menu_sys_pp)->set_border_enabled(border);
             (*menu_sys_pp)->set_border_color(menu_accent);
+            (*menu_sys_pp)->set_border_thickness(thickness);
             (*menu_sys_pp)->set_selection_style(style);
         }
     };
@@ -877,28 +878,28 @@ static std::vector<MenuItem> build_menu(
             apply_theme(IM_COL32(255,255,255,255), IM_COL32(255,255,255,255),
                         IM_COL32(255,255,255,255),
                         IM_COL32(255,255,255,255), IM_COL32(255,255,255,180),
-                        true, SelectionStyle::FILLED_ROW,
+                        true, 5.f, SelectionStyle::FILLED_ROW,
                         IM_COL32(255,255,255,255));
         }),
         leaf("Solar", [apply_theme]{
             apply_theme(IM_COL32(255,160, 32,255), IM_COL32(255,160, 32,255),
                         IM_COL32(255,255,255,255),
                         IM_COL32(255,160, 32,255), IM_COL32(255,160, 32,255),
-                        true, SelectionStyle::ACCENT_BAR,
+                        true, 1.5f, SelectionStyle::ACCENT_BAR,
                         IM_COL32(255,160, 32,255));
         }),
         leaf("Fallout", [apply_theme]{
             apply_theme(IM_COL32(  0,200, 50,255), IM_COL32(  0,200, 50,255),
                         IM_COL32(  0,255, 80,255),
                         IM_COL32(  0,200, 50,255), IM_COL32(  0,200, 50,255),
-                        true, SelectionStyle::ACCENT_BAR,
+                        true, 1.5f, SelectionStyle::ACCENT_BAR,
                         IM_COL32(  0,200, 50,255));
         }),
         leaf("Space", [apply_theme]{
             apply_theme(IM_COL32( 80,100,255,255), IM_COL32( 80,100,255,255),
                         IM_COL32(200,220,255,255),
                         IM_COL32( 80,100,255,255), IM_COL32( 80,100,255,255),
-                        true, SelectionStyle::ACCENT_BAR,
+                        true, 1.5f, SelectionStyle::ACCENT_BAR,
                         IM_COL32( 80,100,255,255));
         }),
     };
@@ -1751,6 +1752,11 @@ int main(int argc, char* argv[]) {
         menu.set_border_thickness(jval  (jm, "border_thickness", menu.border_thickness()));
         menu.set_border_enabled  (jval  (jm, "border_enabled",   menu.border_enabled()));
         {
+            std::string ss = jm.value("selection_style", "filled_row");
+            menu.set_selection_style(ss == "accent_bar"
+                ? SelectionStyle::ACCENT_BAR : SelectionStyle::FILLED_ROW);
+        }
+        {
             std::string a = jm.value("anchor", "top_left");
             if      (a == "top_right")    menu.set_anchor(MenuAnchor::TopRight);
             else if (a == "bottom_left")  menu.set_anchor(MenuAnchor::BottomLeft);
@@ -2209,8 +2215,10 @@ int main(int argc, char* argv[]) {
         jm["bg_color"]         = color_to_json(menu.bg_color());
         jm["bg_enabled"]       = menu.bg_enabled();
         jm["border_color"]     = color_to_json(menu.border_color());
-        jm["border_thickness"] = menu.border_thickness();
-        jm["border_enabled"]   = menu.border_enabled();
+        jm["border_thickness"]  = menu.border_thickness();
+        jm["border_enabled"]    = menu.border_enabled();
+        jm["selection_style"]   = (menu.selection_style() == SelectionStyle::FILLED_ROW)
+                                  ? "filled_row" : "accent_bar";
         {
             const char* a = "top_left";
             switch (menu.anchor()) {

--- a/src/menu/menu_system.cpp
+++ b/src/menu/menu_system.cpp
@@ -368,12 +368,18 @@ void MenuSystem::draw(int screen_w, int screen_h) {
 
     // Text drawing helper: FILLED_ROW selected rows use bold-style black text,
     // all others use the standard glow system.
+    const bool bold_text = !bg_enabled_;
     auto draw_item_text = [&](ImVec2 pos, const char* text, bool sel) {
         if (filled_row && sel) {
             dl->AddText({pos.x - 0.6f, pos.y}, IM_COL32(0, 0, 0, 255), text);
             dl->AddText({pos.x + 0.6f, pos.y}, IM_COL32(0, 0, 0, 255), text);
             dl->AddText(pos,                   IM_COL32(0, 0, 0, 255), text);
         } else {
+            if (bold_text) {
+                // Extra shifted pass simulates bold when there is no bg for contrast
+                const ImU32 fill = sel ? IM_COL32(255,255,255,255) : IM_COL32(255,255,255,160);
+                dl->AddText({pos.x + 0.7f, pos.y}, fill, text);
+            }
             draw_glow_text(dl, pos, text, sel, accent_color_);
         }
     };

--- a/src/menu/menu_system.h
+++ b/src/menu/menu_system.h
@@ -98,13 +98,14 @@ public:
     void set_anchor(MenuAnchor a)              { anchor_          = a; }
 
     // Runtime style getters — for persisting user changes to config on exit.
-    ImU32       accent_color()     const { return accent_color_;     }
-    ImU32       bg_color()         const { return bg_color_;         }
-    bool        bg_enabled()       const { return bg_enabled_;       }
-    bool        border_enabled()   const { return border_enabled_;   }
-    ImU32       border_color()     const { return border_color_;     }
-    float       border_thickness() const { return border_thickness_; }
-    MenuAnchor  anchor()           const { return anchor_;           }
+    ImU32          accent_color()     const { return accent_color_;     }
+    ImU32          bg_color()         const { return bg_color_;         }
+    bool           bg_enabled()       const { return bg_enabled_;       }
+    bool           border_enabled()   const { return border_enabled_;   }
+    ImU32          border_color()     const { return border_color_;     }
+    float          border_thickness() const { return border_thickness_; }
+    SelectionStyle selection_style()  const { return selection_style_;  }
+    MenuAnchor     anchor()           const { return anchor_;           }
 
     // Drive from knob events
     void navigate(int direction);   // +1 = next, -1 = prev (or adjust value in edit mode)
@@ -151,13 +152,13 @@ private:
     DetentCallback         detent_cb_;
 
     // Runtime style
-    ImU32          accent_color_     = IM_COL32(255, 160,  32, 255);
+    ImU32          accent_color_     = IM_COL32(255, 255, 255, 255);  // Halo default: white
     bool           bg_enabled_       = true;
     ImU32          bg_color_         = IM_COL32( 10,  15,  20, 225);
     bool           glow_enabled_     = true;
     bool           border_enabled_   = true;
-    ImU32          border_color_     = IM_COL32(255, 160,  32, 255);
-    float          border_thickness_ = 1.5f;
-    SelectionStyle selection_style_  = SelectionStyle::ACCENT_BAR;
+    ImU32          border_color_     = IM_COL32(255, 255, 255, 255);  // Halo default: white
+    float          border_thickness_ = 5.0f;                           // Halo default
+    SelectionStyle selection_style_  = SelectionStyle::FILLED_ROW;    // Halo default
     MenuAnchor     anchor_           = MenuAnchor::TopLeft;
 };


### PR DESCRIPTION
- MenuSystem defaults changed to Halo: white accent/border, 5px border thickness, FILLED_ROW selection style
- HudColors defaults changed to Halo: white glow_base, glow_color, compass_tick, compass_glow (alpha 180)
- apply_theme gains a border_thickness param; Halo passes 5.f, all others 1.5f
- selection_style now persisted in config (saved as "filled_row"/"accent_bar", default "filled_row" to match Halo)
- Menu: when bg_enabled is false, item text draws an extra pass at x+0.7 to simulate bold for legibility on a transparent background
- HUD: when indicator_bg_enabled is false, indicator labels draw an extra pass at x+0.7 to simulate bold for legibility without the parallelogram background

https://claude.ai/code/session_01LH94rdjztXGergQJDGJ3sV