### PR TITLE
Add adaptive software auto-brightness for USB cameras

### DIFF
--- a/src/camera/camera_manager.cpp
+++ b/src/camera/camera_manager.cpp
@@ -128,8 +128,12 @@ bool CameraManager::init(const CamConfig& left, const CamConfig& right,
     usb2_cfg_ = usb2;
     usb1_brightness_ = usb1.brightness;
     usb2_brightness_ = usb2.brightness;
-    usb1_flip_       = usb1.flip;
-    usb2_flip_       = usb2.flip;
+    usb1_flip_                   = usb1.flip;
+    usb2_flip_                   = usb2.flip;
+    usb1_auto_brightness_        = usb1.auto_brightness;
+    usb1_auto_brightness_target_ = usb1.auto_brightness_target;
+    usb2_auto_brightness_        = usb2.auto_brightness;
+    usb2_auto_brightness_target_ = usb2.auto_brightness_target;
 
     // Scan /dev/video0-63 and list non-ISP capture nodes
     std::cerr << "[cam] USB cameras found:\n";
@@ -228,6 +232,7 @@ void CameraManager::usb_capture_thread() {
     cv::Mat frame, rgba;
     int frames1 = 0, empty1 = 0, consec1 = 0;
     int frames2 = 0, empty2 = 0, consec2 = 0;
+    int luma_tick1 = 0, luma_tick2 = 0;
 
     // Consecutive empty reads before declaring a camera disconnected.
     // At ~30fps with near-instant V4L2 failures this triggers in ~1 s.
@@ -240,6 +245,9 @@ void CameraManager::usb_capture_thread() {
                        int& good, int& bad, int& consec,
                        std::atomic<float>& brightness_ref,
                        std::atomic<bool>& flip_ref,
+                       std::atomic<bool>&  auto_brightness_ref,
+                       std::atomic<float>& auto_brightness_target_ref,
+                       int& luma_tick,
                        const char* name) -> bool {
         bool got_frame = false;
         {
@@ -247,6 +255,20 @@ void CameraManager::usb_capture_thread() {
             if (!cap.isOpened()) { ok_flag = false; return false; }
             cap.read(frame);
             if (!frame.empty()) {
+                // Adaptive luma compensation: sample every 15 frames (~2/sec at 30fps)
+                if (auto_brightness_ref.load() && ++luma_tick >= 15) {
+                    luma_tick = 0;
+                    cv::Scalar m = cv::mean(frame);  // BGR: [0]=B [1]=G [2]=R
+                    float luma = m[2] * 0.299f + m[1] * 0.587f + m[0] * 0.114f;
+                    if (luma > 1.f) {
+                        float target = auto_brightness_target_ref.load();
+                        float ratio  = target / luma;
+                        float cur    = brightness_ref.load();
+                        float next   = cur + (cur * ratio - cur) * 0.15f;
+                        next = std::clamp(next, 0.25f, 4.0f);
+                        brightness_ref.store(next);
+                    }
+                }
                 float b = brightness_ref.load();
                 if (b != 1.0f)
                     frame.convertTo(frame, -1, static_cast<double>(b), 0.0);
@@ -286,9 +308,11 @@ void CameraManager::usb_capture_thread() {
 
     while (running_) {
         bool any = capture(usb_cap1_, usb1_cap_mtx_, usb1_slot_, usb1_ok_,
-                           frames1, empty1, consec1, usb1_brightness_, usb1_flip_, "usb1");
+                           frames1, empty1, consec1, usb1_brightness_, usb1_flip_,
+                           usb1_auto_brightness_, usb1_auto_brightness_target_, luma_tick1, "usb1");
         any      |= capture(usb_cap2_, usb2_cap_mtx_, usb2_slot_, usb2_ok_,
-                            frames2, empty2, consec2, usb2_brightness_, usb2_flip_, "usb2");
+                            frames2, empty2, consec2, usb2_brightness_, usb2_flip_,
+                            usb2_auto_brightness_, usb2_auto_brightness_target_, luma_tick2, "usb2");
 
         // Auto-reconnect: periodically reopen disconnected cameras when enabled.
         auto now = std::chrono::steady_clock::now();

--- a/src/camera/camera_manager.h
+++ b/src/camera/camera_manager.h
@@ -37,6 +37,9 @@ struct UsbCamConfig {
     bool  auto_wb           = true;   // false = manual white balance
     int   wb_temp           = 4600;   // 2800-6500 K, used when auto_wb=false
     bool  flip              = false;  // true = rotate 180° (correct upside-down mount)
+    // Adaptive software brightness compensation
+    bool  auto_brightness        = false; // enable per-frame luma feedback loop
+    float auto_brightness_target = 100.f; // target mean luma 0-255 (default ~39%)
 };
 
 // CameraManager owns:
@@ -124,8 +127,18 @@ public:
     void set_usb2_ctrl(uint32_t id, int32_t value);
 
     // ── USB config access (for menu read-back and config-save persistence) ────
-    void                update_usb1_cfg(const UsbCamConfig& c) { usb1_cfg_ = c; usb1_flip_ = c.flip; }
-    void                update_usb2_cfg(const UsbCamConfig& c) { usb2_cfg_ = c; usb2_flip_ = c.flip; }
+    void update_usb1_cfg(const UsbCamConfig& c) {
+        usb1_cfg_ = c;
+        usb1_flip_                   = c.flip;
+        usb1_auto_brightness_        = c.auto_brightness;
+        usb1_auto_brightness_target_ = c.auto_brightness_target;
+    }
+    void update_usb2_cfg(const UsbCamConfig& c) {
+        usb2_cfg_ = c;
+        usb2_flip_                   = c.flip;
+        usb2_auto_brightness_        = c.auto_brightness;
+        usb2_auto_brightness_target_ = c.auto_brightness_target;
+    }
     const UsbCamConfig& usb1_cfg() const { return usb1_cfg_; }
     const UsbCamConfig& usb2_cfg() const { return usb2_cfg_; }
 
@@ -172,6 +185,10 @@ private:
     std::atomic<float> usb2_brightness_ { 1.0f };
     std::atomic<bool>  usb1_flip_       { false };
     std::atomic<bool>  usb2_flip_       { false };
+    std::atomic<bool>  usb1_auto_brightness_        { false };
+    std::atomic<bool>  usb2_auto_brightness_        { false };
+    std::atomic<float> usb1_auto_brightness_target_ { 100.f };
+    std::atomic<float> usb2_auto_brightness_target_ { 100.f };
 
     std::atomic<bool> running_ { false };
     std::thread       usb_thread_;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -632,6 +632,20 @@ static std::vector<MenuItem> build_menu(
                 UsbCamConfig c = cameras->usb1_cfg(); c.flip = v;
                 cameras->update_usb1_cfg(c);
             }),
+        toggle("Auto Brightness",
+            [cameras]{ return cameras && cameras->usb1_cfg().auto_brightness; },
+            [cameras](bool v){
+                if (!cameras) return;
+                UsbCamConfig c = cameras->usb1_cfg(); c.auto_brightness = v;
+                cameras->update_usb1_cfg(c);
+            }),
+        slider("Brightness Target", 40.f, 220.f, 5.f, "",
+            [cameras]{ return cameras ? cameras->usb1_cfg().auto_brightness_target : 100.f; },
+            [cameras](float v){
+                if (!cameras) return;
+                UsbCamConfig c = cameras->usb1_cfg(); c.auto_brightness_target = v;
+                cameras->update_usb1_cfg(c);
+            }),
         submenu("Overlay",     std::move(cam1_overlay_menu)),
         submenu("Brightness",  std::move(usb1_brightness_menu)),
         submenu("Exposure",    std::move(usb1_exposure_menu)),
@@ -720,6 +734,20 @@ static std::vector<MenuItem> build_menu(
             [cameras](bool v){
                 if (!cameras) return;
                 UsbCamConfig c = cameras->usb2_cfg(); c.flip = v;
+                cameras->update_usb2_cfg(c);
+            }),
+        toggle("Auto Brightness",
+            [cameras]{ return cameras && cameras->usb2_cfg().auto_brightness; },
+            [cameras](bool v){
+                if (!cameras) return;
+                UsbCamConfig c = cameras->usb2_cfg(); c.auto_brightness = v;
+                cameras->update_usb2_cfg(c);
+            }),
+        slider("Brightness Target", 40.f, 220.f, 5.f, "",
+            [cameras]{ return cameras ? cameras->usb2_cfg().auto_brightness_target : 100.f; },
+            [cameras](float v){
+                if (!cameras) return;
+                UsbCamConfig c = cameras->usb2_cfg(); c.auto_brightness_target = v;
                 cameras->update_usb2_cfg(c);
             }),
         submenu("Overlay",    std::move(cam2_overlay_menu)),
@@ -1655,7 +1683,9 @@ int main(int argc, char* argv[]) {
         usb1_cfg.exposure_time      = j1.value("exposure_time",        157);
         usb1_cfg.auto_wb            = j1.value("auto_wb",              true);
         usb1_cfg.wb_temp            = j1.value("wb_temp",              4600);
-        usb1_cfg.flip               = j1.value("flip",                 false);
+        usb1_cfg.flip                    = j1.value("flip",                    false);
+        usb1_cfg.auto_brightness         = j1.value("auto_brightness",         false);
+        usb1_cfg.auto_brightness_target  = j1.value("auto_brightness_target",  100.f);
     }
     if (jcam.contains("usb_cam_2")) {
         auto& j2 = jcam["usb_cam_2"];
@@ -1669,7 +1699,9 @@ int main(int argc, char* argv[]) {
         usb2_cfg.exposure_time      = j2.value("exposure_time",        157);
         usb2_cfg.auto_wb            = j2.value("auto_wb",              true);
         usb2_cfg.wb_temp            = j2.value("wb_temp",              4600);
-        usb2_cfg.flip               = j2.value("flip",                 false);
+        usb2_cfg.flip                    = j2.value("flip",                    false);
+        usb2_cfg.auto_brightness         = j2.value("auto_brightness",         false);
+        usb2_cfg.auto_brightness_target  = j2.value("auto_brightness_target",  100.f);
     }
 
     HudConfig hud_cfg;
@@ -2499,14 +2531,18 @@ int main(int argc, char* argv[]) {
         cfg["cameras"]["usb_cam_1"]["exposure_time"]     = cameras.usb1_cfg().exposure_time;
         cfg["cameras"]["usb_cam_1"]["auto_wb"]           = cameras.usb1_cfg().auto_wb;
         cfg["cameras"]["usb_cam_1"]["wb_temp"]           = cameras.usb1_cfg().wb_temp;
-        cfg["cameras"]["usb_cam_1"]["flip"]              = cameras.usb1_cfg().flip;
+        cfg["cameras"]["usb_cam_1"]["flip"]                   = cameras.usb1_cfg().flip;
+        cfg["cameras"]["usb_cam_1"]["auto_brightness"]        = cameras.usb1_cfg().auto_brightness;
+        cfg["cameras"]["usb_cam_1"]["auto_brightness_target"] = cameras.usb1_cfg().auto_brightness_target;
         cfg["cameras"]["usb_cam_2"]["brightness"]        = cameras.usb2_brightness();
         cfg["cameras"]["usb_cam_2"]["dynamic_framerate"] = cameras.usb2_cfg().dynamic_framerate;
         cfg["cameras"]["usb_cam_2"]["auto_exposure"]     = cameras.usb2_cfg().auto_exposure;
         cfg["cameras"]["usb_cam_2"]["exposure_time"]     = cameras.usb2_cfg().exposure_time;
         cfg["cameras"]["usb_cam_2"]["auto_wb"]           = cameras.usb2_cfg().auto_wb;
         cfg["cameras"]["usb_cam_2"]["wb_temp"]           = cameras.usb2_cfg().wb_temp;
-        cfg["cameras"]["usb_cam_2"]["flip"]              = cameras.usb2_cfg().flip;
+        cfg["cameras"]["usb_cam_2"]["flip"]                   = cameras.usb2_cfg().flip;
+        cfg["cameras"]["usb_cam_2"]["auto_brightness"]        = cameras.usb2_cfg().auto_brightness;
+        cfg["cameras"]["usb_cam_2"]["auto_brightness_target"] = cameras.usb2_cfg().auto_brightness_target;
 
         auto& jm = cfg["menu_style"];
         jm["accent_color"]     = color_to_json(menu.accent_color());


### PR DESCRIPTION
Adds a per-frame luma feedback loop that continuously nudges the existing software brightness multiplier toward a user-configurable target luminance. Enabled per-camera via a new "Auto Brightness" toggle in the USB cam menu.

How it works:
- Every 15 captured frames (~2/sec at 30fps), the capture thread computes the BT.601 weighted mean luma of the BGR frame (cv::mean, ~microseconds).
- If auto_brightness is on, the multiplier is nudged toward target/luma with an exponential step (α=0.15), clamped to [0.25, 4.0].
- Off by default — existing static Brightness presets are unaffected.
- Works on top of hardware AE: if the camera's AE is doing its job the multiplier stays near 1.0; if AE is absent/poor, software compensates.

New config fields (persisted in config.json):
  cameras.usb_cam_1.auto_brightness         (bool, default false)
  cameras.usb_cam_1.auto_brightness_target  (float 40-220, default 100)
  (same for usb_cam_2)

https://claude.ai/code/session_016cRGs2fmvcfrWu3KM8qjZE