### PR TITLE
Add Flip Upside Down option for USB cameras

### DIFF
--- a/src/camera/camera_manager.cpp
+++ b/src/camera/camera_manager.cpp
@@ -128,6 +128,8 @@ bool CameraManager::init(const CamConfig& left, const CamConfig& right,
     usb2_cfg_ = usb2;
     usb1_brightness_ = usb1.brightness;
     usb2_brightness_ = usb2.brightness;
+    usb1_flip_       = usb1.flip;
+    usb2_flip_       = usb2.flip;
 
     // Scan /dev/video0-63 and list non-ISP capture nodes
     std::cerr << "[cam] USB cameras found:\n";
@@ -237,6 +239,7 @@ void CameraManager::usb_capture_thread() {
                        TexSlot& slot, std::atomic<bool>& ok_flag,
                        int& good, int& bad, int& consec,
                        std::atomic<float>& brightness_ref,
+                       std::atomic<bool>& flip_ref,
                        const char* name) -> bool {
         bool got_frame = false;
         {
@@ -247,6 +250,8 @@ void CameraManager::usb_capture_thread() {
                 float b = brightness_ref.load();
                 if (b != 1.0f)
                     frame.convertTo(frame, -1, static_cast<double>(b), 0.0);
+                if (flip_ref.load())
+                    cv::flip(frame, frame, -1);  // -1 = 180° rotation (both axes)
                 cv::cvtColor(frame, rgba, cv::COLOR_BGR2RGBA);
                 got_frame = true;
                 consec = 0;
@@ -281,9 +286,9 @@ void CameraManager::usb_capture_thread() {
 
     while (running_) {
         bool any = capture(usb_cap1_, usb1_cap_mtx_, usb1_slot_, usb1_ok_,
-                           frames1, empty1, consec1, usb1_brightness_, "usb1");
+                           frames1, empty1, consec1, usb1_brightness_, usb1_flip_, "usb1");
         any      |= capture(usb_cap2_, usb2_cap_mtx_, usb2_slot_, usb2_ok_,
-                            frames2, empty2, consec2, usb2_brightness_, "usb2");
+                            frames2, empty2, consec2, usb2_brightness_, usb2_flip_, "usb2");
 
         // Auto-reconnect: periodically reopen disconnected cameras when enabled.
         auto now = std::chrono::steady_clock::now();

--- a/src/camera/camera_manager.h
+++ b/src/camera/camera_manager.h
@@ -36,6 +36,7 @@ struct UsbCamConfig {
     // White balance
     bool  auto_wb           = true;   // false = manual white balance
     int   wb_temp           = 4600;   // 2800-6500 K, used when auto_wb=false
+    bool  flip              = false;  // true = rotate 180° (correct upside-down mount)
 };
 
 // CameraManager owns:
@@ -123,8 +124,8 @@ public:
     void set_usb2_ctrl(uint32_t id, int32_t value);
 
     // ── USB config access (for menu read-back and config-save persistence) ────
-    void                update_usb1_cfg(const UsbCamConfig& c) { usb1_cfg_ = c; }
-    void                update_usb2_cfg(const UsbCamConfig& c) { usb2_cfg_ = c; }
+    void                update_usb1_cfg(const UsbCamConfig& c) { usb1_cfg_ = c; usb1_flip_ = c.flip; }
+    void                update_usb2_cfg(const UsbCamConfig& c) { usb2_cfg_ = c; usb2_flip_ = c.flip; }
     const UsbCamConfig& usb1_cfg() const { return usb1_cfg_; }
     const UsbCamConfig& usb2_cfg() const { return usb2_cfg_; }
 
@@ -169,6 +170,8 @@ private:
 
     std::atomic<float> usb1_brightness_ { 1.0f };
     std::atomic<float> usb2_brightness_ { 1.0f };
+    std::atomic<bool>  usb1_flip_       { false };
+    std::atomic<bool>  usb2_flip_       { false };
 
     std::atomic<bool> running_ { false };
     std::thread       usb_thread_;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -612,6 +612,13 @@ static std::vector<MenuItem> build_menu(
                     *pip_cam1_overlay = false;
                 }
             }),
+        toggle("Flip Upside Down",
+            [cameras]{ return cameras && cameras->usb1_cfg().flip; },
+            [cameras](bool v){
+                if (!cameras) return;
+                UsbCamConfig c = cameras->usb1_cfg(); c.flip = v;
+                cameras->update_usb1_cfg(c);
+            }),
         submenu("Overlay",     std::move(cam1_overlay_menu)),
         submenu("Brightness",  std::move(usb1_brightness_menu)),
         submenu("Exposure",    std::move(usb1_exposure_menu)),
@@ -694,6 +701,13 @@ static std::vector<MenuItem> build_menu(
                     cameras->close_usb2();
                     *pip_cam2_overlay = false;
                 }
+            }),
+        toggle("Flip Upside Down",
+            [cameras]{ return cameras && cameras->usb2_cfg().flip; },
+            [cameras](bool v){
+                if (!cameras) return;
+                UsbCamConfig c = cameras->usb2_cfg(); c.flip = v;
+                cameras->update_usb2_cfg(c);
             }),
         submenu("Overlay",    std::move(cam2_overlay_menu)),
         submenu("Brightness", std::move(usb2_brightness_menu)),
@@ -1628,6 +1642,7 @@ int main(int argc, char* argv[]) {
         usb1_cfg.exposure_time      = j1.value("exposure_time",        157);
         usb1_cfg.auto_wb            = j1.value("auto_wb",              true);
         usb1_cfg.wb_temp            = j1.value("wb_temp",              4600);
+        usb1_cfg.flip               = j1.value("flip",                 false);
     }
     if (jcam.contains("usb_cam_2")) {
         auto& j2 = jcam["usb_cam_2"];
@@ -1641,6 +1656,7 @@ int main(int argc, char* argv[]) {
         usb2_cfg.exposure_time      = j2.value("exposure_time",        157);
         usb2_cfg.auto_wb            = j2.value("auto_wb",              true);
         usb2_cfg.wb_temp            = j2.value("wb_temp",              4600);
+        usb2_cfg.flip               = j2.value("flip",                 false);
     }
 
     HudConfig hud_cfg;
@@ -2465,12 +2481,14 @@ int main(int argc, char* argv[]) {
         cfg["cameras"]["usb_cam_1"]["exposure_time"]     = cameras.usb1_cfg().exposure_time;
         cfg["cameras"]["usb_cam_1"]["auto_wb"]           = cameras.usb1_cfg().auto_wb;
         cfg["cameras"]["usb_cam_1"]["wb_temp"]           = cameras.usb1_cfg().wb_temp;
+        cfg["cameras"]["usb_cam_1"]["flip"]              = cameras.usb1_cfg().flip;
         cfg["cameras"]["usb_cam_2"]["brightness"]        = cameras.usb2_brightness();
         cfg["cameras"]["usb_cam_2"]["dynamic_framerate"] = cameras.usb2_cfg().dynamic_framerate;
         cfg["cameras"]["usb_cam_2"]["auto_exposure"]     = cameras.usb2_cfg().auto_exposure;
         cfg["cameras"]["usb_cam_2"]["exposure_time"]     = cameras.usb2_cfg().exposure_time;
         cfg["cameras"]["usb_cam_2"]["auto_wb"]           = cameras.usb2_cfg().auto_wb;
         cfg["cameras"]["usb_cam_2"]["wb_temp"]           = cameras.usb2_cfg().wb_temp;
+        cfg["cameras"]["usb_cam_2"]["flip"]              = cameras.usb2_cfg().flip;
 
         auto& jm = cfg["menu_style"];
         jm["accent_color"]     = color_to_json(menu.accent_color());


### PR DESCRIPTION
Adds a per-camera flip toggle under Cameras → USB Cam 1/2 → Flip Upside Down. When enabled, each incoming frame is rotated 180° (cv::flip code -1, both axes) in the capture thread before the texture is uploaded, correcting cameras that are physically mounted upside down.

Implementation:
- UsbCamConfig gains a bool flip field (default false)
- CameraManager holds std::atomic<bool> usb1_flip_ / usb2_flip_ so the capture thread can read the setting lock-free; update_usbN_cfg() syncs them
- cv::flip applied after brightness scaling and before BGR→RGBA conversion
- Menu toggle writes through update_usbN_cfg() — takes effect on the next captured frame with no restart required
- flip persisted to config.json alongside the other USB cam fields

https://claude.ai/code/session_016cRGs2fmvcfrWu3KM8qjZE