### PR TITLE
fix(dma_camera): correct NV12 UV plane stride in EGL import

### DIFF
--- a/src/camera/dma_camera.cpp
+++ b/src/camera/dma_camera.cpp
@@ -226,11 +226,13 @@ bool DmaCamera::create_egl_image(const FrameBuffer* buf, Slot& slot) {
         EGL_DMA_BUF_PLANE0_PITCH_EXT,      pitch,
     };
     if (fmt_planes_ >= 2) {
-        // Plane 1 — UV interleaved (NV12) or U/Cb (YUV420)
+        // NV12: UV plane has the same row stride as Y (interleaved, same width).
+        // YUV420: U plane is half width, so stride is halved.
+        EGLint plane1_pitch = (fmt_drm_ == DRM_FORMAT_NV12) ? pitch : pitch / 2;
         attr.insert(attr.end(), {
             EGL_DMA_BUF_PLANE1_FD_EXT,     planes[1].fd.get(),
             EGL_DMA_BUF_PLANE1_OFFSET_EXT, (EGLint)planes[1].offset,
-            EGL_DMA_BUF_PLANE1_PITCH_EXT,  pitch / 2,
+            EGL_DMA_BUF_PLANE1_PITCH_EXT,  plane1_pitch,
         });
     }
     if (fmt_planes_ >= 3) {


### PR DESCRIPTION
NV12 semi-planar format: the UV plane has the same row stride as the Y plane (interleaved Cb/Cr fills the same number of bytes per row; only the height is halved for 4:2:0). Previously create_egl_image() used pitch/2 for all multi-plane formats, which caused the EGL importer to mis-map every chroma sample for NV12. Corrupted Cb/Cr values produce a green-tinted image since the luma-only component of YCbCr is greenish.

pitch/2 is only correct for YUV420's separate U and V planes (each truly half-width). The fix dispatches on fmt_drm_: NV12 → full pitch, YUV420 → half pitch.

https://claude.ai/code/session_01LH94rdjztXGergQJDGJ3sV