### PR TITLE
Add Nebula Edge screen-edge particle effect

### DIFF
--- a/src/app_state.h
+++ b/src/app_state.h
@@ -162,7 +162,7 @@ struct ImuPose {
 // ── Particle effects ──────────────────────────────────────────────────────────
 
 enum class EffectType : uint8_t {
-    None = 0, ArmGlints, CornerDrift, PopupBurst, CompassTurbulence
+    None = 0, ArmGlints, CornerDrift, PopupBurst, CompassTurbulence, NebulaEdge
 };
 enum class EffectPalette : uint8_t {
     Theme = 0, Halo, Solar, Fallout, Space

--- a/src/hud/hud_renderer.cpp
+++ b/src/hud/hud_renderer.cpp
@@ -183,6 +183,7 @@ void HudRenderer::begin_frame(float dt) {
     s_glow_intensity  = cfg_.glow_intensity;
     s_glow_color_base = col_.glow_color;
     fx_tick(dt);
+    fx_tick_lines(dt);
 }
 
 void HudRenderer::render_overlay() {
@@ -1501,6 +1502,121 @@ void HudRenderer::fx_draw(ImDrawList* dl) const {
     }
 }
 
+void HudRenderer::fx_tick_lines(float dt) {
+    if (dt <= 0.f || n_line_particles_ == 0) return;
+    int i = 0;
+    while (i < n_line_particles_) {
+        LineParticle& p = line_particles_[i];
+        p.life -= dt;
+        if (p.life <= 0.f) {
+            line_particles_[i] = line_particles_[--n_line_particles_];
+        } else {
+            p.x     += p.vx * dt;
+            p.y     += p.vy * dt;
+            p.angle += p.angle_drift * dt;
+            ++i;
+        }
+    }
+}
+
+void HudRenderer::fx_emit_line(float x, float y, float vx, float vy,
+                                float life, float len, float angle,
+                                float angle_drift, ImU32 color) {
+    if (n_line_particles_ >= kMaxLineParticles) {
+        line_particles_[0] = { x, y, vx, vy, life, life, len, angle, angle_drift, color };
+        return;
+    }
+    line_particles_[n_line_particles_++] = { x, y, vx, vy, life, life, len, angle, angle_drift, color };
+}
+
+void HudRenderer::fx_draw_lines(ImDrawList* dl) const {
+    for (int i = 0; i < n_line_particles_; ++i) {
+        const LineParticle& p = line_particles_[i];
+        const float frac = p.life / p.life_total;
+        float af;
+        if      (frac > 0.85f) af = (1.f - frac) / 0.15f;  // fade in
+        else if (frac < 0.25f) af = frac / 0.25f;           // fade out
+        else                   af = 1.f;
+        const uint8_t a   = static_cast<uint8_t>(af * 190.f);
+        const ImU32   col = with_alpha(p.color, a);
+        const float   cx  = std::cos(p.angle) * p.len;
+        const float   cy  = std::sin(p.angle) * p.len;
+        dl->AddLine({ p.x - cx, p.y - cy }, { p.x + cx, p.y + cy }, col, 1.4f);
+    }
+}
+
+// Nebula color palette — blue/violet/purple spectrum with occasional pale star
+static const ImU32 kNebulaColors[] = {
+    IM_COL32( 30,  10,  90, 255),   // deep indigo
+    IM_COL32( 60,  30, 180, 255),   // blue-violet
+    IM_COL32( 30, 100, 200, 255),   // steel blue
+    IM_COL32(150, 130, 240, 255),   // pale lavender
+    IM_COL32(200, 200, 255, 255),   // near-white blue
+    IM_COL32(120,  30, 200, 255),   // hot purple
+    IM_COL32( 80,  60, 220, 255),   // periwinkle
+    IM_COL32(  0,  80, 160, 255),   // deep ocean blue
+};
+static constexpr int kNebCount = static_cast<int>(sizeof(kNebulaColors) / sizeof(kNebulaColors[0]));
+
+// Emit nebula-style dot and line particles along all four screen edges.
+void HudRenderer::fx_emit_nebula_edge(float fw, float fh, float dt) {
+    static unsigned rngN = 0x7F3A9B1Cu;
+    auto step  = [&]() -> unsigned {
+        rngN ^= rngN << 13; rngN ^= rngN >> 17; rngN ^= rngN << 5;
+        return rngN;
+    };
+    auto rf    = [&]() { return static_cast<float>(step() & 0xFFFF) / 65535.f; };
+    auto ncol  = [&]() { return kNebulaColors[step() % kNebCount]; };
+
+    const float dot_rate  = 9.0f;   // per edge per second
+    const float line_rate = 3.5f;
+
+    // Each edge described by: spawn origin, along-edge unit vector, inward unit vector,
+    // edge length, and base line-segment angle (parallel to edge).
+    struct EdgeDef {
+        float ox, oy;          // start corner
+        float ax, ay;          // along-edge direction
+        float ix, iy;          // inward-normal direction
+        float edge_len;
+        float seg_angle;       // base orientation for line segments (rad)
+    };
+    static constexpr float kPi = 3.14159265f;
+    const EdgeDef edges[] = {
+        { 0.f,  0.f,  1.f, 0.f,  0.f,  1.f, fw, 0.f            },  // top    → drift down
+        { 0.f,  fh,   1.f, 0.f,  0.f, -1.f, fw, 0.f            },  // bottom → drift up
+        { 0.f,  0.f,  0.f, 1.f,  1.f,  0.f, fh, kPi * 0.5f    },  // left   → drift right
+        { fw,   0.f,  0.f, 1.f, -1.f,  0.f, fh, kPi * 0.5f    },  // right  → drift left
+    };
+
+    for (const auto& e : edges) {
+        // Dot particle
+        if (rf() < dot_rate * dt) {
+            const float t   = rf() * e.edge_len;
+            const float px  = e.ox + e.ax * t;
+            const float py  = e.oy + e.ay * t;
+            const float spd = 5.f + rf() * 18.f;
+            const float vx  = e.ix * spd + e.ax * (rf() - 0.5f) * 8.f;
+            const float vy  = e.iy * spd + e.ay * (rf() - 0.5f) * 8.f;
+            const float sz  = 0.8f + rf() * 2.4f;
+            fx_emit(px, py, vx, vy, 1.6f + rf() * 2.2f, sz, ncol());
+        }
+
+        // Line segment particle
+        if (rf() < line_rate * dt) {
+            const float t     = rf() * e.edge_len;
+            const float px    = e.ox + e.ax * t;
+            const float py    = e.oy + e.ay * t;
+            const float spd   = 3.f + rf() * 12.f;
+            const float vx    = e.ix * spd + e.ax * (rf() - 0.5f) * 6.f;
+            const float vy    = e.iy * spd + e.ay * (rf() - 0.5f) * 6.f;
+            const float len   = 5.f + rf() * 22.f;
+            const float angle = e.seg_angle + (rf() - 0.5f) * 0.45f;
+            const float drift = (rf() - 0.5f) * 0.22f;
+            fx_emit_line(px, py, vx, vy, 2.2f + rf() * 2.5f, len, angle, drift, ncol());
+        }
+    }
+}
+
 // Emit a handful of sparks at random positions along an indicator arm.
 void HudRenderer::fx_emit_arm_glint(float ax, float ay, float dx, float dy,
                                      float diag_len, ImU32 c, float dt) {
@@ -1655,5 +1771,10 @@ void HudRenderer::fx_update(ImDrawList* dl, const AppState& s,
 
     // PopupBurst is event-driven (handled above); no per-frame emission needed.
 
+    if (effect == EffectType::NebulaEdge) {
+        fx_emit_nebula_edge(fw, fh, dt);
+    }
+
     fx_draw(dl);
+    fx_draw_lines(dl);
 }

--- a/src/hud/hud_renderer.h
+++ b/src/hud/hud_renderer.h
@@ -173,14 +173,33 @@ private:
     int       n_particles_ = 0;
     float     fx_prev_heading_ = 0.f;   // for turbulence heading delta
 
+    struct LineParticle {
+        float x, y;
+        float vx, vy;
+        float life;
+        float life_total;
+        float len;          // half-length in pixels
+        float angle;        // orientation in radians
+        float angle_drift;  // rad/s wobble
+        ImU32 color;
+    };
+    static constexpr int kMaxLineParticles = 64;
+    LineParticle  line_particles_[kMaxLineParticles] = {};
+    int           n_line_particles_ = 0;
+
     // Resolve palette → color given current snap
     ImU32 fx_palette_color(const AppState& s) const;
 
     // Low-level pool management
     void  fx_tick(float dt);
+    void  fx_tick_lines(float dt);
     void  fx_emit(float x, float y, float vx, float vy,
                   float life, float size, ImU32 color);
+    void  fx_emit_line(float x, float y, float vx, float vy,
+                       float life, float len, float angle,
+                       float angle_drift, ImU32 color);
     void  fx_draw(ImDrawList* dl) const;
+    void  fx_draw_lines(ImDrawList* dl) const;
 
     // Per-effect emitters (called from fx_update each frame)
     void  fx_emit_arm_glint    (float ax, float ay, float dx, float dy,
@@ -189,6 +208,7 @@ private:
     void  fx_emit_burst        (float cx, float cy, int count, ImU32 c);
     void  fx_emit_turbulence   (float tape_cx, float tape_y,
                                  float tw, float th, ImU32 c, float dt);
+    void  fx_emit_nebula_edge  (float fw, float fh, float dt);
 
     // Master dispatcher — called at end of draw_frame
     void  fx_update(ImDrawList* dl, const AppState& s,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1150,6 +1150,8 @@ static std::vector<MenuItem> build_menu(
                                        [&state]{ return state.effects_cfg.effect == EffectType::PopupBurst;         }),
         leaf_sel("Compass Turbulence", [&state]{ state.effects_cfg.effect = EffectType::CompassTurbulence;  },
                                        [&state]{ return state.effects_cfg.effect == EffectType::CompassTurbulence;  }),
+        leaf_sel("Nebula Edge",        [&state]{ state.effects_cfg.effect = EffectType::NebulaEdge;         },
+                                       [&state]{ return state.effects_cfg.effect == EffectType::NebulaEdge;         }),
         submenu("Color Palette", std::move(fx_palette_menu)),
     };
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds a new **Nebula Edge** effect type (`EffectType::NebulaEdge`) that populates all four screen edges with a blue/violet/purple nebula atmosphere
- Introduces a second particle type — **line segments** — with their own 64-slot pool, angle wobble, and fade-in/fade-out lifecycle (vs the existing dot-only pool)
- Available in the menu under Settings → Effects → **Nebula Edge**; works alongside any Color Palette setting

## How it works

Each frame, four edge emitters (top/bottom/left/right) independently fire:
- **Dot particles** (~9/edge/sec) — small circles (0.8–3.2 px) that drift inward at 5–23 px/s and live 1.6–3.8 s
- **Line segments** (~3.5/edge/sec) — short streaks (10–49 px full length) oriented parallel to the edge ±26°, with slow angular wobble; lifetime 2.2–4.7 s

Line segments use a two-phase alpha curve: fade **in** over the first 15% of their life, then hold full opacity, then fade **out** over the last 25%. This creates an organic "materialising and dissolving" feel rather than a pop-on/fade-off look.

Colors are drawn from a fixed 8-entry nebula palette (deep indigo, blue-violet, steel blue, pale lavender, near-white blue, hot purple, periwinkle, ocean blue) independent of the Color Palette selector, so the nebula look is always self-consistent.

## Files changed

| File | Change |
|------|--------|
| `src/app_state.h` | Added `NebulaEdge` to `EffectType` enum |
| `src/hud/hud_renderer.h` | Added `LineParticle` struct + 64-slot pool; declared `fx_tick_lines`, `fx_emit_line`, `fx_draw_lines`, `fx_emit_nebula_edge` |
| `src/hud/hud_renderer.cpp` | Implemented all four new functions; wired into `begin_frame` (tick) and `fx_update` (emit + draw) |
| `src/main.cpp` | Added "Nebula Edge" menu leaf under Effects |

## Test plan

- [ ] Build succeeds with no new warnings
- [ ] Selecting **Nebula Edge** in the Effects menu shows particles materialising along all four screen edges
- [ ] Particles and line segments drift inward and fade out naturally
- [ ] Switching to another effect (e.g. Arm Glints) immediately stops nebula emission; existing particles drain out
- [ ] Switching effect to None drains all particles without crash
- [ ] No visual regression on other effects (dots-only `fx_draw_lines` call is a no-op when `n_line_particles_ == 0`)
- [ ] Works in both normal and `hud_flip_vertical` orientations

https://claude.ai/code/session_016cRGs2fmvcfrWu3KM8qjZE
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_016cRGs2fmvcfrWu3KM8qjZE)_