### PR TITLE
Enhance vision assistance: HUD/menu polish + bg desat foreground preservation

### DIFF
--- a/assets/shaders/postprocess.fs
+++ b/assets/shaders/postprocess.fs
@@ -34,6 +34,8 @@ uniform float     u_motion_thresh; // min luma delta to count as motion (0.01–
 uniform float     u_motion_radius; // sampling step in texels (controls detection tightness)
 uniform vec3      u_motion_col;    // motion highlight colour (normalised RGB)
 uniform float     u_motion_line;   // 0.0=filled blob, 1.0=fine boundary line
+uniform float     u_color_prot;    // 0.0–1.0; saturated pixels resist desaturation
+uniform float     u_edge_dilate;   // 0.0–3.0; widens colour protection around edges
 
 varying vec2 v_uv;
 
@@ -108,11 +110,29 @@ void main() {
     float sharpness  = clamp(lap * u_focus_sens, 0.0, 1.0);
     bg_weight        = mix(bg_weight, 1.0 - sharpness, u_focus_str);
 
+    // ── Saturation-based colour protection ───────────────────────────────────
+    // Pixels that are already saturated (colourful) should resist desaturation.
+    // Background surfaces (concrete, asphalt, sky) are typically grey/neutral;
+    // foreground objects (faces, gear, clothing) tend to be more colourful.
+    float cmax = max(c11.r, max(c11.g, c11.b));
+    float cmin = min(c11.r, min(c11.g, c11.b));
+    float sat  = (cmax > 0.001) ? (cmax - cmin) / cmax : 0.0;
+    bg_weight *= (1.0 - sat * u_color_prot);
+
+    // ── Dilated edge protection ───────────────────────────────────────────────
+    // Expand the colour-kept zone by one pixel in each cardinal direction using
+    // already-sampled luma differences — no extra texture fetches needed.
+    float edge_n = clamp(abs(l10 - l11) * 4.0 * u_edge_dilate, 0.0, 1.0);
+    float edge_s = clamp(abs(l12 - l11) * 4.0 * u_edge_dilate, 0.0, 1.0);
+    float edge_w = clamp(abs(l01 - l11) * 4.0 * u_edge_dilate, 0.0, 1.0);
+    float edge_e = clamp(abs(l21 - l11) * 4.0 * u_edge_dilate, 0.0, 1.0);
+    float edge_dil = max(edge, max(edge_n, max(edge_s, max(edge_w, edge_e))));
+
     // ── Desaturate background ─────────────────────────────────────────────────
     // Outlined pixels stay in full color: strong edges suppress desaturation.
     // When edge detection is off (u_edge_str=0) this reduces to standard bg_weight behaviour.
     vec3  grey  = vec3(l11);
-    vec3  color = mix(c11, grey, bg_weight * (1.0 - edge * u_edge_str) * u_desat_str);
+    vec3  color = mix(c11, grey, bg_weight * (1.0 - edge_dil * u_edge_str) * u_desat_str);
 
     // ── Overlay edges ─────────────────────────────────────────────────────────
     color = mix(color, u_edge_col, edge * u_edge_str);

--- a/config/config.json
+++ b/config/config.json
@@ -12,6 +12,7 @@
   "cameras": {
     "owlsight_left": {
       "libcamera_id": 0,
+      "model_name": "",
       "width": 1280,
       "height": 800,
       "fps": 60,
@@ -20,6 +21,7 @@
     },
     "owlsight_right": {
       "libcamera_id": 1,
+      "model_name": "",
       "width": 1280,
       "height": 800,
       "fps": 60,

--- a/src/app_state.h
+++ b/src/app_state.h
@@ -124,9 +124,10 @@ struct CameraFocusState {
 };
 
 struct NightVisionState {
-    float exposure_ev = 0.0f;  // -3.0 to +3.0
-    int   shutter_us  = 33333; // microseconds (40 to 1000000)
-    bool  nv_enabled  = false; // night vision preset active (HUD indicator + apply flag)
+    float exposure_ev   = 0.0f;  // -3.0 to +3.0
+    int   shutter_us    = 33333; // microseconds (40 to 1000000)
+    bool  nv_enabled    = false; // night vision preset active (HUD indicator + apply flag)
+    bool  csi_awb_on    = true;  // CSI camera auto white balance (applies to both OWLsight eyes)
 };
 
 struct ClockConfig {

--- a/src/app_state.h
+++ b/src/app_state.h
@@ -24,6 +24,8 @@ struct PostProcessConfig {
     float focus_str          = 0.0f;   // 0.0–1.0; blend Laplacian sharpness into bg_weight
     int   focus_lens_pos     = 500;    // 0–1000 from AF; set each frame — not persisted
     float edge_gate_scale    = 2.0f;   // 0.0=off, else=step multiplier for coarse confirmatory Sobel
+    float color_protect      = 0.5f;   // 0.0–1.0; saturated pixels resist desaturation
+    float edge_dilate        = 1.0f;   // 0.0–3.0; widens colour-kept zone around object edges
 
     // Motion highlight (temporal frame-difference)
     bool  motion_enabled  = false;

--- a/src/camera/camera_manager.cpp
+++ b/src/camera/camera_manager.cpp
@@ -108,14 +108,14 @@ bool CameraManager::init(const CamConfig& left, const CamConfig& right,
 
     // ── OWLsight cameras (zero-copy DMA) ─────────────────────────────────────
     if (lcam_mgr_) {
-        DmaCamera::Config lc { left.libcamera_id, left.width, left.height, left.fps };
+        DmaCamera::Config lc { left.libcamera_id, left.model_name, left.width, left.height, left.fps };
         owl_left_ = std::make_unique<DmaCamera>();
         if (!owl_left_->init(lcam_mgr_.get(), lc, nv12_vs, nv12_fs)) {
             std::cerr << "[cam] OWLsight left init failed\n";
             owl_left_.reset();
         }
 
-        DmaCamera::Config rc { right.libcamera_id, right.width, right.height, right.fps };
+        DmaCamera::Config rc { right.libcamera_id, right.model_name, right.width, right.height, right.fps };
         owl_right_ = std::make_unique<DmaCamera>();
         if (!owl_right_->init(lcam_mgr_.get(), rc, nv12_vs, nv12_fs)) {
             std::cerr << "[cam] OWLsight right init failed\n";

--- a/src/camera/camera_manager.h
+++ b/src/camera/camera_manager.h
@@ -16,10 +16,11 @@
 namespace libcamera { class CameraManager; }
 
 struct CamConfig {
-    int  libcamera_id = 0;
-    int  width        = 1280;
-    int  height       = 800;
-    int  fps          = 60;
+    int         libcamera_id = 0;
+    std::string model_name;   // if non-empty, select camera by model string first
+    int         width        = 1280;
+    int         height       = 800;
+    int         fps          = 60;
 };
 
 struct UsbCamConfig {

--- a/src/camera/dma_camera.cpp
+++ b/src/camera/dma_camera.cpp
@@ -12,11 +12,12 @@
 #include <cstring>
 #include <chrono>
 #include <thread>
+#include <vector>
 
 // DRM fourcc codes — avoids depending on drm/drm_fourcc.h
-// NV12: semi-planar 4:2:0 — Y plane, then interleaved Cb/Cr (UV) plane.
-// fourcc_code('N','V','1','2') = 0x3231564E (little-endian).
-#define DRM_FORMAT_NV12 0x3231564Eu
+#define DRM_FORMAT_NV12   0x3231564Eu  // semi-planar 4:2:0: Y + interleaved UV
+#define DRM_FORMAT_YUV420 0x32315559u  // planar 4:2:0: Y + U + V
+#define DRM_FORMAT_YUYV   0x56595559u  // packed 4:2:2: Y0 Cb Y1 Cr interleaved
 
 using namespace libcamera;
 
@@ -70,53 +71,100 @@ bool DmaCamera::load_egl_procs() {
 
 bool DmaCamera::configure_camera() {
     auto cameras = lcam_mgr_->cameras();
-    if (static_cast<int>(cameras.size()) <= cfg_.libcamera_id) {
-        std::cerr << "[dma] camera id " << cfg_.libcamera_id
-                  << " not found (" << cameras.size() << " cameras)\n";
-        return false;
-    }
 
-    camera_ = lcam_mgr_->get(cameras[cfg_.libcamera_id]->id());
+    // ── Select camera: by model string if provided, else by index ────────────
+    if (!cfg_.model_name.empty()) {
+        for (auto& desc : cameras) {
+            auto c = lcam_mgr_->get(desc->id());
+            try {
+                auto m = c->properties().get(properties::Model);
+                if (m && *m == cfg_.model_name) {
+                    camera_ = c;
+                    break;
+                }
+            } catch (...) {}
+        }
+        if (!camera_)
+            std::cerr << "[dma] model '" << cfg_.model_name
+                      << "' not found, falling back to id " << cfg_.libcamera_id << "\n";
+    }
+    if (!camera_) {
+        if (static_cast<int>(cameras.size()) <= cfg_.libcamera_id) {
+            std::cerr << "[dma] camera id " << cfg_.libcamera_id
+                      << " not found (" << cameras.size() << " cameras)\n";
+            return false;
+        }
+        camera_ = lcam_mgr_->get(cameras[cfg_.libcamera_id]->id());
+    }
     if (!camera_ || camera_->acquire()) {
-        std::cerr << "[dma] failed to acquire camera " << cfg_.libcamera_id << "\n";
+        std::cerr << "[dma] failed to acquire camera\n";
         return false;
     }
 
-    cam_cfg_ = camera_->generateConfiguration({ StreamRole::Viewfinder });
-    auto& sc = cam_cfg_->at(0);
-    sc.pixelFormat = formats::NV12;   // native ISP output — no ISP RGB conversion
-    sc.size        = { static_cast<unsigned>(cfg_.width),
-                       static_cast<unsigned>(cfg_.height) };
-    sc.bufferCount = NUM_SLOTS;
-    // Frame rate is set via FrameDurationLimits control on camera_->start(),
-    // not via StreamConfiguration (frameRate field does not exist on Bullseye).
-
-    auto status = cam_cfg_->validate();
-    if (status == CameraConfiguration::Invalid) {
-        std::cerr << "[dma] camera configuration invalid\n";
-        return false;
+    // ── Log supported modes so users can identify valid resolutions ───────────
+    {
+        auto probe = camera_->generateConfiguration({ StreamRole::Viewfinder });
+        std::cout << "[dma] camera " << cfg_.libcamera_id << " supported modes:\n";
+        for (size_t i = 0; i < probe->size(); ++i) {
+            const auto& s = probe->at(i);
+            std::cout << "  [" << i << "] " << s.pixelFormat
+                      << " " << s.size.width << "×" << s.size.height << "\n";
+        }
     }
-    if (status == CameraConfiguration::Adjusted) {
-        // libcamera snapped the requested size to the nearest supported mode.
-        // Update cfg_ so EGL image dimensions match the actual buffer layout.
+
+    // ── Format negotiation: NV12 → YUV420 → YUYV ─────────────────────────────
+    // NV12 is preferred (native ISP semi-planar, zero-copy via EGL).
+    // YUV420 (3-plane) and YUYV (packed) are fallbacks for sensors/bridges that
+    // do not expose NV12. The samplerExternalOES path handles all three on V3D.
+    const struct { libcamera::PixelFormat fmt; uint32_t drm; int planes; const char* name; }
+    kFmtPrefs[] = {
+        { formats::NV12,   DRM_FORMAT_NV12,   2, "NV12"   },
+        { formats::YUV420, DRM_FORMAT_YUV420, 3, "YUV420" },
+        { formats::YUYV,   DRM_FORMAT_YUYV,   1, "YUYV"   },
+    };
+
+    bool configured = false;
+    for (const auto& fp : kFmtPrefs) {
+        cam_cfg_ = camera_->generateConfiguration({ StreamRole::Viewfinder });
+        auto& sc = cam_cfg_->at(0);
+        sc.pixelFormat = fp.fmt;
+        sc.size        = { static_cast<unsigned>(cfg_.width),
+                           static_cast<unsigned>(cfg_.height) };
+        sc.bufferCount = NUM_SLOTS;
+        auto st = cam_cfg_->validate();
+        if (st == CameraConfiguration::Invalid) continue;
+
+        if (st == CameraConfiguration::Adjusted) {
+            std::cout << "[dma] size adjusted: "
+                      << cfg_.width << "×" << cfg_.height
+                      << " → " << sc.size.width << "×" << sc.size.height << "\n";
+            cfg_.width  = sc.size.width;
+            cfg_.height = sc.size.height;
+        }
+        fmt_drm_    = fp.drm;
+        fmt_planes_ = fp.planes;
+        configured  = true;
         std::cout << "[dma] camera " << cfg_.libcamera_id
-                  << " size adjusted by libcamera: "
-                  << cfg_.width << "×" << cfg_.height
-                  << " → " << sc.size.width << "×" << sc.size.height << "\n";
-        cfg_.width  = sc.size.width;
-        cfg_.height = sc.size.height;
+                  << " using format " << fp.name << "\n";
+        break;
     }
+    if (!configured) {
+        std::cerr << "[dma] no supported pixel format (tried NV12, YUV420, YUYV)\n";
+        return false;
+    }
+
     if (camera_->configure(cam_cfg_.get())) {
         std::cerr << "[dma] camera_->configure() failed\n";
         return false;
     }
 
+    auto& sc = cam_cfg_->at(0);
     stream_ = sc.stream();
     stride_ = sc.stride;
 
     std::cout << "[dma] camera " << cfg_.libcamera_id
               << " configured: " << cfg_.width << "×" << cfg_.height
-              << " NV12 stride=" << stride_ << " fps=" << cfg_.fps << "\n";
+              << " stride=" << stride_ << " fps=" << cfg_.fps << "\n";
     return true;
 }
 
@@ -157,42 +205,52 @@ bool DmaCamera::allocate_buffers_and_egl() {
 
 bool DmaCamera::create_egl_image(const FrameBuffer* buf, Slot& slot) {
     const auto& planes = buf->planes();
-    if (planes.size() < 2) {
-        std::cerr << "[dma] NV12 buffer has fewer than 2 planes\n";
+    if (static_cast<int>(planes.size()) < fmt_planes_) {
+        std::cerr << "[dma] buffer has " << planes.size()
+                  << " planes but format requires " << fmt_planes_ << "\n";
         return false;
     }
 
-    int fd_y    = planes[0].fd.get();
-    int fd_uv   = planes[1].fd.get();
-    auto off_y  = static_cast<EGLint>(planes[0].offset);
-    auto off_uv = static_cast<EGLint>(planes[1].offset);
-    auto pitch  = static_cast<EGLint>(stride_);
+    auto pitch = static_cast<EGLint>(stride_);
 
-    // Import the full NV12 buffer as a single multi-plane EGLImage.
-    // PLANE0 = Y (luma, full resolution), PLANE1 = UV (chroma, interleaved Cb/Cr).
-    // Mesa V3D on Pi5 supports DRM_FORMAT_NV12 natively; sampling via
-    // GL_TEXTURE_EXTERNAL_OES + samplerExternalOES returns RGB (TMU does YCbCr→RGB).
-    // This avoids DRM_FORMAT_RG88 which is not supported on V3D (EGL_BAD_MATCH).
-    EGLint attr[] = {
+    // Build the EGL attribute list for the negotiated DRM format.
+    // NV12 / YUV420 / YUYV all use the same EGL_LINUX_DMA_BUF_EXT path;
+    // only the fourcc and plane count differ.
+    std::vector<EGLint> attr = {
         EGL_WIDTH,                         cfg_.width,
         EGL_HEIGHT,                        cfg_.height,
-        EGL_LINUX_DRM_FOURCC_EXT,          (EGLint)DRM_FORMAT_NV12,
-        EGL_DMA_BUF_PLANE0_FD_EXT,         fd_y,
-        EGL_DMA_BUF_PLANE0_OFFSET_EXT,     off_y,
+        EGL_LINUX_DRM_FOURCC_EXT,          (EGLint)fmt_drm_,
+        // Plane 0 — Y (luma) or packed data (YUYV)
+        EGL_DMA_BUF_PLANE0_FD_EXT,         planes[0].fd.get(),
+        EGL_DMA_BUF_PLANE0_OFFSET_EXT,     (EGLint)planes[0].offset,
         EGL_DMA_BUF_PLANE0_PITCH_EXT,      pitch,
-        EGL_DMA_BUF_PLANE1_FD_EXT,         fd_uv,
-        EGL_DMA_BUF_PLANE1_OFFSET_EXT,     off_uv,
-        EGL_DMA_BUF_PLANE1_PITCH_EXT,      pitch,
-        EGL_NONE
     };
+    if (fmt_planes_ >= 2) {
+        // Plane 1 — UV interleaved (NV12) or U/Cb (YUV420)
+        attr.insert(attr.end(), {
+            EGL_DMA_BUF_PLANE1_FD_EXT,     planes[1].fd.get(),
+            EGL_DMA_BUF_PLANE1_OFFSET_EXT, (EGLint)planes[1].offset,
+            EGL_DMA_BUF_PLANE1_PITCH_EXT,  pitch / 2,
+        });
+    }
+    if (fmt_planes_ >= 3) {
+        // Plane 2 — V/Cr (YUV420 only)
+        attr.insert(attr.end(), {
+            EGL_DMA_BUF_PLANE2_FD_EXT,     planes[2].fd.get(),
+            EGL_DMA_BUF_PLANE2_OFFSET_EXT, (EGLint)planes[2].offset,
+            EGL_DMA_BUF_PLANE2_PITCH_EXT,  pitch / 2,
+        });
+    }
+    attr.push_back(EGL_NONE);
+
     slot.img_y = pfn_create_image_(egl_display_, EGL_NO_CONTEXT,
-                                   EGL_LINUX_DMA_BUF_EXT, nullptr, attr);
+                                   EGL_LINUX_DMA_BUF_EXT, nullptr, attr.data());
     if (slot.img_y == EGL_NO_IMAGE_KHR) {
-        std::cerr << "[dma] eglCreateImageKHR for NV12 failed (err 0x"
+        std::cerr << "[dma] eglCreateImageKHR failed (err 0x"
                   << std::hex << eglGetError() << std::dec << ")\n";
         return false;
     }
-    slot.img_uv = EGL_NO_IMAGE_KHR;   // unused — full NV12 encoded in img_y
+    slot.img_uv = EGL_NO_IMAGE_KHR;  // unused — full frame encoded in img_y
     return true;
 }
 
@@ -444,36 +502,39 @@ bool DmaCamera::reconfigure(int width, int height, int fps) {
     cfg_.height = height;
     cfg_.fps    = fps;
 
-    // 5. Reconfigure the libcamera stream (camera stays acquired)
-    cam_cfg_ = camera_->generateConfiguration({ StreamRole::Viewfinder });
-    auto& sc = cam_cfg_->at(0);
-    sc.pixelFormat = formats::NV12;
-    sc.size        = { static_cast<unsigned>(cfg_.width),
-                       static_cast<unsigned>(cfg_.height) };
-    sc.bufferCount = NUM_SLOTS;
-    // frameRate is set via FrameDurationLimits in start_capture(), not here.
+    // 5. Reconfigure — reuse the same format that was negotiated at init time.
+    // Changing resolution does not change the pixel format, so we keep fmt_drm_/fmt_planes_.
+    const struct { libcamera::PixelFormat fmt; uint32_t drm; int planes; } kPrefs[] = {
+        { formats::NV12,   0x3231564Eu, 2 },
+        { formats::YUV420, 0x32315559u, 3 },
+        { formats::YUYV,   0x56595559u, 1 },
+    };
 
-    auto rcfg_status = cam_cfg_->validate();
-    if (rcfg_status == CameraConfiguration::Adjusted) {
-        std::cout << "[dma] reconfigure: size adjusted "
-                  << cfg_.width << "×" << cfg_.height
-                  << " → " << sc.size.width << "×" << sc.size.height << "\n";
-        cfg_.width  = sc.size.width;
-        cfg_.height = sc.size.height;
-    }
-    if (rcfg_status == CameraConfiguration::Invalid) {
-        std::cerr << "[dma] reconfigure: invalid configuration "
-                  << width << "×" << height << " @" << fps << "fps — reverting\n";
-        cfg_.width = old_w;  cfg_.height = old_h;  cfg_.fps = old_fps;
+    bool recfg_ok = false;
+    for (const auto& fp : kPrefs) {
         cam_cfg_ = camera_->generateConfiguration({ StreamRole::Viewfinder });
-        auto& sc2 = cam_cfg_->at(0);
-        sc2.pixelFormat = formats::NV12;
-        sc2.size = { static_cast<unsigned>(old_w), static_cast<unsigned>(old_h) };
-        sc2.bufferCount = NUM_SLOTS;
-        cam_cfg_->validate();
-        camera_->configure(cam_cfg_.get());
-        stream_ = cam_cfg_->at(0).stream();
-        stride_ = cam_cfg_->at(0).stride;
+        auto& sc = cam_cfg_->at(0);
+        sc.pixelFormat = fp.fmt;
+        sc.size        = { static_cast<unsigned>(cfg_.width),
+                           static_cast<unsigned>(cfg_.height) };
+        sc.bufferCount = NUM_SLOTS;
+        auto st = cam_cfg_->validate();
+        if (st == CameraConfiguration::Invalid) continue;
+        if (st == CameraConfiguration::Adjusted) {
+            std::cout << "[dma] reconfigure: size adjusted "
+                      << cfg_.width << "×" << cfg_.height
+                      << " → " << sc.size.width << "×" << sc.size.height << "\n";
+            cfg_.width  = sc.size.width;
+            cfg_.height = sc.size.height;
+        }
+        fmt_drm_    = fp.drm;
+        fmt_planes_ = fp.planes;
+        recfg_ok    = true;
+        break;
+    }
+    if (!recfg_ok) {
+        std::cerr << "[dma] reconfigure: no valid format found — reverting\n";
+        cfg_.width = old_w;  cfg_.height = old_h;  cfg_.fps = old_fps;
         if (allocate_buffers_and_egl()) start_capture();
         return false;
     }
@@ -481,12 +542,8 @@ bool DmaCamera::reconfigure(int width, int height, int fps) {
     if (camera_->configure(cam_cfg_.get())) {
         std::cerr << "[dma] reconfigure: camera_->configure() failed — reverting\n";
         cfg_.width = old_w;  cfg_.height = old_h;  cfg_.fps = old_fps;
-        // best-effort revert
         cam_cfg_ = camera_->generateConfiguration({ StreamRole::Viewfinder });
-        auto& sc2 = cam_cfg_->at(0);
-        sc2.pixelFormat = formats::NV12;
-        sc2.size = { static_cast<unsigned>(old_w), static_cast<unsigned>(old_h) };
-        sc2.bufferCount = NUM_SLOTS;
+        cam_cfg_->at(0).size = { static_cast<unsigned>(old_w), static_cast<unsigned>(old_h) };
         cam_cfg_->validate();
         camera_->configure(cam_cfg_.get());
         stream_ = cam_cfg_->at(0).stream();
@@ -495,6 +552,7 @@ bool DmaCamera::reconfigure(int width, int height, int fps) {
         return false;
     }
 
+    auto& sc = cam_cfg_->at(0);
     stream_ = sc.stream();
     stride_ = sc.stride;
 
@@ -547,6 +605,17 @@ void DmaCamera::apply_pending_controls(ControlList& ctrls) {
     float lp = pending_lens_pos_.exchange(-1.0f);
     if (lp >= 0.0f)
         ctrls.set(controls::LensPosition, lp);
+
+    int awb = pending_awb_enable_.exchange(-1);
+    if (awb >= 0 && camera_->controls().count(&controls::AwbEnable))
+        ctrls.set(controls::AwbEnable, awb == 1);
+
+    float rg = pending_rg_gain_.exchange(-1.0f);
+    float bg = pending_bg_gain_.exchange(-1.0f);
+    if (rg >= 0.0f && bg >= 0.0f && camera_->controls().count(&controls::ColourGains)) {
+        float gains[2] = { rg, bg };
+        ctrls.set(controls::ColourGains, Span<const float, 2>(gains));
+    }
 }
 
 void DmaCamera::start_autofocus() {
@@ -604,4 +673,43 @@ void DmaCamera::set_ae_enable(bool ae_on) {
     if (!camera_) return;
     if (camera_->controls().count(&controls::AeEnable))
         pending_ae_enable_.store(ae_on ? 1 : 0);
+}
+
+void DmaCamera::set_awb_enable(bool awb_on) {
+    if (!camera_) return;
+    if (camera_->controls().count(&controls::AwbEnable))
+        pending_awb_enable_.store(awb_on ? 1 : 0);
+}
+
+void DmaCamera::set_colour_gains(float rg, float bg) {
+    if (!camera_) return;
+    if (camera_->controls().count(&controls::ColourGains)) {
+        pending_rg_gain_.store(rg);
+        pending_bg_gain_.store(bg);
+    }
+}
+
+void DmaCamera::set_colour_temp(int kelvin) {
+    // Approximate Pi ISP ColourGains (Rg, Bg) for common colour temperatures.
+    // Lower Kelvin = warmer/more red = higher Rg, lower Bg.
+    // Higher Kelvin = cooler/more blue = lower Rg, higher Bg.
+    static const struct { int k; float rg, bg; } lut[] = {
+        { 2800, 2.20f, 1.15f },
+        { 3500, 1.90f, 1.40f },
+        { 4500, 1.60f, 1.65f },
+        { 5600, 1.30f, 1.90f },
+        { 7000, 1.05f, 2.30f },
+    };
+    static constexpr int n = sizeof(lut) / sizeof(lut[0]);
+    if (kelvin <= lut[0].k)   { set_colour_gains(lut[0].rg, lut[0].bg); return; }
+    if (kelvin >= lut[n-1].k) { set_colour_gains(lut[n-1].rg, lut[n-1].bg); return; }
+    for (int i = 1; i < n; i++) {
+        if (kelvin <= lut[i].k) {
+            float t = static_cast<float>(kelvin - lut[i-1].k) /
+                      static_cast<float>(lut[i].k - lut[i-1].k);
+            set_colour_gains(lut[i-1].rg + t * (lut[i].rg - lut[i-1].rg),
+                             lut[i-1].bg + t * (lut[i].bg - lut[i-1].bg));
+            return;
+        }
+    }
 }

--- a/src/camera/dma_camera.h
+++ b/src/camera/dma_camera.h
@@ -21,6 +21,7 @@
 #include <atomic>
 #include <memory>
 #include <mutex>
+#include <string>
 #include <thread>
 #include <array>
 #include <unordered_map>
@@ -44,10 +45,11 @@ namespace libcamera {
 class DmaCamera {
 public:
     struct Config {
-        int libcamera_id = 0;
-        int width        = 1280;
-        int height       = 800;
-        int fps          = 60;
+        int         libcamera_id = 0;
+        std::string model_name;   // if non-empty, match camera by model string first
+        int         width        = 1280;
+        int         height       = 800;
+        int         fps          = 60;
     };
 
     DmaCamera();
@@ -79,6 +81,11 @@ public:
     void set_shutter_speed_us(int us);  // microseconds (requires AE off / manual mode)
     void set_ae_enable(bool ae_on);     // true = auto-exposure, false = manual shutter
 
+    // ── White balance control (libcamera controls API) ─────────────────────────
+    void set_awb_enable(bool awb_on);              // true = auto WB, false = manual
+    void set_colour_gains(float rg, float bg);     // raw ISP gains (typically 0.5–4.0)
+    void set_colour_temp(int kelvin);              // maps 2800–7500 K → ColourGains LUT
+
     bool is_ok()  const { return ok_; }
     int  width()  const { return cfg_.width; }
     int  height() const { return cfg_.height; }
@@ -104,6 +111,10 @@ private:
     void on_request_complete(libcamera::Request* req);
     // Apply any pending control updates to a request's ControlList before requeuing.
     void apply_pending_controls(libcamera::ControlList& ctrls);
+
+    // Negotiated pixel format (set by configure_camera before allocate_buffers_and_egl)
+    uint32_t fmt_drm_    = 0x3231564Eu; // DRM_FORMAT_NV12 default
+    int      fmt_planes_ = 2;           // number of DMA planes for the format
 
     // libcamera
     libcamera::CameraManager*                         lcam_mgr_  = nullptr;
@@ -150,6 +161,9 @@ private:
     std::atomic<int>   pending_shutter_us_ { -1 };       // ExposureTime µs, -1 = no-op
     std::atomic<int>   pending_ae_enable_  { -1 };       // 1=on 0=off -1=no-op
     std::atomic<float> pending_lens_pos_   { -1.0f };    // LensPosition diopters, -1 = no-op
+    std::atomic<int>   pending_awb_enable_ { -1 };       // AwbEnable: 1=on 0=off -1=no-op
+    std::atomic<float> pending_rg_gain_    { -1.0f };    // ColourGains R, -1 = no-op
+    std::atomic<float> pending_bg_gain_    { -1.0f };    // ColourGains B, -1 = no-op
 
     // ── Latest camera metadata (written by capture thread via atomics) ────────
     std::atomic<int>   last_af_state_      { 0 };        // AfState enum value

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1239,6 +1239,12 @@ static std::vector<MenuItem> build_menu(
         submenu("Strength",    std::move(desat_strength_menu)),
         submenu("BG Threshold", std::move(bg_threshold_menu)),
         submenu("Focus Blend", std::move(focus_blend_menu)),
+        slider("Color Protect", 0.f, 100.f, 10.f, " %",
+            [&state]{ return state.pp_cfg.color_protect * 100.f; },
+            [&state](float v){ state.pp_cfg.color_protect = v / 100.f; }),
+        slider("Edge Expand", 0.f, 3.f, 0.5f, "",
+            [&state]{ return state.pp_cfg.edge_dilate; },
+            [&state](float v){ state.pp_cfg.edge_dilate = v; }),
     };
 
     std::vector<MenuItem> vision_menu = {
@@ -1527,6 +1533,8 @@ int main(int argc, char* argv[]) {
             uint8_t a = jpp["edge_color"].size() >= 4 ? (uint8_t)jc[3] : 255;
             state.pp_cfg.edge_color = IM_COL32(r, g, b, a);
         }
+        state.pp_cfg.color_protect   = jpp.value("color_protect",   0.5f);
+        state.pp_cfg.edge_dilate     = jpp.value("edge_dilate",     1.0f);
         state.pp_cfg.motion_enabled  = jpp.value("motion_enabled",  false);
         state.pp_cfg.motion_strength = jpp.value("motion_strength", 0.9f);
         state.pp_cfg.motion_thresh   = jpp.value("motion_thresh",   0.04f);
@@ -2197,6 +2205,8 @@ int main(int argc, char* argv[]) {
         jpp["edge_threshold"]     = state.pp_cfg.edge_threshold;
         jpp["focus_str"]          = state.pp_cfg.focus_str;
         jpp["edge_gate_scale"]    = state.pp_cfg.edge_gate_scale;
+        jpp["color_protect"]      = state.pp_cfg.color_protect;
+        jpp["edge_dilate"]        = state.pp_cfg.edge_dilate;
         jpp["motion_enabled"]     = state.pp_cfg.motion_enabled;
         jpp["motion_strength"]    = state.pp_cfg.motion_strength;
         jpp["motion_thresh"]      = state.pp_cfg.motion_thresh;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,7 +29,66 @@
 #include "post_process.h"
 #include "sensor/mpu9250.h"
 
+#include <fstream>
+#include <unistd.h>
+
 using json = nlohmann::json;
+
+// ── Serial port auto-discovery ────────────────────────────────────────────────
+// Tries the configured path first; if it doesn't exist, scans up to 8 nodes
+// with the same prefix (ttyACM/ttyUSB) and optionally matches by USB VID:PID
+// read from sysfs. Returns the best match (or the original path so the
+// caller's open() fails with the right error message).
+static std::string resolve_serial_port(const std::string& configured,
+                                        uint16_t vid = 0, uint16_t pid = 0) {
+    if (access(configured.c_str(), F_OK) == 0) return configured;
+
+    // Determine prefix (ttyACM / ttyUSB)
+    const char* pfx = nullptr;
+    if (configured.find("/dev/ttyACM") == 0) pfx = "/dev/ttyACM";
+    else if (configured.find("/dev/ttyUSB") == 0) pfx = "/dev/ttyUSB";
+    if (!pfx) return configured;
+
+    std::string tty_prefix(pfx);
+    std::string sys_prefix = "/sys/class/tty/" + tty_prefix.substr(5); // strip /dev/
+
+    std::string first_available;
+    for (int n = 0; n < 8; n++) {
+        std::string dev = tty_prefix + std::to_string(n);
+        if (access(dev.c_str(), F_OK) != 0) continue;
+
+        // If VID:PID were provided, check sysfs uevent for a match
+        if (vid != 0) {
+            std::string uevent = sys_prefix + std::to_string(n) + "/device/uevent";
+            std::ifstream f(uevent);
+            bool match = false;
+            if (f) {
+                std::string line;
+                while (std::getline(f, line)) {
+                    if (line.find("PRODUCT=") != 0) continue;
+                    unsigned rv = 0, rp = 0;
+                    if (sscanf(line.c_str(), "PRODUCT=%x/%x", &rv, &rp) == 2)
+                        match = (rv == vid && rp == pid);
+                    break;
+                }
+            }
+            if (match) {
+                std::cerr << "[serial] " << configured << " not found — using "
+                          << dev << " (VID:PID match)\n";
+                return dev;
+            }
+        }
+        if (first_available.empty()) first_available = dev;
+    }
+
+    // No VID:PID match found; fall back to first available node with same prefix
+    if (!first_available.empty() && vid == 0) {
+        std::cerr << "[serial] " << configured << " not found — trying "
+                  << first_available << "\n";
+        return first_available;
+    }
+    return configured; // give up; caller logs the real open() error
+}
 
 // ── Config loading ────────────────────────────────────────────────────────────
 
@@ -335,6 +394,27 @@ static std::vector<MenuItem> build_menu(
         submenu("Shutter Speed", std::move(shutter_speeds)),
     };
 
+    // ── White balance (OWLsight CSI cameras) ─────────────────────────────────
+    std::vector<MenuItem> wb_temp_menu = {
+        leaf_sel("Tungsten (2800K)",  [cameras]{ if (cameras) { if (cameras->owl_left()) cameras->owl_left()->set_colour_temp(2800); if (cameras->owl_right()) cameras->owl_right()->set_colour_temp(2800); } }, []{ return false; }),
+        leaf_sel("Warm WB (3500K)",   [cameras]{ if (cameras) { if (cameras->owl_left()) cameras->owl_left()->set_colour_temp(3500); if (cameras->owl_right()) cameras->owl_right()->set_colour_temp(3500); } }, []{ return false; }),
+        leaf_sel("Neutral (4500K)",   [cameras]{ if (cameras) { if (cameras->owl_left()) cameras->owl_left()->set_colour_temp(4500); if (cameras->owl_right()) cameras->owl_right()->set_colour_temp(4500); } }, []{ return false; }),
+        leaf_sel("Daylight (5600K)",  [cameras]{ if (cameras) { if (cameras->owl_left()) cameras->owl_left()->set_colour_temp(5600); if (cameras->owl_right()) cameras->owl_right()->set_colour_temp(5600); } }, []{ return false; }),
+        leaf_sel("Cool Blue (7000K)", [cameras]{ if (cameras) { if (cameras->owl_left()) cameras->owl_left()->set_colour_temp(7000); if (cameras->owl_right()) cameras->owl_right()->set_colour_temp(7000); } }, []{ return false; }),
+    };
+
+    std::vector<MenuItem> awb_menu = {
+        toggle("Auto WB",
+            [&state]{ return state.night_vision.csi_awb_on; },
+            [cameras, &state](bool v){
+                state.night_vision.csi_awb_on = v;
+                if (!cameras) return;
+                if (cameras->owl_left())  cameras->owl_left()->set_awb_enable(v);
+                if (cameras->owl_right()) cameras->owl_right()->set_awb_enable(v);
+            }),
+        submenu("Colour Temp", std::move(wb_temp_menu)),
+    };
+
     std::vector<MenuItem> main_cameras_menu = {
         submenu("Resolution",  std::move(resolution_presets)),
         submenu("Focus Mode",  std::move(focus_modes)),
@@ -350,6 +430,7 @@ static std::vector<MenuItem> build_menu(
                 state.focus_right.focus_position = pos;
             }),
         submenu("Autofocus",    std::move(af_triggers)),
+        submenu("White Balance", std::move(awb_menu)),
         submenu("Night Vision", std::move(nv_menu)),
     };
 
@@ -1384,15 +1465,17 @@ int main(int argc, char* argv[]) {
 
     CamConfig owl_left, owl_right;
     if (jcam.contains("owlsight_left")) {
-        auto& jl          = jcam["owlsight_left"];
+        auto& jl              = jcam["owlsight_left"];
         owl_left.libcamera_id = jl.value("libcamera_id", 0);
+        owl_left.model_name   = jl.value("model_name",   std::string(""));
         owl_left.width        = jl.value("width",  1280);
         owl_left.height       = jl.value("height",  800);
         owl_left.fps          = jl.value("fps",      60);
     }
     if (jcam.contains("owlsight_right")) {
-        auto& jr           = jcam["owlsight_right"];
+        auto& jr               = jcam["owlsight_right"];
         owl_right.libcamera_id = jr.value("libcamera_id", 1);
+        owl_right.model_name   = jr.value("model_name",   std::string(""));
         owl_right.width        = jr.value("width",  1280);
         owl_right.height       = jr.value("height",  800);
         owl_right.fps          = jr.value("fps",      60);
@@ -1707,13 +1790,20 @@ int main(int argc, char* argv[]) {
     if (jser.contains("lora"))      lora_port   = jser["lora"].value("port",      lora_port);
     if (jser.contains("smartknob")) knob_port   = jser["smartknob"].value("port", knob_port);
 
+    // Auto-discover serial ports by USB VID:PID when configured paths are absent.
+    // Teensy 4.1: VID=0x16C0, PID=0x0483.  LoRa CH340: VID=0x1A86, PID=0x7523.
+    // SmartKnob (ESP32-S3 dev board): scan ttyACM without VID filter (varies by board).
+    teensy_port = resolve_serial_port(teensy_port, 0x16C0, 0x0483);
+    lora_port   = resolve_serial_port(lora_port,   0x1A86, 0x7523);
+    knob_port   = resolve_serial_port(knob_port);
+
     TeensyController teensy(teensy_port, baud, state);
     LoRaRadio        lora  (lora_port,   baud, state);
     SmartKnob        knob  (knob_port,   baud, state);
 
-    teensy.start();
-    lora.start();
-    knob.start();
+    if (!teensy.start()) std::cerr << "[main] Teensy not available on " << teensy_port << "\n";
+    if (!lora.start())   std::cerr << "[main] LoRa not available on "   << lora_port   << "\n";
+    if (!knob.start())   std::cerr << "[main] SmartKnob not available on " << knob_port << "\n";
 
     uint16_t sleep_tmo = 30;
     if (jser.contains("smartknob"))

--- a/src/post_process.cpp
+++ b/src/post_process.cpp
@@ -30,6 +30,8 @@ bool PostProcessor::init(int w, int h, const char* vs_path, const char* fs_path)
     loc_motion_radius_ = glGetUniformLocation(prog_, "u_motion_radius");
     loc_motion_col_    = glGetUniformLocation(prog_, "u_motion_col");
     loc_motion_line_   = glGetUniformLocation(prog_, "u_motion_line");
+    loc_color_prot_    = glGetUniformLocation(prog_, "u_color_prot");
+    loc_edge_dilate_   = glGetUniformLocation(prog_, "u_edge_dilate");
 
     // EMA blit: blends current frame with previous EMA reference.
     // update_rate=1.0 → hard copy (1-frame trail), lower → longer exponential trail.
@@ -123,6 +125,9 @@ void PostProcessor::process(GLuint src_tex,
     glUniform1f(loc_motion_radius_, cfg.motion_radius);
     glUniform3f(loc_motion_col_,    mr, mg, mb);
     glUniform1f(loc_motion_line_,   cfg.motion_line);
+
+    glUniform1f(loc_color_prot_,  cfg.desat_enabled ? cfg.color_protect : 0.f);
+    glUniform1f(loc_edge_dilate_,  cfg.desat_enabled ? cfg.edge_dilate   : 0.f);
 
     gl::bind_quad(vbo_);
     gl::draw_quad();

--- a/src/post_process.h
+++ b/src/post_process.h
@@ -67,6 +67,8 @@ private:
     GLint loc_motion_radius_ = -1;
     GLint loc_motion_col_    = -1;
     GLint loc_motion_line_   = -1;
+    GLint loc_color_prot_    = -1;
+    GLint loc_edge_dilate_   = -1;
 
     int w_ = 0, h_ = 0;
 };


### PR DESCRIPTION
## Summary

- **Halo as default theme**: White accent/border, 5px border thickness, bold text, no menu glow, `FILLED_ROW` selection style — compiled-in defaults so first run looks correct without a saved config
- **Cursor memory on back navigation**: `MenuSystem::Level` now stores cursor position; navigating back restores where you were in the parent menu
- **Radio indicators throughout**: All multi-option settings (themes, focus mode, resolution, colour presets, PiP anchor/size) show a filled/empty circle indicator to the right
- **Menu restructure**: Vision Assist moved under Cameras; Background Options submenu removed, Tape Height slider inlined into Compass menu
- **PiP/theme polish**: TOP_CENTER PiP renders below compass tape; pip border tracks `glow_base` colour; bold text when HUD or menu background is off
- **Bg desaturation — saturation colour protection** (`Color Protect` slider 0–100%): Saturated pixels resist desaturation proportionally to their HSV saturation. Background surfaces (concrete, asphalt) stay neutral and eligible for desaturation; foreground objects (faces, clothing, gear) are more colourful and stay vivid.
- **Bg desaturation — dilated edge protection** (`Edge Expand` slider 0–3): Expands the colour-kept zone one pixel in each cardinal direction using already-sampled luma diffs (no extra texture fetches). Prevents the greyed-out fringe immediately inside object boundaries.

## Test plan

- [ ] First run (no config.json): Halo theme active, white border visible, bold menu text, no glow
- [ ] Navigate into a submenu and press Back — cursor returns to the item that was selected, not the top
- [ ] Theme/focus/resolution selectors show filled dot next to active option
- [ ] PiP at TOP_CENTER sits below the compass tape, not behind it
- [ ] Vision Assist appears under Cameras menu; Compass menu has Tape Height slider directly
- [ ] Enable Bg Desaturate; set Color Protect = 80% — colourful objects stay vivid, grey/brown background desaturates
- [ ] Set Edge Expand = 2 — colour fringe inside object outlines is wider, less "greyed at the edges"
- [ ] Config saves and restores `color_protect` and `edge_dilate` across restarts

https://claude.ai/code/session_01LH94rdjztXGergQJDGJ3sV

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH94rdjztXGergQJDGJ3sV)_