### PR TITLE
Halo: no glow + bold text; menu cursor memory on back navigation

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -858,7 +858,9 @@ static std::vector<MenuItem> build_menu(
     auto apply_theme = [hud_col, menu_sys_pp](
             ImU32 glow, ImU32 glow_col, ImU32 text,
             ImU32 tick, ImU32 tick_glow,
-            bool border, float thickness, SelectionStyle style, ImU32 menu_accent) {
+            bool border, float thickness, SelectionStyle style,
+            bool menu_glow, bool menu_bold,
+            ImU32 menu_accent) {
         hud_col->glow_base    = glow;
         hud_col->glow_color   = glow_col;
         hud_col->text_fill    = text;
@@ -870,6 +872,8 @@ static std::vector<MenuItem> build_menu(
             (*menu_sys_pp)->set_border_color(menu_accent);
             (*menu_sys_pp)->set_border_thickness(thickness);
             (*menu_sys_pp)->set_selection_style(style);
+            (*menu_sys_pp)->set_glow_enabled(menu_glow);
+            (*menu_sys_pp)->set_bold_text(menu_bold);
         }
     };
 
@@ -879,6 +883,7 @@ static std::vector<MenuItem> build_menu(
                         IM_COL32(255,255,255,255),
                         IM_COL32(255,255,255,255), IM_COL32(255,255,255,180),
                         true, 5.f, SelectionStyle::FILLED_ROW,
+                        false, true,
                         IM_COL32(255,255,255,255));
         }),
         leaf("Solar", [apply_theme]{
@@ -886,6 +891,7 @@ static std::vector<MenuItem> build_menu(
                         IM_COL32(255,255,255,255),
                         IM_COL32(255,160, 32,255), IM_COL32(255,160, 32,255),
                         true, 1.5f, SelectionStyle::ACCENT_BAR,
+                        true, false,
                         IM_COL32(255,160, 32,255));
         }),
         leaf("Fallout", [apply_theme]{
@@ -893,6 +899,7 @@ static std::vector<MenuItem> build_menu(
                         IM_COL32(  0,255, 80,255),
                         IM_COL32(  0,200, 50,255), IM_COL32(  0,200, 50,255),
                         true, 1.5f, SelectionStyle::ACCENT_BAR,
+                        true, false,
                         IM_COL32(  0,200, 50,255));
         }),
         leaf("Space", [apply_theme]{
@@ -900,6 +907,7 @@ static std::vector<MenuItem> build_menu(
                         IM_COL32(200,220,255,255),
                         IM_COL32( 80,100,255,255), IM_COL32( 80,100,255,255),
                         true, 1.5f, SelectionStyle::ACCENT_BAR,
+                        true, false,
                         IM_COL32( 80,100,255,255));
         }),
     };

--- a/src/menu/menu_system.cpp
+++ b/src/menu/menu_system.cpp
@@ -84,7 +84,9 @@ void MenuSystem::push_level(const std::vector<MenuItem>& items) {
     nav.action = [this] { this->back(); };
     level.push_back(nav);
 
-    stack_.push_back({ level });
+    if (!stack_.empty())
+        stack_.back().cursor = cursor_;  // remember where we were on the parent page
+    stack_.push_back({ level, 0 });
     cursor_ = 0;
     emit_detents();
 }
@@ -92,7 +94,7 @@ void MenuSystem::push_level(const std::vector<MenuItem>& items) {
 void MenuSystem::pop_level() {
     if (stack_.size() > 1) {
         stack_.pop_back();
-        cursor_ = 0;
+        cursor_ = stack_.back().cursor;  // restore cursor to where user was on this page
         emit_detents();
     } else {
         close();
@@ -368,7 +370,7 @@ void MenuSystem::draw(int screen_w, int screen_h) {
 
     // Text drawing helper: FILLED_ROW selected rows use bold-style black text,
     // all others use the standard glow system.
-    const bool bold_text = !bg_enabled_;
+    const bool bold_text = bold_text_ || !bg_enabled_;
     auto draw_item_text = [&](ImVec2 pos, const char* text, bool sel) {
         if (filled_row && sel) {
             dl->AddText({pos.x - 0.6f, pos.y}, IM_COL32(0, 0, 0, 255), text);

--- a/src/menu/menu_system.h
+++ b/src/menu/menu_system.h
@@ -91,6 +91,7 @@ public:
     void set_bg_enabled(bool e)           { bg_enabled_       = e; }
     void set_bg_color(ImU32 c)            { bg_color_         = c; }
     void set_glow_enabled(bool e)         { glow_enabled_     = e; }
+    void set_bold_text(bool b)            { bold_text_        = b; }
     void set_border_enabled(bool e)       { border_enabled_   = e; }
     void set_border_color(ImU32 c)        { border_color_     = c; }
     void set_border_thickness(float t)    { border_thickness_ = t; }
@@ -129,7 +130,7 @@ public:
     const std::string& current_label() const;
 
 private:
-    struct Level { std::vector<MenuItem> items; };
+    struct Level { std::vector<MenuItem> items; int cursor = 0; };
 
     void push_level(const std::vector<MenuItem>& items);
     void pop_level();
@@ -155,7 +156,8 @@ private:
     ImU32          accent_color_     = IM_COL32(255, 255, 255, 255);  // Halo default: white
     bool           bg_enabled_       = true;
     ImU32          bg_color_         = IM_COL32( 10,  15,  20, 225);
-    bool           glow_enabled_     = true;
+    bool           glow_enabled_     = false;   // Halo default: no glow
+    bool           bold_text_        = true;    // Halo default: bold
     bool           border_enabled_   = true;
     ImU32          border_color_     = IM_COL32(255, 255, 255, 255);  // Halo default: white
     float          border_thickness_ = 5.0f;                           // Halo default


### PR DESCRIPTION
- MenuSystem: add bold_text_ flag (default true = Halo); when set, all non-selected items draw an extra shifted text pass for a bold appearance
- MenuSystem: glow_enabled_ default changed to false (Halo default: clean, no glow)
- apply_theme: add menu_glow and menu_bold params; Halo passes false/true, all other themes pass true/false
- Level struct: add cursor field so each stack level remembers where the user was
- push_level: saves cursor_ into stack_.back().cursor before descending
- pop_level: restores cursor_ from stack_.back().cursor after ascending, so going back returns the highlight to the item the user selected from, not the top

https://claude.ai/code/session_01LH94rdjztXGergQJDGJ3sV