### PR TITLE
Fix draw order, remove top bar, persist PiP positions

### DIFF
--- a/src/hud/hud_renderer.cpp
+++ b/src/hud/hud_renderer.cpp
@@ -201,21 +201,18 @@ void HudRenderer::draw_frame(const AppState& s, int w, int h) {
 
     const float fw       = static_cast<float>(w);
     const float fh       = static_cast<float>(h);
-    const float th       = static_cast<float>(cfg_.top_bar_height);
     const float ch       = static_cast<float>(cfg_.compass_height);
-    const float mid_h    = fh - th;
     const float c_margin = static_cast<float>(cfg_.compass_bottom_margin);
     const bool  flip     = cfg_.hud_flip_vertical;
 
-    const float bar_y    = flip ? fh - th : 0.f;
-    draw_top_bar(dl, s, fw, bar_y);
+    // Particle/nebula effects drawn first so all HUD chrome renders on top.
+    fx_update(dl, s, fw, fh, frame_dt_);
 
     if (!s.lora_messages.empty()) {
         float pw    = static_cast<float>(cfg_.panel_width);
         float msg_w = std::min(pw, fw / 3.f);
-        // Flipped: messages appear just below the compass at top; normal: just below status bar.
-        float msg_y = flip ? (c_margin + ch) : th;
-        draw_lora_messages(dl, s, { 0.f, msg_y }, msg_w, mid_h);
+        float msg_y = flip ? (c_margin + ch) : 0.f;
+        draw_lora_messages(dl, s, { 0.f, msg_y }, msg_w, fh);
     }
 
     const float cw        = fw / 3.f;
@@ -231,9 +228,6 @@ void HudRenderer::draw_frame(const AppState& s, int w, int h) {
     draw_face_indicator         (dl, s.face, fw, fh);
     draw_clock_indicator        (dl, s,      fw, fh);
     draw_timer_alarm_indicator  (dl, s,      fw, fh);
-
-    // Particle effects drawn on top of all HUD chrome.
-    fx_update(dl, s, fw, fh, frame_dt_);
 }
 
 // ── Shared overlay layout helper ──────────────────────────────────────────────

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -126,6 +126,19 @@ static OverlayConfig::Anchor parse_anchor(const std::string& s) {
     return OverlayConfig::Anchor::TOP_CENTER;
 }
 
+static const char* anchor_to_str(OverlayConfig::Anchor a) {
+    using A = OverlayConfig::Anchor;
+    switch (a) {
+        case A::TOP_LEFT:      return "top_left";
+        case A::TOP_CENTER:    return "top_center";
+        case A::TOP_RIGHT:     return "top_right";
+        case A::BOTTOM_LEFT:   return "bottom_left";
+        case A::BOTTOM_CENTER: return "bottom_center";
+        case A::BOTTOM_RIGHT:  return "bottom_right";
+    }
+    return "top_left";
+}
+
 // ── Color serialization helpers ───────────────────────────────────────────────
 // ImU32 is ABGR: alpha in high byte, red in low byte.
 
@@ -2453,6 +2466,11 @@ int main(int argc, char* argv[]) {
         cfg["clock"]["show_date"]       = state.clock_cfg.show_date;
         cfg["clock"]["font_scale"]      = state.clock_cfg.font_scale;
         cfg["clock"]["manual_offset_s"] = state.clock_cfg.manual_offset_s;
+
+        cfg["pip"]["cam1"]["anchor"] = anchor_to_str(pip_overlay_cfg1.anchor);
+        cfg["pip"]["cam1"]["size"]   = pip_overlay_cfg1.size;
+        cfg["pip"]["cam2"]["anchor"] = anchor_to_str(pip_overlay_cfg2.anchor);
+        cfg["pip"]["cam2"]["size"]   = pip_overlay_cfg2.size;
 
         auto& jpp = cfg["post_process"];
         jpp["edge_enabled"]       = state.pp_cfg.edge_enabled;


### PR DESCRIPTION
Three independent fixes:

1. HUD above nebula: moved fx_update() to the start of draw_frame() so the nebula cloud vignette and comet particles are drawn first into the background DrawList; all HUD chrome (compass, arms, indicators) then renders on top of them.

2. Remove top-bar clock and black bar: removed draw_top_bar() and its backing AddRectFilled slab entirely. The clock shown on the diagonal arm indicator (draw_clock_indicator) remains. LoRa message panel origin adjusted to y=0 now that the bar no longer occupies the top strip.

3. Persist PiP camera overlay positions: added anchor_to_str() helper (inverse of parse_anchor) and write pip.cam1/cam2 anchor + size to config.json on shutdown alongside every other runtime setting. The load path already handled per-camera sub-objects so no load change needed.

https://claude.ai/code/session_016cRGs2fmvcfrWu3KM8qjZE