### PR TITLE
Add auto Night Vision based on ISP analogue gain

### DIFF
--- a/src/app_state.h
+++ b/src/app_state.h
@@ -133,10 +133,12 @@ struct CameraFocusState {
 };
 
 struct NightVisionState {
-    float exposure_ev   = 0.0f;  // -3.0 to +3.0
-    int   shutter_us    = 33333; // microseconds (40 to 1000000)
-    bool  nv_enabled    = false; // night vision preset active (HUD indicator + apply flag)
-    bool  csi_awb_on    = true;  // CSI camera auto white balance (applies to both OWLsight eyes)
+    float exposure_ev        = 0.0f;  // -3.0 to +3.0
+    int   shutter_us         = 33333; // microseconds (40 to 1000000)
+    bool  nv_enabled         = false; // night vision preset active (HUD indicator + apply flag)
+    bool  csi_awb_on         = true;  // CSI camera auto white balance (applies to both OWLsight eyes)
+    bool  auto_nv            = false; // auto-enable NV when scene is dark
+    float auto_nv_gain_threshold = 4.0f; // AnalogueGain above which auto-NV activates
 };
 
 struct ClockConfig {

--- a/src/camera/dma_camera.cpp
+++ b/src/camera/dma_camera.cpp
@@ -347,6 +347,8 @@ void DmaCamera::on_request_complete(Request* req) {
             last_af_state_.store(meta.get(controls::AfState).value_or(0));
         if (camCtrls.count(&controls::LensPosition))
             last_lens_pos_.store(meta.get(controls::LensPosition).value_or(0.0f));
+        if (camCtrls.count(&controls::AnalogueGain))
+            last_analogue_gain_.store(meta.get(controls::AnalogueGain).value_or(1.0f));
     } catch (...) {}
 
     auto it = req_to_slot_.find(req);

--- a/src/camera/dma_camera.h
+++ b/src/camera/dma_camera.h
@@ -86,9 +86,10 @@ public:
     void set_colour_gains(float rg, float bg);     // raw ISP gains (typically 0.5–4.0)
     void set_colour_temp(int kelvin);              // maps 2800–7500 K → ColourGains LUT
 
-    bool is_ok()  const { return ok_; }
-    int  width()  const { return cfg_.width; }
-    int  height() const { return cfg_.height; }
+    bool  is_ok()           const { return ok_; }
+    int   width()           const { return cfg_.width; }
+    int   height()          const { return cfg_.height; }
+    float analogue_gain()   const { return last_analogue_gain_.load(); }
 
 private:
     enum class SlotState { IDLE, CAPTURING, READY, RENDERING };
@@ -168,6 +169,7 @@ private:
     // ── Latest camera metadata (written by capture thread via atomics) ────────
     std::atomic<int>   last_af_state_      { 0 };        // AfState enum value
     std::atomic<float> last_lens_pos_      { 0.0f };     // LensPosition diopters
+    std::atomic<float> last_analogue_gain_ { 1.0f };     // AnalogueGain (1.0 = ISO100 equiv)
 
     Config cfg_;
     bool   ok_ = false;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -450,6 +450,12 @@ static std::vector<MenuItem> build_menu(
                 state.night_vision.exposure_ev = v ? 3.0f : 0.0f;
                 state.night_vision.shutter_us  = v ? 40000 : 16667;
             }),
+        toggle("Auto Night Vision",
+            [&state]{ return state.night_vision.auto_nv; },
+            [&state](bool v){ state.night_vision.auto_nv = v; }),
+        slider("Auto NV Gain Threshold", 1.5f, 16.f, 0.5f, "x",
+            [&state]{ return state.night_vision.auto_nv_gain_threshold; },
+            [&state](float v){ state.night_vision.auto_nv_gain_threshold = v; }),
         slider("Exposure (EV)", -3.f, 3.f, 0.5f, " EV",
             [&state]{ return state.night_vision.exposure_ev; },
             [&state](float v){ state.night_vision.exposure_ev = v; }),
@@ -1780,8 +1786,10 @@ int main(int argc, char* argv[]) {
 
     if (cfg.contains("night_vision")) {
         auto& jnv = cfg["night_vision"];
-        state.night_vision.exposure_ev = jnv.value("exposure_ev",  0.0f);
-        state.night_vision.shutter_us  = jnv.value("shutter_us",  33333);
+        state.night_vision.exposure_ev            = jnv.value("exposure_ev",             0.0f);
+        state.night_vision.shutter_us             = jnv.value("shutter_us",              33333);
+        state.night_vision.auto_nv                = jnv.value("auto_nv",                 false);
+        state.night_vision.auto_nv_gain_threshold = jnv.value("auto_nv_gain_threshold",  4.0f);
     }
 
     if (cfg.contains("clock")) {
@@ -2334,7 +2342,29 @@ int main(int argc, char* argv[]) {
         {
             static NightVisionState s_last_nv{};
             static bool s_first = true;
-            const auto& nv = snap.night_vision;
+            auto& nv = snap.night_vision;
+
+            // Auto-NV: enable/disable NV based on ISP analogue gain as a dark proxy.
+            // High gain (bright amplification) means the ISP is compensating for low light.
+            if (nv.auto_nv) {
+                float gain_l = cameras.owl_left()  ? cameras.owl_left()->analogue_gain()  : 1.f;
+                float gain_r = cameras.owl_right() ? cameras.owl_right()->analogue_gain() : 1.f;
+                float gain   = std::max(gain_l, gain_r);
+                bool  want   = (gain >= nv.auto_nv_gain_threshold);
+                if (want != nv.nv_enabled) {
+                    std::lock_guard<std::mutex> lk(state.mtx);
+                    state.night_vision.nv_enabled = want;
+                    if (want) {
+                        state.night_vision.exposure_ev = 3.0f;
+                        state.night_vision.shutter_us  = 40000;
+                    } else {
+                        state.night_vision.exposure_ev = 0.0f;
+                        state.night_vision.shutter_us  = 16667;
+                    }
+                    nv = state.night_vision;
+                }
+            }
+
             if (s_first ||
                 nv.nv_enabled  != s_last_nv.nv_enabled  ||
                 nv.exposure_ev != s_last_nv.exposure_ev  ||
@@ -2492,6 +2522,11 @@ int main(int argc, char* argv[]) {
         cfg["hud"]["flip_vertical"]             = hud.config().hud_flip_vertical;
         cfg["hud"]["effects"]["type"]           = static_cast<int>(state.effects_cfg.effect);
         cfg["hud"]["effects"]["palette"]        = static_cast<int>(state.effects_cfg.palette);
+
+        cfg["night_vision"]["exposure_ev"]            = state.night_vision.exposure_ev;
+        cfg["night_vision"]["shutter_us"]             = state.night_vision.shutter_us;
+        cfg["night_vision"]["auto_nv"]                = state.night_vision.auto_nv;
+        cfg["night_vision"]["auto_nv_gain_threshold"] = state.night_vision.auto_nv_gain_threshold;
 
         cfg["clock"]["use_24h"]         = state.clock_cfg.use_24h;
         cfg["clock"]["show_seconds"]    = state.clock_cfg.show_seconds;


### PR DESCRIPTION
When enabled, the render thread reads AnalogueGain from both OWLsight cameras each frame (extracted from libcamera request metadata) and automatically toggles NV mode when the max gain crosses the configurable threshold. NV state and exposure/shutter are updated atomically so the existing apply block picks them up on the same frame. Menu exposes toggle + gain threshold slider; settings persist across restarts.

https://claude.ai/code/session_016cRGs2fmvcfrWu3KM8qjZE