### PR TITLE
Add standalone MP3 player firmware (Pico 2 W + ESP32 bridge)

### DIFF
--- a/firmware/mp3_player/README.md
+++ b/firmware/mp3_player/README.md
@@ -1,0 +1,209 @@
+# ProtoHUD MP3 Player
+
+Standalone embedded MP3/FLAC player using a two-chip design:
+
+| Board | Role |
+|-------|------|
+| **Raspberry Pi Pico 2 W** | Main controller: display, SD, UI, USB file upload, BLE control |
+| **ESP32-WROOM-32** | Bluetooth audio bridge: A2DP source/sink, PCM5102A DAC |
+
+---
+
+## Features
+
+- MP3 and FLAC playback from microSD (FAT32)
+- **USB Mass Storage**: plug in a USB cable → SD card mounts on your computer for drag-and-drop file transfer
+- **Wired headphones**: PCM5102A DAC → 3.5mm jack
+- **BT Headphones (source)**: stream music wirelessly to any A2DP Bluetooth headphone or speaker
+- **BT Receive (sink)**: receive A2DP audio from your phone → play on wired headphones
+- **BLE control**: play/pause, skip, volume, mode change from phone (nRF Connect compatible)
+- **ILI9341 320×240 TFT**: Now Playing, File Browser, Settings, BT Devices screens
+- **ANO Rotary Navigation Encoder**: rotate to scroll/volume, click to select, directional buttons to navigate screens
+- Shuffle, repeat (OFF / ONE / ALL), queue management
+
+---
+
+## Bill of Materials
+
+| Part | Notes |
+|------|-------|
+| Raspberry Pi Pico 2 W | RP2350 + CYW43439, ~$7 |
+| ESP32-WROOM-32 dev board | Any bare ESP32 (not S3/S2), ~$5 |
+| ILI9341 2.8" TFT (320×240) | With SPI interface, ~$8 |
+| Adafruit ANO Rotary Navigation Encoder | Stemma QT, product #6310 |
+| PCM5102A DAC breakout | e.g. HiLetgo PCM5102A, ~$6 |
+| MicroSD breakout (SPI) | Or use the one on the TFT module |
+| MicroSD card | FAT32 formatted |
+| 3.5mm stereo jack | TRRS or TRS |
+| Misc | Dupont wires, breadboard or custom PCB |
+
+---
+
+## Wiring
+
+### Pico 2 W
+
+```
+Pico 2 W GPIO    →  Device
+─────────────────────────────────────────────────────────────────
+GP0  (UART0 TX)  →  ESP32 GPIO3 (U0RXD)      2 Mbps audio bridge
+GP1  (UART0 RX)  →  ESP32 GPIO1 (U0TXD)
+GP4  (I2C0 SDA)  →  ANO Encoder SDA (Stemma QT)
+GP5  (I2C0 SCL)  →  ANO Encoder SCL (Stemma QT)
+GP6  (input)     →  ANO Encoder INT
+GP16 (SPI0 MISO) →  ILI9341 MISO  +  SD MISO
+GP18 (SPI0 SCK)  →  ILI9341 SCK   +  SD SCK
+GP19 (SPI0 MOSI) →  ILI9341 MOSI  +  SD MOSI
+GP17             →  ILI9341 CS
+GP20             →  ILI9341 DC
+GP21             →  ILI9341 RST
+GP22             →  SD card CS
+USB              →  Host computer (USB Mass Storage)
+3V3              →  ANO VIN, ILI9341 VCC, SD VCC
+GND              →  All grounds
+```
+
+> **SPI bus shared**: ILI9341 and SD share MOSI/MISO/SCK. CS pins are separate.
+> The firmware uses `SPI.beginTransaction()` around each access for safe arbitration.
+> Core 1 (audio decode) only touches UART — never SPI.
+
+### ESP32-WROOM-32
+
+```
+ESP32 GPIO  →  Device
+─────────────────────────────────────────────────────────────────
+GPIO3  (U0RXD)  →  Pico GP0 (UART TX)
+GPIO1  (U0TXD)  →  Pico GP1 (UART RX)
+GPIO26          →  PCM5102A BCK
+GPIO25          →  PCM5102A LRCK
+GPIO22          →  PCM5102A DIN
+GPIO27          →  PCM5102A XSMT (mute, active low)
+3V3             →  PCM5102A VCC
+GND             →  PCM5102A GND
+```
+
+### PCM5102A Breakout Wiring
+
+```
+PCM5102A pin  →  Connection
+─────────────────────────────────────────────────────────────────
+VCC           →  3.3 V
+GND           →  GND
+BCK           →  ESP32 GPIO26
+LRCK/WS       →  ESP32 GPIO25
+DIN           →  ESP32 GPIO22
+XSMT          →  ESP32 GPIO27  (drive HIGH to unmute)
+FLT           →  GND  (normal latency filter)
+DEMP          →  GND  (de-emphasis off)
+FMT           →  GND  (I2S standard format)
+SCK           →  GND  (no system clock needed for PCM5102A)
+LINEOUT L/R   →  3.5mm stereo jack tip/ring
+AGND          →  Sleeve of 3.5mm jack
+```
+
+### ANO Encoder (Stemma QT)
+
+Connect via a Stemma QT / QWIIC 4-pin cable to the Pico's I2C0 pins:
+- **VIN** → 3V3
+- **GND** → GND
+- **SDA** → GP4
+- **SCL** → GP5
+- **INT** → GP6 (wire manually from the INT pad on the encoder breakout)
+
+---
+
+## Firmware
+
+Two separate PlatformIO projects, one per chip.
+
+### Building & Flashing
+
+```bash
+# Flash ESP32 bridge (do this first — it's simpler)
+cd firmware/mp3_player/esp32_bridge
+pio run -e esp32bridge -t upload
+
+# Vendor the header-only decoders for Pico
+cd firmware/mp3_player/pico/src/audio/vendor
+# see vendor/README.md for curl commands
+
+# Flash Pico 2 W
+cd firmware/mp3_player/pico
+pio run -e rpipico2w -t upload
+```
+
+### SD Card Preparation
+
+1. Format as FAT32.
+2. Create a `/Music` folder (or any structure — the player scans recursively).
+3. Copy `.mp3` or `.flac` files.
+4. **Eject safely** before unplugging (same as any USB drive).
+
+### USB File Transfer
+
+1. Connect Pico USB to computer. Audio pauses automatically.
+2. SD card appears as a removable drive ("MP3 Player SD Card").
+3. Drag and drop files, create folders, delete unwanted tracks.
+4. Eject the drive. Playback resumes automatically.
+
+---
+
+## UI Navigation
+
+| Encoder Action | Effect |
+|----------------|--------|
+| Rotate CW/CCW  | Scroll list / adjust focused value |
+| Centre press   | Select item / play file |
+| Centre hold    | Play / pause toggle |
+| Up button      | Now Playing screen |
+| Down button    | File Browser screen |
+| Right button   | Settings screen |
+| Left button    | BT Devices screen |
+
+---
+
+## BLE Control (nRF Connect / Custom App)
+
+Connect to `MP3Player` in your BLE scanner.  
+Service UUID: `12340000-5678-1234-5678-1234567890AB`
+
+| Characteristic | UUID suffix | Direction | Values |
+|----------------|-------------|-----------|--------|
+| Play/Pause | `...1001...` | Write | `0x01` play, `0x00` pause |
+| Skip | `...1002...` | Write | `0x01` next, `0xFF` prev |
+| Volume | `...1003...` | Write/Notify | `0`–`100` |
+| Mode | `...1004...` | Write | `0` SD, `1` BT Source, `2` BT Sink |
+| Track Info | `...1005...` | Notify | `title|artist|album|pos_s|dur_s` |
+| Status | `...1006...` | Notify | 2 bytes: `[playing, mode]` |
+
+---
+
+## Bluetooth Audio Notes
+
+- **Source mode** (stream to BT headphones): device advertises as `MP3Player`. Pair your headphones to it. Music streams from SD via the ESP32 A2DP source role.
+- **Sink mode** (receive from phone): device advertises as `MP3Player-In`. Connect from your phone's Bluetooth audio settings (like connecting to a speaker). Audio plays on the wired PCM5102A output.
+- **A2DP source and sink cannot run simultaneously** — switch modes in Settings.
+- Mode switch takes ~1 second (BT stack handoff on ESP32).
+
+---
+
+## Architecture
+
+```
+Pico 2 W (Core 0)              Pico 2 W (Core 1)
+────────────────────────        ──────────────────────────────
+LVGL UI @ ~30 fps               MP3/FLAC decode (minimp3/dr_flac)
+Encoder polling (seesaw)        ↓ 512-sample PCM frames
+BLE GATT server                 UART → ESP32 bridge
+USB MSC (TinyUSB)               @ 2 Mbps (1.4 Mbps audio net)
+Bridge poll (status RX)
+App state machine
+
+                    UART (GP0/GP1, 2 Mbps)
+                           ↕
+ESP32-WROOM (Core 0)                 ESP32-WROOM (Core 1)
+────────────────────────────         ──────────────────────────────
+UART frame handler                   I2S drain task (priority 22)
+BT A2DP source/sink                  Writes PCM ring buffer → I2S
+PCM5102A I2S master                  → PCM5102A → 3.5mm jack
+```

--- a/firmware/mp3_player/esp32_bridge/platformio.ini
+++ b/firmware/mp3_player/esp32_bridge/platformio.ini
@@ -1,0 +1,16 @@
+[env:esp32bridge]
+platform  = espressif32
+board     = esp32dev
+framework = arduino
+
+lib_deps =
+    pschatzmann/ESP32-A2DP @ ^1.8.6
+
+build_flags =
+    -DCORE_DEBUG_LEVEL=1
+    -DCONFIG_BT_CLASSIC_ENABLED=y
+
+board_build.partitions = min_spiffs.csv
+
+monitor_speed = 115200
+monitor_filters = esp32_exception_decoder

--- a/firmware/mp3_player/esp32_bridge/src/bt_audio.cpp
+++ b/firmware/mp3_player/esp32_bridge/src/bt_audio.cpp
@@ -1,0 +1,104 @@
+#include "bt_audio.h"
+#include <Arduino.h>
+#include <cstring>
+
+BtAudio* BtAudio::instance_ = nullptr;
+
+BtAudio::BtAudio(I2sDac& dac) : dac_(dac) {
+    instance_ = this;
+    source_ring_ = xRingbufferCreate(SOURCE_RING_BYTES, RINGBUF_TYPE_BYTEBUF);
+}
+
+bool BtAudio::start_source(const char* name) {
+    if (mode_.load() != BtMode::OFF) return false;
+    a2dp_src_.set_auto_reconnect(false);
+    a2dp_src_.set_on_connection_state_changed(connection_state_cb, this);
+    a2dp_src_.start(name, source_data_cb);
+    mode_.store(BtMode::SOURCE);
+    dac_.unmute();
+    return true;
+}
+
+bool BtAudio::start_sink(const char* name) {
+    if (mode_.load() != BtMode::OFF) return false;
+    a2dp_sink_.set_auto_reconnect(false);
+    a2dp_sink_.set_on_connection_state_changed(connection_state_cb, this);
+    a2dp_sink_.set_stream_reader(sink_data_cb, false);
+    a2dp_sink_.start(name);
+    mode_.store(BtMode::SINK);
+    dac_.unmute();
+    return true;
+}
+
+void BtAudio::stop() {
+    BtMode m = mode_.load();
+    if (m == BtMode::OFF) return;
+
+    dac_.flush_and_mute();
+
+    if (m == BtMode::SOURCE) {
+        a2dp_src_.disconnect();
+        const uint32_t deadline = millis() + 2000;
+        while (a2dp_src_.get_connection_state() != ESP_A2D_CONNECTION_STATE_DISCONNECTED
+               && millis() < deadline) {
+            vTaskDelay(pdMS_TO_TICKS(20));
+        }
+        a2dp_src_.end(false);
+    } else {
+        a2dp_sink_.disconnect();
+        const uint32_t deadline = millis() + 2000;
+        while (a2dp_sink_.get_connection_state() != ESP_A2D_CONNECTION_STATE_DISCONNECTED
+               && millis() < deadline) {
+            vTaskDelay(pdMS_TO_TICKS(20));
+        }
+        a2dp_sink_.end(false);
+    }
+
+    mode_.store(BtMode::OFF);
+    connected_.store(false);
+    vTaskDelay(pdMS_TO_TICKS(600));
+}
+
+void BtAudio::push_source_audio(const uint8_t* pcm, size_t bytes) {
+    if (source_ring_)
+        xRingbufferSend(source_ring_, pcm, bytes, 0);
+}
+
+void BtAudio::peer_name(char out[33]) const {
+    strncpy(out, peer_name_, 32);
+    out[32] = '\0';
+}
+
+// ── Static callbacks ──────────────────────────────────────────────────────────
+
+int32_t BtAudio::source_data_cb(Frame* frame, int32_t frame_count) {
+    if (!instance_ || !instance_->source_ring_) return 0;
+    const size_t wanted = static_cast<size_t>(frame_count) * sizeof(Frame);
+    size_t item_size;
+    void* item = xRingbufferReceiveUpTo(instance_->source_ring_, &item_size,
+                                        0, wanted);
+    if (!item) {
+        // Underrun: send silence.
+        memset(frame, 0, wanted);
+        return frame_count;
+    }
+    const size_t frames_got = item_size / sizeof(Frame);
+    memcpy(frame, item, frames_got * sizeof(Frame));
+    vRingbufferReturnItem(instance_->source_ring_, item);
+    if (frames_got < static_cast<size_t>(frame_count))
+        memset(frame + frames_got, 0, (frame_count - frames_got) * sizeof(Frame));
+    return frame_count;
+}
+
+void BtAudio::sink_data_cb(const uint8_t* data, uint32_t len) {
+    if (instance_)
+        instance_->dac_.write(data, len);
+}
+
+void BtAudio::connection_state_cb(esp_a2d_connection_state_t state, void* obj) {
+    auto* self = static_cast<BtAudio*>(obj);
+    const bool connected = (state == ESP_A2D_CONNECTION_STATE_CONNECTED);
+    self->connected_.store(connected);
+    if (self->on_connection_changed)
+        self->on_connection_changed(connected, nullptr, self->peer_name_);
+}

--- a/firmware/mp3_player/esp32_bridge/src/bt_audio.h
+++ b/firmware/mp3_player/esp32_bridge/src/bt_audio.h
@@ -1,0 +1,69 @@
+#pragma once
+#include <BluetoothA2DPSource.h>
+#include <BluetoothA2DPSink.h>
+#include <atomic>
+#include <functional>
+#include "i2s_dac.h"
+
+enum class BtMode : uint8_t { OFF = 0, SOURCE = 1, SINK = 2 };
+
+// Manages Bluetooth Classic A2DP source and sink.
+// Source mode: streams decoded PCM arriving from Pico (via ring buffer) to BT headphones.
+// Sink  mode:  receives A2DP audio from a phone, writes directly to PCM5102 via I2sDac.
+//
+// A2DP source and sink cannot run simultaneously — call stop() before switching.
+// Full BT stack deinit/reinit takes ~600 ms; this is built into stop().
+
+class BtAudio {
+public:
+    explicit BtAudio(I2sDac& dac);
+
+    // Start advertising as an A2DP source device.
+    bool start_source(const char* name);
+
+    // Start advertising as an A2DP sink device (receives from phone).
+    bool start_sink(const char* name);
+
+    // Orderly shutdown — blocks until BT stack is idle.
+    void stop();
+
+    // Feed PCM audio from the Pico into the source ring buffer.
+    // Called by UartHandler when CMD_AUDIO_FRAME arrives.
+    void push_source_audio(const uint8_t* pcm, size_t bytes);
+
+    BtMode mode()      const { return mode_.load(); }
+    bool   connected() const { return connected_.load(); }
+    int8_t rssi()      const { return rssi_.load(); }
+    void   peer_name(char out[33]) const;
+
+    // Callback invoked on connection state changes.
+    std::function<void(bool connected, const uint8_t* addr, const char* name)> on_connection_changed;
+
+private:
+    // A2DP source data callback — drains source_ring_.
+    static int32_t source_data_cb(Frame* frame, int32_t frame_count);
+
+    // A2DP sink data callback — writes to DAC.
+    static void sink_data_cb(const uint8_t* data, uint32_t len);
+
+    // A2DP connection state callback.
+    static void connection_state_cb(esp_a2d_connection_state_t state, void* obj);
+
+    I2sDac& dac_;
+
+    BluetoothA2DPSource a2dp_src_;
+    BluetoothA2DPSink   a2dp_sink_;
+
+    std::atomic<BtMode> mode_      { BtMode::OFF };
+    std::atomic<bool>   connected_ { false };
+    std::atomic<int8_t> rssi_      { 0 };
+
+    char peer_name_[33] = {};
+
+    // Ring buffer for source audio (filled by Pico UART frames).
+    // ~400 ms of audio at 44100 Hz stereo 16-bit.
+    static constexpr size_t SOURCE_RING_BYTES = 44100 * 4 * 2 / 5;
+    RingbufHandle_t source_ring_ = nullptr;
+
+    static BtAudio* instance_;
+};

--- a/firmware/mp3_player/esp32_bridge/src/i2s_dac.cpp
+++ b/firmware/mp3_player/esp32_bridge/src/i2s_dac.cpp
@@ -1,0 +1,78 @@
+#include "i2s_dac.h"
+#include <Arduino.h>
+#include <driver/gpio.h>
+
+bool I2sDac::begin() {
+    // Configure mute pin — start muted to prevent power-on pop.
+    pinMode(PIN_PCM_XSMT, OUTPUT);
+    digitalWrite(PIN_PCM_XSMT, LOW);
+    muted_ = true;
+
+    const i2s_config_t cfg = {
+        .mode                 = static_cast<i2s_mode_t>(I2S_MODE_MASTER | I2S_MODE_TX),
+        .sample_rate          = 44100,
+        .bits_per_sample      = I2S_BITS_PER_SAMPLE_16BIT,
+        .channel_format       = I2S_CHANNEL_FMT_RIGHT_LEFT,
+        .communication_format = I2S_COMM_FORMAT_STAND_I2S,
+        .intr_alloc_flags     = ESP_INTR_FLAG_LEVEL1,
+        .dma_buf_count        = 8,
+        .dma_buf_len          = 512,
+        .use_apll             = true,
+        .tx_desc_auto_clear   = true,
+        .fixed_mclk           = 0,
+    };
+    const i2s_pin_config_t pins = {
+        .bck_io_num   = PIN_I2S_BCLK,
+        .ws_io_num    = PIN_I2S_LRC,
+        .data_out_num = PIN_I2S_DOUT,
+        .data_in_num  = I2S_PIN_NO_CHANGE,
+    };
+    if (i2s_driver_install(DAC_I2S_PORT, &cfg, 0, nullptr) != ESP_OK) return false;
+    if (i2s_set_pin(DAC_I2S_PORT, &pins) != ESP_OK) return false;
+    i2s_zero_dma_buffer(DAC_I2S_PORT);
+
+    ring_ = xRingbufferCreate(DAC_RING_BUF_BYTES, RINGBUF_TYPE_BYTEBUF);
+    if (!ring_) return false;
+
+    xTaskCreatePinnedToCore(drain_task_fn, "i2s_drain", 4096, this, 22, &drain_task_, 1);
+    return true;
+}
+
+size_t I2sDac::write(const uint8_t* pcm, size_t len) {
+    if (!ring_) return 0;
+    if (xRingbufferSend(ring_, pcm, len, 0) == pdTRUE) return len;
+    return 0;
+}
+
+void I2sDac::mute() {
+    muted_ = true;
+    digitalWrite(PIN_PCM_XSMT, LOW);
+}
+
+void I2sDac::unmute() {
+    muted_ = false;
+    digitalWrite(PIN_PCM_XSMT, HIGH);
+}
+
+void I2sDac::flush_and_mute() {
+    vTaskDelay(pdMS_TO_TICKS(100));
+    mute();
+}
+
+void I2sDac::drain_task_fn(void* param) {
+    auto* self = static_cast<I2sDac*>(param);
+    size_t bytes_written;
+    for (;;) {
+        size_t item_size;
+        void* item = xRingbufferReceiveUpTo(self->ring_, &item_size,
+                                            pdMS_TO_TICKS(20), 2048);
+        if (item) {
+            i2s_write(DAC_I2S_PORT, item, item_size, &bytes_written, portMAX_DELAY);
+            vRingbufferReturnItem(self->ring_, item);
+        } else {
+            // No data: write silence to keep I2S DMA fed and prevent underrun clicks.
+            static const uint8_t silence[256] = {};
+            i2s_write(DAC_I2S_PORT, silence, sizeof(silence), &bytes_written, 0);
+        }
+    }
+}

--- a/firmware/mp3_player/esp32_bridge/src/i2s_dac.h
+++ b/firmware/mp3_player/esp32_bridge/src/i2s_dac.h
@@ -1,0 +1,44 @@
+#pragma once
+#include <driver/i2s.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/ringbuf.h>
+
+// PCM5102A I2S DAC output.
+// I2S port I2S_NUM_0, master transmit, 44100 Hz 16-bit stereo.
+// XSMT pin (mute, active low) driven by mute() / unmute().
+//
+// Thread-safe: write() may be called from the UART handler task or the A2DP
+// sink callback (both on Core 0). I2S DMA feeds from the ring buffer.
+
+static constexpr i2s_port_t DAC_I2S_PORT = I2S_NUM_0;
+static constexpr int PIN_I2S_BCLK = 26;
+static constexpr int PIN_I2S_LRC  = 25;
+static constexpr int PIN_I2S_DOUT = 22;
+static constexpr int PIN_PCM_XSMT = 27;  // HIGH = unmuted, LOW = muted
+
+// Ring buffer holds ~200 ms of 44100 Hz stereo s16le audio before I2S drains it.
+static constexpr size_t DAC_RING_BUF_BYTES = 44100 * 4 / 5;  // 200 ms
+
+class I2sDac {
+public:
+    bool begin();
+
+    // Write raw PCM s16le stereo bytes into the ring buffer.
+    // Returns bytes written (may be less than len if buffer is full).
+    size_t write(const uint8_t* pcm, size_t len);
+
+    void mute();
+    void unmute();
+
+    // Drain remaining ring buffer samples and mute when empty.
+    void flush_and_mute();
+
+    bool is_muted() const { return muted_; }
+
+private:
+    bool         muted_    = true;
+    RingbufHandle_t ring_  = nullptr;
+    TaskHandle_t drain_task_ = nullptr;
+
+    static void drain_task_fn(void* param);
+};

--- a/firmware/mp3_player/esp32_bridge/src/main.cpp
+++ b/firmware/mp3_player/esp32_bridge/src/main.cpp
@@ -1,0 +1,42 @@
+#include <Arduino.h>
+#include "i2s_dac.h"
+#include "bt_audio.h"
+#include "uart_handler.h"
+#include "protocol.h"
+
+static I2sDac       dac;
+static BtAudio      bt(dac);
+static UartHandler  uart(bt, dac);
+
+void setup() {
+    if (!dac.begin()) {
+        // Fatal: I2S init failed — blink LED and halt.
+        pinMode(LED_BUILTIN, OUTPUT);
+        for (;;) {
+            digitalWrite(LED_BUILTIN, !digitalRead(LED_BUILTIN));
+            delay(100);
+        }
+    }
+
+    bt.on_connection_changed = [](bool connected, const uint8_t* /*addr*/, const char* /*name*/) {
+        uart.send_status();
+        if (connected) {
+            uint8_t evt[sizeof(BtEventPayload)] = {};
+            uart.send_frame(RSP_BT_CONNECTED, evt, sizeof(evt));
+        } else {
+            uart.send_frame(RSP_BT_DISCONNECTED, nullptr, 0);
+        }
+    };
+
+    uart.begin();
+
+    // Signal Pico that the bridge is ready with an initial status frame.
+    vTaskDelay(pdMS_TO_TICKS(100));
+    uart.send_status();
+}
+
+void loop() {
+    // All work is done in FreeRTOS tasks; send periodic keepalive status.
+    vTaskDelay(pdMS_TO_TICKS(5000));
+    uart.send_status();
+}

--- a/firmware/mp3_player/esp32_bridge/src/protocol.h
+++ b/firmware/mp3_player/esp32_bridge/src/protocol.h
@@ -1,0 +1,67 @@
+#pragma once
+#include <stdint.h>
+
+// UART bridge between Pico 2 W (main controller) and ESP32 (BT audio bridge).
+// Baud: 2 000 000. All frames: [MAGIC 2B][CMD 1B][LEN 2B (little-endian)][PAYLOAD][CRC16 2B]
+// CRC16-CCITT (poly 0x1021, init 0xFFFF) over CMD + LEN bytes + PAYLOAD bytes.
+// Magic: 0xAA 0x55.
+
+static constexpr uint8_t  FRAME_MAGIC0 = 0xAA;
+static constexpr uint8_t  FRAME_MAGIC1 = 0x55;
+static constexpr uint16_t FRAME_HEADER_LEN = 5;  // magic(2) + cmd(1) + len(2)
+static constexpr uint16_t FRAME_CRC_LEN    = 2;
+static constexpr uint16_t FRAME_OVERHEAD   = FRAME_HEADER_LEN + FRAME_CRC_LEN;
+
+// ── Pico → ESP32 commands ────────────────────────────────────────────────────
+static constexpr uint8_t CMD_PLAY             = 0x01;  // no payload
+static constexpr uint8_t CMD_PAUSE            = 0x02;  // no payload
+static constexpr uint8_t CMD_SET_VOLUME       = 0x03;  // uint8_t vol (0–100)
+static constexpr uint8_t CMD_BT_SOURCE_START  = 0x04;  // char name[32]
+static constexpr uint8_t CMD_BT_SINK_START    = 0x05;  // char name[32]
+static constexpr uint8_t CMD_BT_STOP          = 0x06;  // no payload
+static constexpr uint8_t CMD_BT_CONNECT       = 0x07;  // uint8_t addr[6]
+static constexpr uint8_t CMD_AUDIO_FRAME      = 0x10;  // uint16_t samples + PCM s16le stereo
+static constexpr uint8_t CMD_MUTE             = 0x11;  // uint8_t on (1=mute, 0=unmute)
+
+// ── ESP32 → Pico responses ───────────────────────────────────────────────────
+static constexpr uint8_t RSP_STATUS           = 0x80;  // BtStatusPayload
+static constexpr uint8_t RSP_BT_CONNECTED     = 0x81;  // BtEventPayload
+static constexpr uint8_t RSP_BT_DISCONNECTED  = 0x82;  // no payload
+static constexpr uint8_t RSP_ERROR            = 0x84;  // uint8_t code + char msg[32]
+
+#pragma pack(push, 1)
+struct BtStatusPayload {
+    uint8_t bt_mode;      // 0=off, 1=source, 2=sink
+    uint8_t connected;    // 0/1
+    int8_t  rssi;         // dBm; 0 if not connected
+};
+
+struct BtEventPayload {
+    uint8_t addr[6];
+    char    name[32];
+};
+
+struct ErrorPayload {
+    uint8_t code;
+    char    msg[32];
+};
+#pragma pack(pop)
+
+// Maximum audio payload: 512 stereo samples × 4 bytes (s16le L+R) = 2048 bytes
+static constexpr uint16_t AUDIO_SAMPLES_PER_FRAME = 512;
+static constexpr uint16_t AUDIO_BYTES_PER_FRAME   = AUDIO_SAMPLES_PER_FRAME * 4;
+
+// CRC16-CCITT (poly 0x1021, init 0xFFFF)
+inline uint16_t crc16_update(uint16_t crc, uint8_t byte) {
+    crc ^= static_cast<uint16_t>(byte) << 8;
+    for (int i = 0; i < 8; ++i)
+        crc = (crc & 0x8000) ? (crc << 1) ^ 0x1021 : crc << 1;
+    return crc;
+}
+
+inline uint16_t crc16(const uint8_t* data, uint16_t len) {
+    uint16_t crc = 0xFFFF;
+    for (uint16_t i = 0; i < len; ++i)
+        crc = crc16_update(crc, data[i]);
+    return crc;
+}

--- a/firmware/mp3_player/esp32_bridge/src/uart_handler.cpp
+++ b/firmware/mp3_player/esp32_bridge/src/uart_handler.cpp
@@ -1,0 +1,171 @@
+#include "uart_handler.h"
+#include <cstring>
+
+UartHandler::UartHandler(BtAudio& bt, I2sDac& dac) : bt_(bt), dac_(dac) {
+    tx_mtx_ = xSemaphoreCreateMutex();
+}
+
+void UartHandler::begin() {
+    Serial.begin(BRIDGE_BAUD);
+    xTaskCreatePinnedToCore(uart_task, "uart_rx", 8192, this, 10, &task_, 0);
+}
+
+void UartHandler::send_frame(uint8_t cmd, const uint8_t* payload, uint16_t len) {
+    uint8_t header[FRAME_HEADER_LEN];
+    header[0] = FRAME_MAGIC0;
+    header[1] = FRAME_MAGIC1;
+    header[2] = cmd;
+    header[3] = len & 0xFF;
+    header[4] = (len >> 8) & 0xFF;
+
+    // CRC over cmd, len bytes, and payload.
+    uint16_t crc = 0xFFFF;
+    crc = crc16_update(crc, cmd);
+    crc = crc16_update(crc, header[3]);
+    crc = crc16_update(crc, header[4]);
+    for (uint16_t i = 0; i < len; ++i)
+        crc = crc16_update(crc, payload[i]);
+
+    uint8_t crc_bytes[2] = { static_cast<uint8_t>(crc & 0xFF),
+                              static_cast<uint8_t>((crc >> 8) & 0xFF) };
+
+    xSemaphoreTake(tx_mtx_, portMAX_DELAY);
+    Serial.write(header, FRAME_HEADER_LEN);
+    if (len > 0) Serial.write(payload, len);
+    Serial.write(crc_bytes, 2);
+    xSemaphoreGive(tx_mtx_);
+}
+
+void UartHandler::send_status() {
+    BtStatusPayload p;
+    p.bt_mode  = static_cast<uint8_t>(bt_.mode());
+    p.connected = bt_.connected() ? 1 : 0;
+    p.rssi      = bt_.rssi();
+    send_frame(RSP_STATUS, reinterpret_cast<uint8_t*>(&p), sizeof(p));
+}
+
+void UartHandler::uart_task(void* param) {
+    auto* self = static_cast<UartHandler*>(param);
+    for (;;) {
+        self->read_frame();
+        taskYIELD();
+    }
+}
+
+bool UartHandler::read_frame() {
+    // Fill buffer byte by byte until we have a complete frame.
+    while (Serial.available()) {
+        uint8_t b = Serial.read();
+
+        // Scan for magic header.
+        if (rx_pos_ == 0 && b != FRAME_MAGIC0) continue;
+        if (rx_pos_ == 1 && b != FRAME_MAGIC1) { rx_pos_ = 0; continue; }
+
+        if (rx_pos_ < RX_BUF)
+            rx_buf_[rx_pos_++] = b;
+
+        // Need at least the full header (5 bytes) to know payload length.
+        if (rx_pos_ < FRAME_HEADER_LEN) continue;
+
+        const uint16_t payload_len = rx_buf_[3] | (static_cast<uint16_t>(rx_buf_[4]) << 8);
+        const uint16_t total       = FRAME_HEADER_LEN + payload_len + FRAME_CRC_LEN;
+
+        if (payload_len > AUDIO_BYTES_PER_FRAME + 2) {
+            // Implausible length — reset.
+            rx_pos_ = 0;
+            continue;
+        }
+
+        if (rx_pos_ < total) continue;
+
+        // Verify CRC.
+        const uint8_t* payload = rx_buf_ + FRAME_HEADER_LEN;
+        const uint16_t rx_crc  = rx_buf_[total - 2] |
+                                  (static_cast<uint16_t>(rx_buf_[total - 1]) << 8);
+        uint16_t calc_crc = 0xFFFF;
+        calc_crc = crc16_update(calc_crc, rx_buf_[2]);  // cmd
+        calc_crc = crc16_update(calc_crc, rx_buf_[3]);  // len lo
+        calc_crc = crc16_update(calc_crc, rx_buf_[4]);  // len hi
+        for (uint16_t i = 0; i < payload_len; ++i)
+            calc_crc = crc16_update(calc_crc, payload[i]);
+
+        if (calc_crc == rx_crc)
+            process_frame(rx_buf_[2], payload, payload_len);
+
+        rx_pos_ = 0;
+        return true;
+    }
+    return false;
+}
+
+void UartHandler::process_frame(uint8_t cmd, const uint8_t* payload, uint16_t len) {
+    switch (cmd) {
+    case CMD_PLAY:
+        dac_.unmute();
+        break;
+
+    case CMD_PAUSE:
+        dac_.flush_and_mute();
+        break;
+
+    case CMD_SET_VOLUME:
+        if (len >= 1) {
+            // Volume 0–100 mapped to AVRC absolute volume 0–127.
+            uint8_t vol = payload[0];
+            if (bt_.mode() == BtMode::SOURCE)
+                bt_.a2dp_src_.set_volume(vol * 127 / 100);
+        }
+        break;
+
+    case CMD_BT_SOURCE_START: {
+        char name[33] = "MP3Player";
+        if (len > 0) {
+            memcpy(name, payload, len < 32 ? len : 32);
+            name[len < 32 ? len : 32] = '\0';
+        }
+        bt_.start_source(name);
+        send_status();
+        break;
+    }
+
+    case CMD_BT_SINK_START: {
+        char name[33] = "MP3Player-In";
+        if (len > 0) {
+            memcpy(name, payload, len < 32 ? len : 32);
+            name[len < 32 ? len : 32] = '\0';
+        }
+        bt_.start_sink(name);
+        send_status();
+        break;
+    }
+
+    case CMD_BT_STOP:
+        bt_.stop();
+        send_status();
+        break;
+
+    case CMD_AUDIO_FRAME:
+        if (len >= 2) {
+            // First 2 bytes: sample count (little-endian); remainder: PCM data.
+            const uint16_t samples = payload[0] | (static_cast<uint16_t>(payload[1]) << 8);
+            const size_t   pcm_len = static_cast<size_t>(samples) * 4;
+            if (len >= 2 + pcm_len) {
+                // Write to DAC ring buffer (wired) and BT source ring buffer.
+                dac_.write(payload + 2, pcm_len);
+                if (bt_.mode() == BtMode::SOURCE)
+                    bt_.push_source_audio(payload + 2, pcm_len);
+            }
+        }
+        break;
+
+    case CMD_MUTE:
+        if (len >= 1 && payload[0])
+            dac_.mute();
+        else
+            dac_.unmute();
+        break;
+
+    default:
+        break;
+    }
+}

--- a/firmware/mp3_player/esp32_bridge/src/uart_handler.h
+++ b/firmware/mp3_player/esp32_bridge/src/uart_handler.h
@@ -1,0 +1,39 @@
+#pragma once
+#include <Arduino.h>
+#include "protocol.h"
+#include "bt_audio.h"
+#include "i2s_dac.h"
+
+static constexpr uint32_t BRIDGE_BAUD = 2000000;
+
+// Receives framed commands from Pico over Serial (UART0) at 2 Mbps.
+// Sends status frames back to Pico.
+// All parsing happens in the uart_task FreeRTOS task on Core 0.
+
+class UartHandler {
+public:
+    UartHandler(BtAudio& bt, I2sDac& dac);
+
+    void begin();
+
+    // Send a response frame to Pico.
+    void send_frame(uint8_t cmd, const uint8_t* payload, uint16_t len);
+    void send_status();
+
+    static void uart_task(void* param);
+
+private:
+    void process_frame(uint8_t cmd, const uint8_t* payload, uint16_t len);
+    bool read_frame();
+
+    BtAudio& bt_;
+    I2sDac&  dac_;
+
+    // Parse state machine buffer.
+    static constexpr size_t RX_BUF = AUDIO_BYTES_PER_FRAME + FRAME_OVERHEAD + 2;
+    uint8_t  rx_buf_[RX_BUF];
+    size_t   rx_pos_ = 0;
+
+    TaskHandle_t task_ = nullptr;
+    SemaphoreHandle_t tx_mtx_ = nullptr;
+};

--- a/firmware/mp3_player/pico/include/lv_conf.h
+++ b/firmware/mp3_player/pico/include/lv_conf.h
@@ -1,0 +1,62 @@
+#if 1  /* Guard: set to 1 to enable this file */
+
+#ifndef LV_CONF_H
+#define LV_CONF_H
+
+#include <stdint.h>
+
+#define LV_COLOR_DEPTH     16
+#define LV_COLOR_16_SWAP   1   /* ILI9341 uses big-endian; TFT_eSPI swaps for us */
+
+#define LV_MEM_CUSTOM      0
+#define LV_MEM_SIZE        (48U * 1024U)  /* 48 KB from SRAM */
+
+#define LV_DISP_DEF_REFR_PERIOD  33  /* ~30 fps */
+#define LV_INDEV_DEF_READ_PERIOD 30
+
+#define LV_USE_PERF_MONITOR 0
+#define LV_USE_MEM_MONITOR  0
+
+/* Font: only embed what we need to save flash */
+#define LV_FONT_MONTSERRAT_12  1
+#define LV_FONT_MONTSERRAT_14  1
+#define LV_FONT_MONTSERRAT_18  1
+#define LV_FONT_MONTSERRAT_24  1
+#define LV_FONT_DEFAULT        &lv_font_montserrat_14
+
+/* Widgets */
+#define LV_USE_ARC        1
+#define LV_USE_BAR        1
+#define LV_USE_BTN        1
+#define LV_USE_BTNMATRIX  0
+#define LV_USE_CANVAS     0
+#define LV_USE_CHECKBOX   1
+#define LV_USE_DROPDOWN   1
+#define LV_USE_IMG        0
+#define LV_USE_LABEL      1
+#define LV_USE_LINE       1
+#define LV_USE_ROLLER     0
+#define LV_USE_SLIDER     1
+#define LV_USE_SWITCH     1
+#define LV_USE_TEXTAREA   1
+#define LV_USE_TABLE      0
+#define LV_USE_LIST       1
+#define LV_USE_METER      0
+#define LV_USE_MSGBOX     0
+#define LV_USE_SPINBOX    0
+#define LV_USE_SPINNER    1
+#define LV_USE_TABVIEW    0
+#define LV_USE_TILEVIEW   0
+#define LV_USE_WIN        0
+#define LV_USE_SPAN       0
+
+/* Layout */
+#define LV_USE_FLEX  1
+#define LV_USE_GRID  0
+
+/* Logging */
+#define LV_USE_LOG     0
+#define LV_USE_ASSERT  0
+
+#endif /* LV_CONF_H */
+#endif /* Guard */

--- a/firmware/mp3_player/pico/include/pins.h
+++ b/firmware/mp3_player/pico/include/pins.h
@@ -1,0 +1,24 @@
+#pragma once
+
+// ── SPI0 (shared: ILI9341 display + SD card) ─────────────────────────────────
+static constexpr int PIN_SPI_MOSI  = 19;
+static constexpr int PIN_SPI_SCK   = 18;
+static constexpr int PIN_SPI_MISO  = 16;
+static constexpr int PIN_TFT_CS    = 17;
+static constexpr int PIN_TFT_DC    = 20;
+static constexpr int PIN_TFT_RST   = 21;
+static constexpr int PIN_SD_CS     = 22;
+
+// ── I2C0 (ANO Rotary Navigation Encoder via Stemma QT) ───────────────────────
+static constexpr int PIN_I2C_SDA   =  4;
+static constexpr int PIN_I2C_SCL   =  5;
+static constexpr int PIN_ANO_INT   =  6;  // active-low interrupt
+static constexpr int ANO_I2C_ADDR  = 0x49;
+
+// ── UART0 (ESP32 bridge, 2 Mbps) ─────────────────────────────────────────────
+static constexpr int PIN_UART_TX   =  0;  // Pico TX → ESP32 RX (GPIO3)
+static constexpr int PIN_UART_RX   =  1;  // Pico RX ← ESP32 TX (GPIO1)
+
+// ── Miscellaneous ─────────────────────────────────────────────────────────────
+// Pico 2 W built-in LED is on the CYW43 GPIO, not a direct pin.
+// Use the Arduino-Pico LED_BUILTIN define (maps to CYW43_WL_GPIO_LED_PIN).

--- a/firmware/mp3_player/pico/platformio.ini
+++ b/firmware/mp3_player/pico/platformio.ini
@@ -1,0 +1,34 @@
+[env:rpipico2w]
+platform  = https://github.com/earlephilhower/arduino-pico/releases/download/global/package_rp2040_index.json
+board     = rpipico2w
+framework = arduino
+
+lib_deps =
+    Bodmer/TFT_eSPI @ ^2.5.43
+    lvgl/lvgl @ ^8.3.11
+    adafruit/Adafruit seesaw Library @ ^1.7.5
+    adafruit/Adafruit BusIO @ ^1.14.5
+
+build_flags =
+    ; TFT_eSPI ILI9341 config
+    -DUSER_SETUP_LOADED
+    -DILI9341_DRIVER
+    -DTFT_MOSI=19
+    -DTFT_SCLK=18
+    -DTFT_MISO=16
+    -DTFT_CS=17
+    -DTFT_DC=20
+    -DTFT_RST=21
+    -DTFT_BL=-1
+    -DSPI_FREQUENCY=40000000
+    -DSPI_READ_FREQUENCY=20000000
+    ; LVGL
+    -DLV_CONF_INCLUDE_SIMPLE
+    -DLV_COLOR_DEPTH=16
+    ; TinyUSB for USB Mass Storage
+    -DUSE_TINYUSB
+
+board_build.core   = earlephilhower
+board_build.f_cpu  = 150000000L
+
+monitor_speed = 115200

--- a/firmware/mp3_player/pico/src/app_state.h
+++ b/firmware/mp3_player/pico/src/app_state.h
@@ -1,0 +1,68 @@
+#pragma once
+#include <pico/mutex.h>
+#include <atomic>
+#include <cstdint>
+#include <cstring>
+
+enum class AppMode : uint8_t {
+    SD_PLAYBACK = 0,
+    BT_SOURCE,      // stream decoded SD audio to BT headphones via ESP32
+    BT_SINK,        // receive A2DP from phone → PCM5102 via ESP32
+    USB_MSC,        // SD card presented as USB mass storage
+    SETTINGS,
+};
+
+enum class RepeatMode : uint8_t { OFF = 0, ONE, ALL };
+
+struct TrackInfo {
+    char    path[256]    = {};
+    char    title[128]   = {};
+    char    artist[128]  = {};
+    char    album[128]   = {};
+    uint32_t duration_s  = 0;
+    uint32_t position_s  = 0;
+};
+
+struct PlaybackState {
+    bool       playing   = false;
+    bool       shuffled  = false;
+    RepeatMode repeat    = RepeatMode::OFF;
+    uint8_t    volume    = 80;
+    TrackInfo  current;
+    uint16_t   queue_index = 0;
+    uint16_t   queue_total = 0;
+};
+
+struct BtBridgeState {
+    bool    source_connected = false;
+    bool    sink_connected   = false;
+    char    peer_name[33]    = {};
+    int8_t  rssi             = 0;
+    bool    bridge_ready     = false;
+};
+
+// Shared state accessed by both cores and all tasks.
+// Hot-path fields use std::atomic; multi-field reads use the pico mutex.
+struct AppState {
+    mutex_t mtx;
+
+    std::atomic<AppMode>  mode          { AppMode::SD_PLAYBACK };
+    std::atomic<AppMode>  requested_mode{ AppMode::SD_PLAYBACK };
+    std::atomic<bool>     mode_switch_pending { false };
+
+    // Playback (guard with mtx for multi-field reads)
+    PlaybackState  playback;
+    BtBridgeState  bt;
+
+    bool sd_mounted = false;
+    bool usb_active = false;
+
+    void init() { mutex_init(&mtx); }
+};
+
+struct AppLock {
+    explicit AppLock(AppState& s) : s_(s) { mutex_enter_blocking(&s_.mtx); }
+    ~AppLock()                             { mutex_exit(&s_.mtx); }
+private:
+    AppState& s_;
+};

--- a/firmware/mp3_player/pico/src/audio/sd_player.cpp
+++ b/firmware/mp3_player/pico/src/audio/sd_player.cpp
@@ -1,0 +1,220 @@
+#include "sd_player.h"
+#include <pico/mutex.h>
+#include <cstring>
+#include <cctype>
+
+// minimp3 — header-only MP3 decoder (vendored).
+#define MINIMP3_IMPLEMENTATION
+#define MINIMP3_ONLY_MP3
+#include "vendor/minimp3_ex.h"
+
+// dr_flac — header-only FLAC decoder (vendored).
+#define DR_FLAC_IMPLEMENTATION
+#define DR_FLAC_NO_STDIO
+#include "vendor/dr_flac.h"
+
+SdPlayer::SdPlayer(AppState& state) : state_(state) {
+    mutex_init(&queue_mtx_);
+}
+
+void SdPlayer::run() {
+    for (;;) {
+        if (!playing_.load()) {
+            sleep_ms(10);
+            continue;
+        }
+
+        // Reload queue if requested from Core 0.
+        if (queue_dirty_.load()) {
+            queue_dirty_.store(false);
+            // queue_ was updated under queue_mtx_ by load_queue().
+        }
+
+        if (queue_.empty()) {
+            playing_.store(false);
+            sleep_ms(10);
+            continue;
+        }
+
+        const std::string path = queue_.current();
+        if (open_track(path)) {
+            // Identify format by extension.
+            const char* ext = strrchr(path.c_str(), '.');
+            bool is_flac = ext && (strcasecmp(ext, ".flac") == 0);
+
+            File f = SD.open(path.c_str(), FILE_READ);
+            if (!f) { queue_.next(state_.playback.repeat); continue; }
+
+            if (is_flac) decode_flac(f);
+            else         decode_mp3(f);
+            f.close();
+        }
+
+        if (stop_req_.load())   { stop_req_.store(false); playing_.store(false); continue; }
+        if (skip_next_.load())  { skip_next_.store(false); }
+        if (skip_prev_.load())  { skip_prev_.store(false); queue_.prev(); queue_.prev(); }
+
+        // Advance queue on natural end-of-track.
+        if (!queue_.next(state_.playback.repeat))
+            playing_.store(false);
+    }
+}
+
+void SdPlayer::decode_mp3(File& f) {
+    mp3dec_t dec;
+    mp3dec_init(&dec);
+
+    static uint8_t  file_buf[16384];
+    static int16_t  pcm_buf[DECODE_BUF_SAMPLES];
+    size_t buf_filled = 0;
+
+    for (;;) {
+        if (stop_req_.load() || skip_next_.load() || skip_prev_.load()) break;
+
+        if (!playing_.load()) { sleep_ms(5); continue; }
+
+        // Refill file buffer.
+        const size_t space = sizeof(file_buf) - buf_filled;
+        if (space > 0 && f.available()) {
+            const size_t got = f.read(file_buf + buf_filled, space);
+            buf_filled += got;
+        }
+        if (buf_filled == 0) break;  // EOF
+
+        mp3dec_frame_info_t info;
+        const int samples = mp3dec_decode_frame(&dec, file_buf, static_cast<int>(buf_filled),
+                                                 pcm_buf, &info);
+        if (info.frame_bytes == 0) break;  // sync error / EOF
+        buf_filled -= info.frame_bytes;
+        memmove(file_buf, file_buf + info.frame_bytes, buf_filled);
+
+        if (samples > 0) {
+            apply_volume(pcm_buf, static_cast<size_t>(samples) * info.channels);
+            if (on_pcm_frame) on_pcm_frame(pcm_buf, static_cast<size_t>(samples));
+        }
+
+        // Update position.
+        if (info.hz > 0 && samples > 0) {
+            mutex_enter_blocking(&state_.mtx);
+            state_.playback.current.position_s =
+                state_.playback.current.position_s + samples / info.hz;
+            mutex_exit(&state_.mtx);
+        }
+    }
+}
+
+// dr_flac read/seek callbacks backed by Arduino SD File.
+static size_t drflac_read_cb(void* ud, void* out, size_t bytes) {
+    return static_cast<File*>(ud)->read(static_cast<uint8_t*>(out), bytes);
+}
+static drflac_bool32 drflac_seek_cb(void* ud, int offset, drflac_seek_origin origin) {
+    auto* f = static_cast<File*>(ud);
+    if (origin == drflac_seek_origin_start) return f->seek(offset) ? DRFLAC_TRUE : DRFLAC_FALSE;
+    return f->seek(f->position() + offset) ? DRFLAC_TRUE : DRFLAC_FALSE;
+}
+
+void SdPlayer::decode_flac(File& f) {
+    drflac* pFlac = drflac_open(drflac_read_cb, drflac_seek_cb, &f, nullptr);
+    if (!pFlac) return;
+
+    static int16_t pcm_buf[DECODE_BUF_SAMPLES];
+    constexpr drflac_uint64 CHUNK = DECODE_BUF_SAMPLES / 2;  // sample pairs
+
+    for (;;) {
+        if (stop_req_.load() || skip_next_.load() || skip_prev_.load()) break;
+        if (!playing_.load()) { sleep_ms(5); continue; }
+
+        const drflac_uint64 got = drflac_read_pcm_frames_s16(pFlac, CHUNK, pcm_buf);
+        if (got == 0) break;
+
+        apply_volume(pcm_buf, static_cast<size_t>(got) * pFlac->channels);
+        if (on_pcm_frame) on_pcm_frame(pcm_buf, static_cast<size_t>(got));
+
+        mutex_enter_blocking(&state_.mtx);
+        if (pFlac->sampleRate > 0)
+            state_.playback.current.position_s += static_cast<uint32_t>(got / pFlac->sampleRate);
+        mutex_exit(&state_.mtx);
+    }
+    drflac_close(pFlac);
+}
+
+bool SdPlayer::open_track(const std::string& path) {
+    TrackInfo info;
+    strncpy(info.path, path.c_str(), sizeof(info.path) - 1);
+    read_tags(path, info);
+
+    mutex_enter_blocking(&state_.mtx);
+    state_.playback.current = info;
+    state_.playback.queue_index = static_cast<uint16_t>(queue_.current_index());
+    mutex_exit(&state_.mtx);
+
+    if (on_track_changed) on_track_changed(info);
+    return SD.exists(path.c_str());
+}
+
+void SdPlayer::apply_volume(int16_t* pcm, size_t samples) {
+    const uint8_t vol = volume_.load();
+    if (vol >= 100) return;
+    for (size_t i = 0; i < samples; ++i)
+        pcm[i] = static_cast<int16_t>(static_cast<int32_t>(pcm[i]) * vol / 100);
+}
+
+void SdPlayer::read_tags(const std::string& path, TrackInfo& out) {
+    // Minimal ID3v1 (last 128 bytes of file): TAG + 30-byte title + 30-byte artist + ...
+    File f = SD.open(path.c_str(), FILE_READ);
+    if (!f) return;
+    const size_t fsize = f.size();
+    if (fsize >= 128) {
+        f.seek(fsize - 128);
+        uint8_t tag[128];
+        f.read(tag, 128);
+        if (tag[0] == 'T' && tag[1] == 'A' && tag[2] == 'G') {
+            memcpy(out.title,  tag +  3, 30);  out.title[30]  = '\0';
+            memcpy(out.artist, tag + 33, 30);  out.artist[30] = '\0';
+            memcpy(out.album,  tag + 63, 30);  out.album[30]  = '\0';
+        }
+    }
+    f.close();
+
+    // Fallback: use filename stripped of extension as title.
+    if (out.title[0] == '\0') {
+        const char* slash = strrchr(path.c_str(), '/');
+        const char* name  = slash ? slash + 1 : path.c_str();
+        const char* dot   = strrchr(name, '.');
+        const size_t len  = dot ? static_cast<size_t>(dot - name) : strlen(name);
+        strncpy(out.title, name, len < sizeof(out.title) - 1 ? len : sizeof(out.title) - 1);
+    }
+}
+
+// ── Thread-safe controls ──────────────────────────────────────────────────────
+
+void SdPlayer::play()   { playing_.store(true); }
+void SdPlayer::pause()  { playing_.store(false); }
+void SdPlayer::toggle() { playing_.store(!playing_.load()); }
+void SdPlayer::stop()   { stop_req_.store(true); playing_.store(false); }
+
+void SdPlayer::skip_next() { skip_next_.store(true); }
+void SdPlayer::skip_prev() { skip_prev_.store(true); }
+
+void SdPlayer::set_volume(uint8_t vol) {
+    volume_.store(vol > 100 ? 100 : vol);
+    mutex_enter_blocking(&state_.mtx);
+    state_.playback.volume = volume_.load();
+    mutex_exit(&state_.mtx);
+}
+
+void SdPlayer::load_queue(TrackQueue q, bool play_immediately) {
+    mutex_enter_blocking(&queue_mtx_);
+    queue_ = std::move(q);
+    queue_dirty_.store(true);
+    mutex_exit(&queue_mtx_);
+    if (play_immediately) play();
+}
+
+void SdPlayer::jump_to(size_t index) {
+    mutex_enter_blocking(&queue_mtx_);
+    queue_.jump(index);
+    queue_dirty_.store(true);
+    mutex_exit(&queue_mtx_);
+    skip_next_.store(true);
+}

--- a/firmware/mp3_player/pico/src/audio/sd_player.h
+++ b/firmware/mp3_player/pico/src/audio/sd_player.h
@@ -1,0 +1,65 @@
+#pragma once
+#include <SD.h>
+#include <string>
+#include <functional>
+#include <atomic>
+#include "track_queue.h"
+#include "../app_state.h"
+
+// MP3/FLAC decoder running on Core 1.
+// Reads compressed audio from SD, decodes frame-by-frame, and calls
+// on_pcm_frame() with raw s16le stereo PCM for the bridge to forward to ESP32.
+//
+// Uses minimp3 (header-only) for MP3 and dr_flac (header-only) for FLAC.
+// Both are vendored in src/audio/vendor/.
+
+class SdPlayer {
+public:
+    explicit SdPlayer(AppState& state);
+
+    // Called once from setup1() on Core 1 — does not return.
+    void run();
+
+    // Thread-safe controls (called from Core 0 tasks).
+    void play();
+    void pause();
+    void toggle();
+    void stop();
+    void skip_next();
+    void skip_prev();
+    void set_volume(uint8_t vol_0_100);   // applied as integer gain shift
+    void load_queue(TrackQueue q, bool play_immediately = true);
+    void jump_to(size_t queue_index);
+
+    bool        is_playing()   const { return playing_.load(); }
+    uint8_t     volume()       const { return volume_.load(); }
+
+    // Called with decoded PCM frames. Set before run().
+    std::function<void(const int16_t* pcm, size_t sample_pairs)> on_pcm_frame;
+
+    // Called when track changes — provides updated TrackInfo.
+    std::function<void(const TrackInfo&)> on_track_changed;
+
+private:
+    void decode_mp3(File& f);
+    void decode_flac(File& f);
+    bool open_track(const std::string& path);
+    void apply_volume(int16_t* pcm, size_t samples);
+    void read_tags(const std::string& path, TrackInfo& out);
+
+    AppState& state_;
+
+    TrackQueue queue_;
+    TrackInfo  current_info_;
+
+    std::atomic<bool>    playing_      { false };
+    std::atomic<bool>    skip_next_    { false };
+    std::atomic<bool>    skip_prev_    { false };
+    std::atomic<bool>    stop_req_     { false };
+    std::atomic<bool>    queue_dirty_  { false };
+    std::atomic<uint8_t> volume_       { 80 };
+
+    mutex_t queue_mtx_;
+
+    static constexpr size_t DECODE_BUF_SAMPLES = 2304;  // max mp3 frame × 2 ch
+};

--- a/firmware/mp3_player/pico/src/audio/track_queue.cpp
+++ b/firmware/mp3_player/pico/src/audio/track_queue.cpp
@@ -1,0 +1,52 @@
+#include "track_queue.h"
+#include <algorithm>
+#include <random>
+#include <ctime>
+
+static std::mt19937 rng(static_cast<unsigned>(time(nullptr)));
+
+void TrackQueue::load(std::vector<std::string> paths, bool shuffle) {
+    original_ = paths;
+    queue_    = std::move(paths);
+    idx_      = 0;
+    if (shuffle) shuffle_from(0);
+}
+
+const std::string& TrackQueue::current() const {
+    static const std::string empty;
+    return queue_.empty() ? empty : queue_[idx_];
+}
+
+bool TrackQueue::next(RepeatMode repeat) {
+    if (queue_.empty()) return false;
+    if (repeat == RepeatMode::ONE) return true;  // stay on same track
+    if (idx_ + 1 < queue_.size()) { ++idx_; return true; }
+    if (repeat == RepeatMode::ALL) { idx_ = 0; return true; }
+    return false;  // end of queue, no repeat
+}
+
+void TrackQueue::prev() {
+    if (queue_.empty()) return;
+    idx_ = (idx_ > 0) ? idx_ - 1 : queue_.size() - 1;
+}
+
+bool TrackQueue::jump(size_t target) {
+    if (target >= queue_.size()) return false;
+    idx_ = target;
+    return true;
+}
+
+void TrackQueue::reshuffle() {
+    if (queue_.empty()) return;
+    const std::string cur = queue_[idx_];
+    shuffle_from(0);
+    // Keep current track at the front.
+    auto it = std::find(queue_.begin(), queue_.end(), cur);
+    if (it != queue_.end()) std::iter_swap(queue_.begin(), it);
+    idx_ = 0;
+}
+
+void TrackQueue::shuffle_from(size_t start) {
+    if (start >= queue_.size()) return;
+    std::shuffle(queue_.begin() + static_cast<ptrdiff_t>(start), queue_.end(), rng);
+}

--- a/firmware/mp3_player/pico/src/audio/track_queue.h
+++ b/firmware/mp3_player/pico/src/audio/track_queue.h
@@ -1,0 +1,35 @@
+#pragma once
+#include <vector>
+#include <string>
+#include <cstdint>
+#include "../app_state.h"
+
+// Ordered play queue with shuffle and repeat support.
+// Not thread-safe — call only from Core 1 (audio decode context).
+
+class TrackQueue {
+public:
+    void load(std::vector<std::string> paths, bool shuffle = false);
+
+    const std::string& current() const;
+    bool  empty()         const { return queue_.empty(); }
+    size_t size()         const { return queue_.size(); }
+    size_t current_index()const { return idx_; }
+
+    // Advance to next track. Returns false if at end (and repeat == OFF).
+    bool next(RepeatMode repeat);
+
+    // Step back to previous track (wraps to end if at start).
+    void prev();
+
+    bool jump(size_t idx);
+
+    void reshuffle();   // re-randomise, keeping current track first
+
+private:
+    void shuffle_from(size_t start);
+
+    std::vector<std::string> queue_;
+    std::vector<std::string> original_;  // unshuffle reference
+    size_t idx_ = 0;
+};

--- a/firmware/mp3_player/pico/src/audio/vendor/README.md
+++ b/firmware/mp3_player/pico/src/audio/vendor/README.md
@@ -1,0 +1,22 @@
+# Vendored audio decoder headers
+
+Copy the following header-only libraries here before building:
+
+## minimp3 (MP3 decoder)
+- Source: https://github.com/lieff/minimp3
+- Files needed: `minimp3.h`, `minimp3_ex.h`
+- License: CC0
+
+```sh
+curl -L https://raw.githubusercontent.com/lieff/minimp3/master/minimp3.h -o minimp3.h
+curl -L https://raw.githubusercontent.com/lieff/minimp3/master/minimp3_ex.h -o minimp3_ex.h
+```
+
+## dr_flac (FLAC decoder)
+- Source: https://github.com/mackron/dr_libs
+- File needed: `dr_flac.h`
+- License: MIT / public domain
+
+```sh
+curl -L https://raw.githubusercontent.com/mackron/dr_libs/master/dr_flac.h -o dr_flac.h
+```

--- a/firmware/mp3_player/pico/src/ble/ble_control.cpp
+++ b/firmware/mp3_player/pico/src/ble/ble_control.cpp
@@ -1,0 +1,83 @@
+#include "ble_control.h"
+#include <cstring>
+#include <cstdio>
+
+BleControl::BleControl(AppState& state) : state_(state) {}
+
+bool BleControl::begin(const char* device_name) {
+    if (!BLE.begin()) return false;
+    BLE.setLocalName(device_name);
+    BLE.setAdvertisedService(svc_);
+
+    svc_.addCharacteristic(ch_play_pause_);
+    svc_.addCharacteristic(ch_skip_);
+    svc_.addCharacteristic(ch_volume_);
+    svc_.addCharacteristic(ch_mode_);
+    svc_.addCharacteristic(ch_track_);
+    svc_.addCharacteristic(ch_status_);
+    BLE.addService(svc_);
+
+    ch_volume_.writeValue(state_.playback.volume);
+
+    // Register write callbacks.
+    ch_play_pause_.setEventHandler(BLEWritten,
+        [this](BLEDevice c, BLECharacteristic ch) { handle_write(c, ch); });
+    ch_skip_.setEventHandler(BLEWritten,
+        [this](BLEDevice c, BLECharacteristic ch) { handle_write(c, ch); });
+    ch_volume_.setEventHandler(BLEWritten,
+        [this](BLEDevice c, BLECharacteristic ch) { handle_write(c, ch); });
+    ch_mode_.setEventHandler(BLEWritten,
+        [this](BLEDevice c, BLECharacteristic ch) { handle_write(c, ch); });
+
+    BLE.advertise();
+    return true;
+}
+
+void BleControl::stop() {
+    BLE.stopAdvertise();
+    BLE.end();
+}
+
+void BleControl::task() {
+    BLE.poll();
+}
+
+bool BleControl::client_connected() const {
+    return BLE.connected();
+}
+
+void BleControl::notify_track(const TrackInfo& info) {
+    if (!client_connected()) return;
+    // Pack null-separated: title\0artist\0album\0pos_s\0dur_s
+    char buf[128];
+    const int n = snprintf(buf, sizeof(buf), "%s|%s|%s|%lu|%lu",
+                           info.title, info.artist, info.album,
+                           static_cast<unsigned long>(info.position_s),
+                           static_cast<unsigned long>(info.duration_s));
+    if (n > 0)
+        ch_track_.writeValue(reinterpret_cast<uint8_t*>(buf),
+                             static_cast<int>(n > 127 ? 127 : n));
+}
+
+void BleControl::notify_status() {
+    if (!client_connected()) return;
+    uint8_t buf[2] = {
+        state_.playback.playing ? 1u : 0u,
+        static_cast<uint8_t>(state_.mode.load())
+    };
+    ch_status_.writeValue(buf, 2);
+}
+
+void BleControl::handle_write(BLEDevice& /*central*/, BLECharacteristic& ch) {
+    const uint8_t val = ch.value()[0];
+
+    if (ch.uuid() == ch_play_pause_.uuid()) {
+        if (on_play_pause) on_play_pause(val != 0);
+    } else if (ch.uuid() == ch_skip_.uuid()) {
+        if (on_skip) on_skip(val == 0xFF ? -1 : 1);
+    } else if (ch.uuid() == ch_volume_.uuid()) {
+        if (on_volume) on_volume(val);
+    } else if (ch.uuid() == ch_mode_.uuid()) {
+        if (on_mode) on_mode(static_cast<AppMode>(val));
+    }
+}

--- a/firmware/mp3_player/pico/src/ble/ble_control.h
+++ b/firmware/mp3_player/pico/src/ble/ble_control.h
@@ -1,0 +1,55 @@
+#pragma once
+#include <ArduinoBLE.h>
+#include <functional>
+#include <cstdint>
+#include "../app_state.h"
+
+// BLE GATT server running on the Pico 2 W's CYW43439.
+// Service UUID: 12340000-5678-1234-5678-1234567890AB (custom)
+//
+// Characteristics:
+//   PLAY_PAUSE  0x0001  Write: 0x01 play / 0x00 pause
+//   SKIP        0x0002  Write: 0x01 next / 0xFF prev
+//   VOLUME      0x0003  Write/Notify: uint8_t 0–100
+//   MODE        0x0004  Write: AppMode enum value
+//   TRACK_INFO  0x0005  Notify: null-separated "title\0artist\0album\0pos_s\0dur_s"
+//   STATUS      0x0006  Notify: uint8_t playing + uint8_t mode
+//
+// Designed to be used with nRF Connect or a custom companion app.
+
+class BleControl {
+public:
+    explicit BleControl(AppState& state);
+
+    bool begin(const char* device_name = "MP3Player");
+    void stop();
+    void task();  // call from loop() on Core 0
+
+    // Notify phone of updated track info and playback state.
+    void notify_track(const TrackInfo& info);
+    void notify_status();
+
+    bool client_connected() const;
+
+    // Callbacks fired when phone writes a characteristic.
+    std::function<void(bool play)>       on_play_pause;
+    std::function<void(int8_t dir)>      on_skip;      // +1 next, -1 prev
+    std::function<void(uint8_t vol)>     on_volume;
+    std::function<void(AppMode mode)>    on_mode;
+
+private:
+    void handle_write(BLEDevice& central, BLECharacteristic& ch);
+
+    AppState& state_;
+
+    BLEService        svc_  { "12340000-5678-1234-5678-1234567890AB" };
+    BLEByteCharacteristic    ch_play_pause_ { "00001001-0000-1000-8000-00805F9B34FB", BLEWrite };
+    BLEByteCharacteristic    ch_skip_       { "00001002-0000-1000-8000-00805F9B34FB", BLEWrite };
+    BLEByteCharacteristic    ch_volume_     { "00001003-0000-1000-8000-00805F9B34FB",
+                                              BLEWrite | BLENotify };
+    BLEByteCharacteristic    ch_mode_       { "00001004-0000-1000-8000-00805F9B34FB", BLEWrite };
+    BLECharacteristic        ch_track_      { "00001005-0000-1000-8000-00805F9B34FB",
+                                              BLENotify, 128 };
+    BLECharacteristic        ch_status_     { "00001006-0000-1000-8000-00805F9B34FB",
+                                              BLENotify, 2 };
+};

--- a/firmware/mp3_player/pico/src/bridge/esp32_bridge.cpp
+++ b/firmware/mp3_player/pico/src/bridge/esp32_bridge.cpp
@@ -1,0 +1,154 @@
+#include "esp32_bridge.h"
+#include <hardware/uart.h>
+#include <hardware/gpio.h>
+#include <pico/mutex.h>
+#include <cstring>
+
+static constexpr uint32_t BRIDGE_BAUD = 2000000;
+
+Esp32Bridge::Esp32Bridge(uart_inst_t* uart) : uart_(uart) {
+    mutex_init(&tx_mtx_);
+}
+
+void Esp32Bridge::begin() {
+    uart_init(uart_, BRIDGE_BAUD);
+    gpio_set_function(PIN_UART_TX, GPIO_FUNC_UART);
+    gpio_set_function(PIN_UART_RX, GPIO_FUNC_UART);
+    uart_set_format(uart_, 8, 1, UART_PARITY_NONE);
+    uart_set_fifo_enabled(uart_, true);
+}
+
+void Esp32Bridge::send_frame(uint8_t cmd, const uint8_t* payload, uint16_t len) {
+    uint8_t header[FRAME_HEADER_LEN];
+    header[0] = FRAME_MAGIC0;
+    header[1] = FRAME_MAGIC1;
+    header[2] = cmd;
+    header[3] = static_cast<uint8_t>(len & 0xFF);
+    header[4] = static_cast<uint8_t>((len >> 8) & 0xFF);
+
+    uint16_t crc = 0xFFFF;
+    crc = crc16_update(crc, cmd);
+    crc = crc16_update(crc, header[3]);
+    crc = crc16_update(crc, header[4]);
+    for (uint16_t i = 0; i < len; ++i)
+        crc = crc16_update(crc, payload[i]);
+
+    uint8_t crc_bytes[2] = { static_cast<uint8_t>(crc & 0xFF),
+                              static_cast<uint8_t>((crc >> 8) & 0xFF) };
+
+    mutex_enter_blocking(&tx_mtx_);
+    uart_write_blocking(uart_, header, FRAME_HEADER_LEN);
+    if (len > 0) uart_write_blocking(uart_, payload, len);
+    uart_write_blocking(uart_, crc_bytes, 2);
+    mutex_exit(&tx_mtx_);
+}
+
+void Esp32Bridge::play()  { send_frame(CMD_PLAY,  nullptr, 0); }
+void Esp32Bridge::pause() { send_frame(CMD_PAUSE, nullptr, 0); }
+
+void Esp32Bridge::set_volume(uint8_t vol) {
+    send_frame(CMD_SET_VOLUME, &vol, 1);
+}
+
+void Esp32Bridge::mute(bool on) {
+    uint8_t v = on ? 1 : 0;
+    send_frame(CMD_MUTE, &v, 1);
+}
+
+void Esp32Bridge::bt_source_start(const char* name) {
+    send_frame(CMD_BT_SOURCE_START,
+               reinterpret_cast<const uint8_t*>(name),
+               static_cast<uint16_t>(strlen(name)));
+}
+
+void Esp32Bridge::bt_sink_start(const char* name) {
+    send_frame(CMD_BT_SINK_START,
+               reinterpret_cast<const uint8_t*>(name),
+               static_cast<uint16_t>(strlen(name)));
+}
+
+void Esp32Bridge::bt_stop() {
+    send_frame(CMD_BT_STOP, nullptr, 0);
+}
+
+void Esp32Bridge::bt_connect(const uint8_t addr[6]) {
+    send_frame(CMD_BT_CONNECT, addr, 6);
+}
+
+void Esp32Bridge::send_audio_frame(const int16_t* pcm, size_t sample_pairs) {
+    // Payload: uint16_t sample count + raw PCM bytes.
+    const uint16_t samples    = static_cast<uint16_t>(sample_pairs);
+    const uint16_t pcm_bytes  = samples * 4;
+    const uint16_t total_len  = 2 + pcm_bytes;
+
+    // Stack-allocate for small frames; heap for large ones is avoidable because
+    // AUDIO_BYTES_PER_FRAME is always exactly 2048 bytes.
+    uint8_t payload[2 + AUDIO_BYTES_PER_FRAME];
+    payload[0] = static_cast<uint8_t>(samples & 0xFF);
+    payload[1] = static_cast<uint8_t>((samples >> 8) & 0xFF);
+    memcpy(payload + 2, pcm, pcm_bytes);
+
+    send_frame(CMD_AUDIO_FRAME, payload, total_len);
+}
+
+void Esp32Bridge::poll() {
+    while (uart_is_readable(uart_)) {
+        const uint8_t b = uart_getc(uart_);
+
+        if (rx_pos_ == 0 && b != FRAME_MAGIC0) continue;
+        if (rx_pos_ == 1 && b != FRAME_MAGIC1) { rx_pos_ = 0; continue; }
+        if (rx_pos_ < RX_BUF) rx_buf_[rx_pos_++] = b;
+
+        if (rx_pos_ < FRAME_HEADER_LEN) continue;
+
+        const uint16_t payload_len = rx_buf_[3] | (static_cast<uint16_t>(rx_buf_[4]) << 8);
+        const uint16_t total       = FRAME_HEADER_LEN + payload_len + FRAME_CRC_LEN;
+
+        if (payload_len >= RX_BUF || rx_pos_ < total) continue;
+
+        // Verify CRC.
+        const uint8_t* payload  = rx_buf_ + FRAME_HEADER_LEN;
+        const uint16_t rx_crc   = rx_buf_[total - 2] |
+                                   (static_cast<uint16_t>(rx_buf_[total - 1]) << 8);
+        uint16_t calc = 0xFFFF;
+        calc = crc16_update(calc, rx_buf_[2]);
+        calc = crc16_update(calc, rx_buf_[3]);
+        calc = crc16_update(calc, rx_buf_[4]);
+        for (uint16_t i = 0; i < payload_len; ++i)
+            calc = crc16_update(calc, payload[i]);
+
+        if (calc == rx_crc)
+            process_frame(rx_buf_[2], payload, payload_len);
+
+        rx_pos_ = 0;
+    }
+}
+
+void Esp32Bridge::process_frame(uint8_t cmd, const uint8_t* payload, uint16_t len) {
+    switch (cmd) {
+    case RSP_STATUS:
+        if (len >= sizeof(BtStatusPayload) && on_status) {
+            const auto* s = reinterpret_cast<const BtStatusPayload*>(payload);
+            on_status(s->bt_mode, s->connected != 0, s->rssi);
+        }
+        break;
+
+    case RSP_BT_CONNECTED:
+        if (on_bt_connected) {
+            char name[33] = {};
+            if (len >= sizeof(BtEventPayload)) {
+                const auto* e = reinterpret_cast<const BtEventPayload*>(payload);
+                memcpy(name, e->name, 32);
+            }
+            on_bt_connected(true, name);
+        }
+        break;
+
+    case RSP_BT_DISCONNECTED:
+        if (on_bt_disconnected) on_bt_disconnected();
+        break;
+
+    default:
+        break;
+    }
+}

--- a/firmware/mp3_player/pico/src/bridge/esp32_bridge.h
+++ b/firmware/mp3_player/pico/src/bridge/esp32_bridge.h
@@ -1,0 +1,56 @@
+#pragma once
+#include <Arduino.h>
+#include <cstdint>
+#include <functional>
+#include "../../include/pins.h"
+
+// UART framing protocol shared with the ESP32 bridge.
+// Include the same protocol.h definition (copied / symlinked from esp32_bridge).
+#include "protocol_pico.h"
+
+// Communicates with the ESP32 BT audio bridge over UART0 at 2 Mbps.
+// send_*() methods may be called from Core 1 (audio task).
+// receive polling must be called from Core 0 (loop/task).
+
+class Esp32Bridge {
+public:
+    explicit Esp32Bridge(uart_inst_t* uart = uart0);
+
+    void begin();
+
+    // ── Commands to ESP32 ─────────────────────────────────────────────────────
+
+    void play();
+    void pause();
+    void set_volume(uint8_t vol_0_100);
+    void mute(bool on);
+    void bt_source_start(const char* name = "MP3Player");
+    void bt_sink_start(const char* name = "MP3Player-In");
+    void bt_stop();
+    void bt_connect(const uint8_t addr[6]);
+
+    // Send a decoded PCM frame (512 stereo sample pairs = 2048 bytes).
+    // Returns immediately; frame is written via DMA.
+    void send_audio_frame(const int16_t* pcm, size_t sample_pairs);
+
+    // ── Status from ESP32 (call poll() regularly from Core 0) ─────────────────
+    void poll();  // parse incoming frames; fires callbacks below
+
+    std::function<void(bool connected, const char* peer_name)> on_bt_connected;
+    std::function<void()>                                       on_bt_disconnected;
+    std::function<void(uint8_t mode, bool connected, int8_t rssi)> on_status;
+
+private:
+    void send_frame(uint8_t cmd, const uint8_t* payload, uint16_t len);
+    void process_frame(uint8_t cmd, const uint8_t* payload, uint16_t len);
+
+    uart_inst_t* uart_;
+
+    // Receive state machine.
+    static constexpr size_t RX_BUF = 64;
+    uint8_t  rx_buf_[RX_BUF];
+    uint16_t rx_pos_ = 0;
+
+    // Transmit mutex (shared between Core 0 and Core 1).
+    mutex_t tx_mtx_;
+};

--- a/firmware/mp3_player/pico/src/bridge/protocol_pico.h
+++ b/firmware/mp3_player/pico/src/bridge/protocol_pico.h
@@ -1,0 +1,50 @@
+#pragma once
+// Pico-side copy of the bridge protocol constants.
+// Keep in sync with esp32_bridge/src/protocol.h.
+
+#include <stdint.h>
+
+static constexpr uint8_t  FRAME_MAGIC0      = 0xAA;
+static constexpr uint8_t  FRAME_MAGIC1      = 0x55;
+static constexpr uint16_t FRAME_HEADER_LEN  = 5;
+static constexpr uint16_t FRAME_CRC_LEN     = 2;
+static constexpr uint16_t FRAME_OVERHEAD    = FRAME_HEADER_LEN + FRAME_CRC_LEN;
+
+// Pico → ESP32
+static constexpr uint8_t CMD_PLAY            = 0x01;
+static constexpr uint8_t CMD_PAUSE           = 0x02;
+static constexpr uint8_t CMD_SET_VOLUME      = 0x03;
+static constexpr uint8_t CMD_BT_SOURCE_START = 0x04;
+static constexpr uint8_t CMD_BT_SINK_START   = 0x05;
+static constexpr uint8_t CMD_BT_STOP         = 0x06;
+static constexpr uint8_t CMD_BT_CONNECT      = 0x07;
+static constexpr uint8_t CMD_AUDIO_FRAME     = 0x10;
+static constexpr uint8_t CMD_MUTE            = 0x11;
+
+// ESP32 → Pico
+static constexpr uint8_t RSP_STATUS          = 0x80;
+static constexpr uint8_t RSP_BT_CONNECTED    = 0x81;
+static constexpr uint8_t RSP_BT_DISCONNECTED = 0x82;
+static constexpr uint8_t RSP_ERROR           = 0x84;
+
+static constexpr uint16_t AUDIO_SAMPLES_PER_FRAME = 512;
+static constexpr uint16_t AUDIO_BYTES_PER_FRAME   = AUDIO_SAMPLES_PER_FRAME * 4;
+
+#pragma pack(push, 1)
+struct BtStatusPayload {
+    uint8_t bt_mode;
+    uint8_t connected;
+    int8_t  rssi;
+};
+struct BtEventPayload {
+    uint8_t addr[6];
+    char    name[32];
+};
+#pragma pack(pop)
+
+inline uint16_t crc16_update(uint16_t crc, uint8_t byte) {
+    crc ^= static_cast<uint16_t>(byte) << 8;
+    for (int i = 0; i < 8; ++i)
+        crc = (crc & 0x8000) ? (crc << 1) ^ 0x1021 : crc << 1;
+    return crc;
+}

--- a/firmware/mp3_player/pico/src/input/encoder.cpp
+++ b/firmware/mp3_player/pico/src/input/encoder.cpp
@@ -1,0 +1,96 @@
+#include "encoder.h"
+#include <Wire.h>
+#include <Arduino.h>
+
+static constexpr uint32_t ANO_BTN_MASK =
+    (1u << ANO_BTN_SELECT) | (1u << ANO_BTN_UP) | (1u << ANO_BTN_DOWN) |
+    (1u << ANO_BTN_LEFT)   | (1u << ANO_BTN_RIGHT);
+
+bool AnoEncoder::begin(int int_pin) {
+    int_pin_ = int_pin;
+    pinMode(int_pin, INPUT_PULLUP);
+
+    if (!ss_.begin(ANO_I2C_ADDR)) return false;
+
+    // Enable pull-ups on all button pins; seesaw handles this internally.
+    ss_.pinModeBulk(ANO_BTN_MASK, INPUT_PULLUP);
+    ss_.setGPIOInterrupts(ANO_BTN_MASK, true);
+    ss_.enableEncoderInterrupt();
+
+    last_pos_  = ss_.getEncoderPosition();
+    last_btns_ = static_cast<uint8_t>(ss_.digitalReadBulk(ANO_BTN_MASK) & 0xFF);
+    return true;
+}
+
+bool AnoEncoder::poll() {
+    if (digitalRead(int_pin_) == HIGH) {
+        // No interrupt pending — check for long-press timeout only.
+        if (select_held_) {
+            if ((millis() - select_down_) >= LONG_PRESS_MS) {
+                select_held_ = false;
+                if (on_select_long) on_select_long();
+                return true;
+            }
+        }
+        return false;
+    }
+
+    bool fired = false;
+
+    // Read encoder position delta.
+    const int32_t new_pos = ss_.getEncoderPosition();
+    const int32_t delta   = new_pos - last_pos_;
+    if (delta != 0) {
+        last_pos_ = new_pos;
+        const int steps = delta > 0 ? delta : -delta;
+        for (int i = 0; i < steps; ++i) {
+            if (on_rotate) on_rotate(delta > 0 ? 1 : -1);
+        }
+        fired = true;
+    }
+
+    // Read button states (active low, pull-up).
+    const uint8_t btns = static_cast<uint8_t>(
+        ss_.digitalReadBulk(ANO_BTN_MASK) & 0xFF);
+    const uint8_t changed = last_btns_ ^ btns;
+    last_btns_ = btns;
+
+    if (changed) {
+        const uint32_t now = millis();
+
+        auto check = [&](uint8_t pin, auto& cb) {
+            if (!(changed & (1u << pin))) return;
+            const bool pressed = !(btns & (1u << pin));
+            if (pressed) {
+                if (pin == ANO_BTN_SELECT) {
+                    select_down_ = now;
+                    select_held_ = true;
+                }
+            } else {
+                if (pin == ANO_BTN_SELECT && select_held_) {
+                    select_held_ = false;
+                    const uint32_t held = now - select_down_;
+                    if (held < LONG_PRESS_MS && cb) cb();
+                } else if (cb) {
+                    cb();
+                }
+            }
+        };
+
+        check(ANO_BTN_SELECT, on_select);
+        check(ANO_BTN_UP,     on_up);
+        check(ANO_BTN_DOWN,   on_down);
+        check(ANO_BTN_LEFT,   on_left);
+        check(ANO_BTN_RIGHT,  on_right);
+        fired = true;
+    }
+
+    // Long-press check after reading buttons.
+    if (select_held_ && (millis() - select_down_) >= LONG_PRESS_MS) {
+        select_held_ = false;
+        if (on_select_long) on_select_long();
+        fired = true;
+    }
+
+    return fired;
+}

--- a/firmware/mp3_player/pico/src/input/encoder.h
+++ b/firmware/mp3_player/pico/src/input/encoder.h
@@ -1,0 +1,59 @@
+#pragma once
+#include <Adafruit_seesaw.h>
+#include <cstdint>
+#include <functional>
+
+// Adafruit ANO Rotary Navigation Encoder via Stemma QT / I2C seesaw.
+// Encoder seesaw chip: ATSAMD09, I2C address 0x49.
+// INT pin is active-low — asserted when any button or encoder changes.
+//
+// 5 directional buttons (seesaw GPIO) + rotary encoder (24 detents / rev).
+// Call begin() from setup(), then poll() from the encoder task.
+
+enum class EncoderEvent : uint8_t {
+    ROTATE_CW,       // clockwise  (+1 detent)
+    ROTATE_CCW,      // counter-CW (-1 detent)
+    BTN_SELECT,      // centre press
+    BTN_UP,
+    BTN_DOWN,
+    BTN_LEFT,
+    BTN_RIGHT,
+    BTN_SELECT_LONG, // centre held >700 ms
+};
+
+// ANO encoder seesaw GPIO pin mapping.
+static constexpr uint8_t ANO_BTN_SELECT = 1;
+static constexpr uint8_t ANO_BTN_UP     = 2;
+static constexpr uint8_t ANO_BTN_DOWN   = 3;
+static constexpr uint8_t ANO_BTN_LEFT   = 4;
+static constexpr uint8_t ANO_BTN_RIGHT  = 5;
+
+class AnoEncoder {
+public:
+    // int_pin: Pico GPIO connected to the ANO INT line.
+    bool begin(int int_pin);
+
+    // Call regularly from Core 0 (after INT fires or on timer).
+    // Returns true if any event was posted.
+    bool poll();
+
+    // Callbacks — set before begin() or any time.
+    std::function<void(int delta)> on_rotate;  // delta: +1 or -1
+    std::function<void()> on_select;
+    std::function<void()> on_select_long;
+    std::function<void()> on_up;
+    std::function<void()> on_down;
+    std::function<void()> on_left;
+    std::function<void()> on_right;
+
+private:
+    void dispatch_button(uint8_t pin, bool pressed, uint32_t held_ms);
+
+    Adafruit_seesaw ss_;
+    int             int_pin_     = -1;
+    int32_t         last_pos_    = 0;
+    uint32_t        select_down_ = 0;  // millis() when select was pressed
+    uint8_t         last_btns_   = 0xFF;
+    bool            select_held_ = false;
+    static constexpr uint32_t LONG_PRESS_MS = 700;
+};

--- a/firmware/mp3_player/pico/src/main.cpp
+++ b/firmware/mp3_player/pico/src/main.cpp
@@ -1,0 +1,293 @@
+#include <Arduino.h>
+#include <Wire.h>
+#include <SPI.h>
+#include <SD.h>
+#include <pico/multicore.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+
+#include "app_state.h"
+#include "audio/sd_player.h"
+#include "bridge/esp32_bridge.h"
+#include "storage/sd_card.h"
+#include "storage/usb_msc.h"
+#include "input/encoder.h"
+#include "ble/ble_control.h"
+#include "ui/display.h"
+#include "ui/screens/now_playing.h"
+#include "ui/screens/file_browser.h"
+#include "ui/screens/settings.h"
+#include "ui/screens/bt_devices.h"
+#include "../include/pins.h"
+
+// ── Global instances ──────────────────────────────────────────────────────────
+
+static AppState         g_state;
+static SdCard           g_sd;
+static SdPlayer         g_player(g_state);
+static Esp32Bridge      g_bridge;
+static AnoEncoder       g_encoder;
+static BleControl       g_ble(g_state);
+static UsbMsc           g_msc;
+static Display          g_display(g_state, g_encoder);
+
+// UI screens (created on their LVGL parent objects in setup()).
+static NowPlayingScreen g_scr_now;
+static FileBrowserScreen g_scr_files;
+static SettingsScreen   g_scr_settings;
+static BtDevicesScreen  g_scr_bt;
+
+static lv_obj_t* g_scr_now_obj     = nullptr;
+static lv_obj_t* g_scr_files_obj   = nullptr;
+static lv_obj_t* g_scr_settings_obj= nullptr;
+static lv_obj_t* g_scr_bt_obj      = nullptr;
+
+// ── Core 1 — audio decode loop ────────────────────────────────────────────────
+
+void setup1() { /* Core 1 stack is ready */ }
+
+void loop1() {
+    // SdPlayer::run() never returns; it blocks waiting for play state.
+    g_player.run();
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+static void switch_screen(lv_obj_t* scr) {
+    lv_scr_load_anim(scr, LV_SCR_LOAD_ANIM_FADE_ON, 150, 0, false);
+}
+
+static void apply_mode_switch(AppMode target) {
+    const AppMode current = g_state.mode.load();
+    if (target == current) return;
+
+    // Stop current mode.
+    switch (current) {
+    case AppMode::SD_PLAYBACK:
+        g_player.pause();
+        g_bridge.mute(true);
+        break;
+    case AppMode::BT_SOURCE:
+    case AppMode::BT_SINK:
+        g_player.pause();
+        g_bridge.bt_stop();
+        vTaskDelay(pdMS_TO_TICKS(700));  // BT stack teardown
+        break;
+    case AppMode::USB_MSC:
+        // USB MSC mode is exited automatically when cable disconnects.
+        break;
+    default: break;
+    }
+
+    g_state.mode.store(target);
+
+    switch (target) {
+    case AppMode::SD_PLAYBACK:
+        g_bridge.mute(false);
+        g_player.play();
+        switch_screen(g_scr_now_obj);
+        break;
+    case AppMode::BT_SOURCE:
+        g_bridge.bt_source_start("MP3Player");
+        g_player.play();
+        switch_screen(g_scr_bt_obj);
+        break;
+    case AppMode::BT_SINK:
+        g_bridge.bt_sink_start("MP3Player-In");
+        switch_screen(g_scr_now_obj);
+        break;
+    case AppMode::SETTINGS:
+        switch_screen(g_scr_settings_obj);
+        break;
+    default: break;
+    }
+
+    g_state.mode_switch_pending.store(false);
+}
+
+// ── Setup ─────────────────────────────────────────────────────────────────────
+
+void setup() {
+    g_state.init();
+
+    // I2C for ANO encoder (400 kHz Fast Mode).
+    Wire.setSDA(PIN_I2C_SDA);
+    Wire.setSCL(PIN_I2C_SCL);
+    Wire.begin();
+    Wire.setClock(400000);
+
+    // SPI for ILI9341 + SD.
+    SPI.setRX(PIN_SPI_MISO);
+    SPI.setTX(PIN_SPI_MOSI);
+    SPI.setSCK(PIN_SPI_SCK);
+    SPI.begin();
+
+    // SD card.
+    if (g_sd.begin(PIN_SD_CS)) {
+        g_state.sd_mounted = true;
+        const auto tracks = g_sd.collect_tracks("/");
+        TrackQueue q;
+        q.load(tracks, false);
+        g_player.load_queue(std::move(q), false);
+        {
+            AppLock lk(g_state);
+            g_state.playback.queue_total = static_cast<uint16_t>(tracks.size());
+        }
+    }
+
+    // UART bridge to ESP32.
+    g_bridge.begin();
+    g_bridge.on_bt_connected = [](bool /*connected*/, const char* name) {
+        AppLock lk(g_state);
+        strncpy(g_state.bt.peer_name, name, 32);
+        g_state.bt.source_connected =
+            (g_state.mode.load() == AppMode::BT_SOURCE);
+        g_state.bt.sink_connected =
+            (g_state.mode.load() == AppMode::BT_SINK);
+    };
+    g_bridge.on_bt_disconnected = []() {
+        AppLock lk(g_state);
+        g_state.bt.source_connected = false;
+        g_state.bt.sink_connected   = false;
+    };
+
+    // SdPlayer output → bridge.
+    g_player.on_pcm_frame = [](const int16_t* pcm, size_t pairs) {
+        g_bridge.send_audio_frame(pcm, pairs);
+    };
+    g_player.on_track_changed = [](const TrackInfo& info) {
+        g_ble.notify_track(info);
+    };
+
+    // Display + LVGL.
+    g_display.begin();
+
+    // Create LVGL screens.
+    g_scr_now_obj      = lv_obj_create(nullptr);
+    g_scr_files_obj    = lv_obj_create(nullptr);
+    g_scr_settings_obj = lv_obj_create(nullptr);
+    g_scr_bt_obj       = lv_obj_create(nullptr);
+
+    g_scr_now.create(g_scr_now_obj);
+    g_scr_files.create(g_scr_files_obj);
+    g_scr_settings.create(g_scr_settings_obj);
+    g_scr_bt.create(g_scr_bt_obj);
+
+    lv_scr_load(g_scr_now_obj);
+
+    // Encoder navigation wiring.
+    g_encoder.on_up    = []() { switch_screen(g_scr_now_obj);      };
+    g_encoder.on_down  = []() { switch_screen(g_scr_files_obj);    };
+    g_encoder.on_right = []() { switch_screen(g_scr_settings_obj); };
+    g_encoder.on_left  = []() { switch_screen(g_scr_bt_obj);       };
+    g_encoder.on_select_long = []() {
+        g_player.toggle();
+        g_bridge.play();  // or pause — bridge mirrors player state
+    };
+    if (!g_encoder.begin(PIN_ANO_INT))
+        ; // encoder not found — continue without it
+
+    // File browser callbacks.
+    g_scr_files.on_play = [](const std::string& path) {
+        SdCard sd;
+        auto tracks = sd.collect_tracks(path.substr(0, path.rfind('/')));
+        TrackQueue q;
+        q.load(tracks, g_state.playback.shuffled);
+        // Jump to the selected file.
+        for (size_t i = 0; i < tracks.size(); ++i) {
+            if (tracks[i] == path) { q.jump(i); break; }
+        }
+        g_player.load_queue(std::move(q), true);
+        switch_screen(g_scr_now_obj);
+    };
+
+    // Settings callbacks.
+    g_scr_settings.on_mode_change   = [](AppMode m) {
+        g_state.requested_mode.store(m);
+        g_state.mode_switch_pending.store(true);
+    };
+    g_scr_settings.on_volume_change = [](uint8_t v) {
+        g_player.set_volume(v);
+        g_bridge.set_volume(v);
+    };
+    g_scr_settings.on_shuffle_change = [](bool s) {
+        AppLock lk(g_state);
+        g_state.playback.shuffled = s;
+    };
+    g_scr_settings.on_repeat_change = [](RepeatMode r) {
+        AppLock lk(g_state);
+        g_state.playback.repeat = r;
+    };
+
+    // BLE.
+    g_ble.begin("MP3Player");
+    g_ble.on_play_pause = [](bool play) {
+        if (play) { g_player.play(); g_bridge.play(); }
+        else       { g_player.pause(); g_bridge.pause(); }
+    };
+    g_ble.on_skip      = [](int8_t dir) {
+        if (dir > 0) g_player.skip_next(); else g_player.skip_prev();
+    };
+    g_ble.on_volume    = [](uint8_t v) {
+        g_player.set_volume(v);
+        g_bridge.set_volume(v);
+    };
+    g_ble.on_mode      = [](AppMode m) {
+        g_state.requested_mode.store(m);
+        g_state.mode_switch_pending.store(true);
+    };
+
+    // USB MSC — SD hands off to TinyUSB when cable is plugged.
+    g_msc.on_msc_start = []() {
+        g_player.pause();
+        g_bridge.mute(true);
+        g_state.usb_active = true;
+        g_state.mode.store(AppMode::USB_MSC);
+        SD.end();
+    };
+    g_msc.on_msc_end = []() {
+        g_sd.begin(PIN_SD_CS);
+        g_state.sd_mounted = true;
+        g_state.usb_active = false;
+        g_state.mode.store(AppMode::SD_PLAYBACK);
+        g_bridge.mute(false);
+        g_player.play();
+    };
+    g_msc.begin(PIN_SD_CS);
+
+    // Start audio playback if SD is ready.
+    if (g_state.sd_mounted)
+        g_player.play();
+}
+
+// ── Main loop (Core 0) ────────────────────────────────────────────────────────
+
+void loop() {
+    // Handle pending mode switches (requested by UI or BLE).
+    if (g_state.mode_switch_pending.load()) {
+        apply_mode_switch(g_state.requested_mode.load());
+    }
+
+    // Drive USB MSC and BLE.
+    g_msc.task();
+    g_ble.task();
+
+    // Poll UART bridge for status frames from ESP32.
+    g_bridge.poll();
+
+    // Update LVGL + encoder + display at ~30 fps.
+    g_display.task();
+
+    // Update Now Playing screen ~1 Hz (cheap string ops).
+    static uint32_t last_ui_update = 0;
+    const uint32_t now = millis();
+    if (now - last_ui_update >= 1000) {
+        last_ui_update = now;
+        AppState* s = &g_state;  // snapshot under lock not needed for display
+        g_scr_now.update(*s);
+        g_scr_settings.update(*s);
+    }
+
+    // Tiny yield so FreeRTOS idle task can run.
+    vTaskDelay(1);
+}

--- a/firmware/mp3_player/pico/src/storage/sd_card.cpp
+++ b/firmware/mp3_player/pico/src/storage/sd_card.cpp
@@ -1,0 +1,84 @@
+#include "sd_card.h"
+#include <algorithm>
+#include <cctype>
+#include <cstring>
+
+bool SdCard::begin(int cs_pin) {
+    mounted_ = SD.begin(cs_pin);
+    return mounted_;
+}
+
+bool SdCard::is_audio(const char* name) {
+    const char* dot = strrchr(name, '.');
+    if (!dot) return false;
+    char ext[8] = {};
+    for (int i = 0; i < 7 && dot[i + 1]; ++i)
+        ext[i] = static_cast<char>(tolower(static_cast<unsigned char>(dot[i + 1])));
+    return strcmp(ext, "mp3") == 0 || strcmp(ext, "flac") == 0;
+}
+
+std::vector<DirEntry> SdCard::list(const std::string& path) {
+    std::vector<DirEntry> dirs, files;
+
+    File dir = SD.open(path.c_str());
+    if (!dir || !dir.isDirectory()) return {};
+
+    File entry = dir.openNextFile();
+    while (entry) {
+        const char* name = entry.name();
+        if (name[0] != '.') {
+            if (entry.isDirectory()) {
+                dirs.push_back({ name, true, 0 });
+            } else if (is_audio(name)) {
+                files.push_back({ name, false,
+                                  static_cast<uint32_t>(entry.size()) });
+            }
+        }
+        entry.close();
+        entry = dir.openNextFile();
+    }
+    dir.close();
+
+    auto cmp = [](const DirEntry& a, const DirEntry& b) { return a.name < b.name; };
+    std::sort(dirs.begin(),  dirs.end(),  cmp);
+    std::sort(files.begin(), files.end(), cmp);
+    dirs.insert(dirs.end(), files.begin(), files.end());
+    return dirs;
+}
+
+void SdCard::collect_recursive(const std::string& path, std::vector<std::string>& out) {
+    File dir = SD.open(path.c_str());
+    if (!dir || !dir.isDirectory()) return;
+
+    File entry = dir.openNextFile();
+    while (entry) {
+        const char* name = entry.name();
+        if (name[0] != '.') {
+            const std::string full = path + "/" + name;
+            if (entry.isDirectory()) {
+                collect_recursive(full, out);
+            } else if (is_audio(name)) {
+                out.push_back(full);
+            }
+        }
+        entry.close();
+        entry = dir.openNextFile();
+    }
+    dir.close();
+    std::sort(out.begin(), out.end());
+}
+
+std::vector<std::string> SdCard::collect_tracks(const std::string& path) {
+    std::vector<std::string> tracks;
+    collect_recursive(path, tracks);
+    return tracks;
+}
+
+TrackQueue SdCard::build_queue(const std::string& path, bool shuffle) {
+    TrackQueue q;
+    q.load(collect_tracks(path), shuffle);
+    return q;
+}
+
+uint64_t SdCard::total_bytes() const { return SD.totalBytes(); }
+uint64_t SdCard::used_bytes()  const { return SD.usedBytes(); }

--- a/firmware/mp3_player/pico/src/storage/sd_card.h
+++ b/firmware/mp3_player/pico/src/storage/sd_card.h
@@ -1,0 +1,38 @@
+#pragma once
+#include <SD.h>
+#include <string>
+#include <vector>
+#include "../audio/track_queue.h"
+
+struct DirEntry {
+    std::string name;
+    bool        is_dir;
+    uint32_t    size_bytes;
+};
+
+// FAT32 SD card access via Arduino SPI SD library.
+// All methods must be called from Core 0 (SPI is not multicore-safe).
+
+class SdCard {
+public:
+    bool begin(int cs_pin);
+    bool is_mounted() const { return mounted_; }
+
+    // List a directory (sorted: dirs first, then supported audio files).
+    std::vector<DirEntry> list(const std::string& path);
+
+    // Recursively collect all .mp3 and .flac files under path.
+    std::vector<std::string> collect_tracks(const std::string& path);
+
+    // Build a TrackQueue from all tracks under path, optionally shuffled.
+    TrackQueue build_queue(const std::string& path, bool shuffle = false);
+
+    uint64_t total_bytes() const;
+    uint64_t used_bytes()  const;
+
+private:
+    bool mounted_ = false;
+
+    bool is_audio(const char* name);
+    void collect_recursive(const std::string& path, std::vector<std::string>& out);
+};

--- a/firmware/mp3_player/pico/src/storage/usb_msc.cpp
+++ b/firmware/mp3_player/pico/src/storage/usb_msc.cpp
@@ -1,0 +1,60 @@
+#include "usb_msc.h"
+#include <SPI.h>
+
+UsbMsc* UsbMsc::instance_ = nullptr;
+
+UsbMsc::UsbMsc() { instance_ = this; }
+
+bool UsbMsc::begin(int sd_cs_pin) {
+    sd_cs_ = sd_cs_pin;
+
+    // Vendor / product strings shown in the host OS.
+    USBDevice.setManufacturerDescriptor("ProtoHUD");
+    USBDevice.setProductDescriptor("MP3 Player SD Card");
+
+    msc_.setID("ProtoHUD", "SD Card", "1.0");
+    msc_.setReadWriteCallback(msc_read_cb, msc_write_cb, msc_flush_cb);
+
+    // Expose the SD card as a single unit (512-byte sectors, total set after SD init).
+    if (SD.begin(sd_cs_)) {
+        const uint64_t sectors = SD.totalBytes() / 512;
+        msc_.setCapacity(static_cast<uint32_t>(sectors), 512);
+        msc_.setUnitReady(true);
+    }
+
+    msc_.begin();
+    TinyUSBDevice.begin(0);  // 0 = CDC descriptor index; MSC uses next slot
+    return true;
+}
+
+void UsbMsc::task() {
+    TinyUSBDevice.task();
+    const bool now_connected = TinyUSBDevice.mounted();
+    if (now_connected == connected_) return;
+    connected_ = now_connected;
+    if (connected_) {
+        msc_active_ = true;
+        if (on_msc_start) on_msc_start();
+    } else {
+        msc_active_ = false;
+        if (on_msc_end) on_msc_end();
+    }
+}
+
+int32_t UsbMsc::msc_read_cb(uint32_t lba, void* buf, uint32_t bufsize) {
+    const uint32_t n = bufsize / 512;
+    if (SD.card()->readBlocks(lba, static_cast<uint8_t*>(buf), n))
+        return static_cast<int32_t>(bufsize);
+    return -1;
+}
+
+int32_t UsbMsc::msc_write_cb(uint32_t lba, uint8_t* buf, uint32_t bufsize) {
+    const uint32_t n = bufsize / 512;
+    if (SD.card()->writeBlocks(lba, buf, n))
+        return static_cast<int32_t>(bufsize);
+    return -1;
+}
+
+void UsbMsc::msc_flush_cb() {
+    SD.card()->syncBlocks();
+}

--- a/firmware/mp3_player/pico/src/storage/usb_msc.h
+++ b/firmware/mp3_player/pico/src/storage/usb_msc.h
@@ -1,0 +1,47 @@
+#pragma once
+#include <Adafruit_TinyUSB.h>
+#include <SD.h>
+#include <cstdint>
+#include <functional>
+
+// USB Mass Storage class backed by the microSD card.
+// When the host enumerates the device, the SD is handed off exclusively to
+// TinyUSB — audio playback must be stopped and SD.end() called first.
+// On USB disconnect, SD.begin() is called again and playback can resume.
+//
+// Call begin() once from setup(). Then poll usb_connected() in the main loop
+// to detect transitions; the class handles the TinyUSB callbacks internally.
+
+class UsbMsc {
+public:
+    UsbMsc();
+
+    // cs_pin: SD chip-select GPIO used to re-init the SD library on reconnect.
+    bool begin(int sd_cs_pin);
+
+    // Must be called from loop() — drives TinyUSB task.
+    void task();
+
+    bool usb_connected() const { return connected_; }
+    bool msc_active()    const { return msc_active_; }
+
+    // Fired when host connects and MSC becomes active.
+    // Caller should stop audio and call SD.end() before returning.
+    std::function<void()> on_msc_start;
+
+    // Fired when host disconnects.
+    // Caller should re-init SD and resume playback.
+    std::function<void()> on_msc_end;
+
+private:
+    static int32_t msc_read_cb (uint32_t lba, void* buf, uint32_t bufsize);
+    static int32_t msc_write_cb(uint32_t lba, uint8_t* buf, uint32_t bufsize);
+    static void    msc_flush_cb();
+
+    Adafruit_USBD_MSC msc_;
+    int   sd_cs_    = -1;
+    bool  connected_  = false;
+    bool  msc_active_ = false;
+
+    static UsbMsc* instance_;
+};

--- a/firmware/mp3_player/pico/src/ui/display.cpp
+++ b/firmware/mp3_player/pico/src/ui/display.cpp
@@ -1,0 +1,71 @@
+#include "display.h"
+#include "theme.h"
+#include <Arduino.h>
+
+lv_color_t Display::buf1_[320 * Display::BUF_LINES];
+lv_color_t Display::buf2_[320 * Display::BUF_LINES];
+int        Display::enc_delta_  = 0;
+bool       Display::enc_select_ = false;
+
+Display::Display(AppState& state, AnoEncoder& enc)
+    : state_(state), enc_(enc) {}
+
+bool Display::begin() {
+    tft_.begin();
+    tft_.setRotation(1);  // landscape: 320×240
+    tft_.fillScreen(TFT_BLACK);
+    tft_.initDMA();
+
+    lv_init();
+
+    lv_disp_draw_buf_init(&draw_buf_, buf1_, buf2_, 320 * BUF_LINES);
+
+    lv_disp_drv_init(&disp_drv_);
+    disp_drv_.hor_res   = 320;
+    disp_drv_.ver_res   = 240;
+    disp_drv_.draw_buf  = &draw_buf_;
+    disp_drv_.flush_cb  = flush_cb;
+    disp_drv_.user_data = this;
+    lv_disp_t* disp = lv_disp_drv_register(&disp_drv_);
+
+    Theme::apply(disp);
+
+    // Register rotary encoder as LVGL input device.
+    lv_indev_drv_init(&enc_drv_);
+    enc_drv_.type    = LV_INDEV_TYPE_ENCODER;
+    enc_drv_.read_cb = encoder_read_cb;
+    enc_indev_ = lv_indev_drv_register(&enc_drv_);
+
+    // Wire encoder events to LVGL delta accumulation.
+    enc_.on_rotate = [](int delta) { enc_delta_ += delta; };
+    enc_.on_select = []() { enc_select_ = true; };
+
+    // 1 ms system tick via Arduino-Pico hardware timer.
+    // Arduino-Pico calls millis() which is already driven by SysTick;
+    // update LVGL tick from task() instead.
+    return true;
+}
+
+void Display::task() {
+    lv_tick_inc(33);       // ~30 fps nominal tick
+    enc_.poll();           // read seesaw; fires enc_ callbacks above
+    lv_task_handler();
+}
+
+void Display::flush_cb(lv_disp_drv_t* drv, const lv_area_t* area, lv_color_t* color_p) {
+    auto* self = static_cast<Display*>(drv->user_data);
+    const int32_t w = area->x2 - area->x1 + 1;
+    const int32_t h = area->y2 - area->y1 + 1;
+    self->tft_.startWrite();
+    self->tft_.setAddrWindow(area->x1, area->y1, w, h);
+    self->tft_.pushPixelsDMA(reinterpret_cast<uint16_t*>(color_p), w * h);
+    self->tft_.endWrite();
+    lv_disp_flush_ready(drv);
+}
+
+void Display::encoder_read_cb(lv_indev_drv_t* /*drv*/, lv_indev_data_t* data) {
+    data->enc_diff = static_cast<int16_t>(enc_delta_);
+    enc_delta_     = 0;
+    data->state    = enc_select_ ? LV_INDEV_STATE_PRESSED : LV_INDEV_STATE_RELEASED;
+    enc_select_    = false;
+}

--- a/firmware/mp3_player/pico/src/ui/display.h
+++ b/firmware/mp3_player/pico/src/ui/display.h
@@ -1,0 +1,42 @@
+#pragma once
+#include <TFT_eSPI.h>
+#include <lvgl.h>
+#include "../app_state.h"
+#include "../input/encoder.h"
+
+// LVGL 8 display driver on top of TFT_eSPI / ILI9341 (320×240).
+// Two 320×20-line draw buffers in static RAM (~25 KB total).
+// Flush uses TFT_eSPI::pushImageDMA for DMA-backed transfers.
+//
+// Call begin() once from setup() (Core 0).
+// Call task()  from the UI FreeRTOS task at ~30 fps.
+
+class Display {
+public:
+    Display(AppState& state, AnoEncoder& enc);
+
+    bool begin();
+    void task();  // drives lv_task_handler() and encoder input
+
+private:
+    static void flush_cb(lv_disp_drv_t* drv, const lv_area_t* area, lv_color_t* color_p);
+    static void encoder_read_cb(lv_indev_drv_t* drv, lv_indev_data_t* data);
+
+    AppState&   state_;
+    AnoEncoder& enc_;
+    TFT_eSPI    tft_;
+
+    // Double draw buffer: 320 × 20 × 2 bytes × 2 = 25.6 KB static.
+    static constexpr int BUF_LINES = 20;
+    static lv_color_t buf1_[320 * BUF_LINES];
+    static lv_color_t buf2_[320 * BUF_LINES];
+
+    lv_disp_draw_buf_t draw_buf_;
+    lv_disp_drv_t      disp_drv_;
+    lv_indev_drv_t     enc_drv_;
+    lv_indev_t*        enc_indev_ = nullptr;
+
+    // Encoder state passed to LVGL indev callback.
+    static int    enc_delta_;
+    static bool   enc_select_;
+};

--- a/firmware/mp3_player/pico/src/ui/screens/bt_devices.cpp
+++ b/firmware/mp3_player/pico/src/ui/screens/bt_devices.cpp
@@ -1,0 +1,76 @@
+#include "bt_devices.h"
+#include "../theme.h"
+#include <cstring>
+#include <cstdio>
+
+void BtDevicesScreen::create(lv_obj_t* parent) {
+    lv_obj_set_style_bg_color(parent, Theme::BG(), 0);
+    lv_obj_set_style_bg_opa(parent, LV_OPA_COVER, 0);
+    lv_obj_clear_flag(parent, LV_OBJ_FLAG_SCROLLABLE);
+
+    lbl_status_ = lv_label_create(parent);
+    lv_label_set_text(lbl_status_, "BT Devices (Source mode)");
+    lv_obj_set_style_text_color(lbl_status_, Theme::ACCENT(), 0);
+    lv_obj_set_style_text_font(lbl_status_, &lv_font_montserrat_12, 0);
+    lv_obj_align(lbl_status_, LV_ALIGN_TOP_MID, 0, 4);
+
+    list_ = lv_list_create(parent);
+    lv_obj_set_size(list_, 320, 200);
+    lv_obj_align(list_, LV_ALIGN_TOP_MID, 0, 24);
+    lv_obj_set_style_bg_color(list_, Theme::BG(), 0);
+    lv_obj_set_style_border_width(list_, 0, 0);
+}
+
+void BtDevicesScreen::clear_devices() {
+    devices_.clear();
+    lv_obj_clean(list_);
+}
+
+void BtDevicesScreen::add_device(const BtDevice& dev) {
+    devices_.push_back(dev);
+
+    char label[64];
+    snprintf(label, sizeof(label), "%s  [%d dBm]", dev.name, dev.rssi);
+
+    lv_obj_t* btn = lv_list_add_btn(list_,
+                                     dev.connected ? LV_SYMBOL_OK : LV_SYMBOL_BLUETOOTH,
+                                     label);
+    const lv_color_t col = dev.connected ? Theme::SUCCESS() : Theme::TEXT();
+    lv_obj_set_style_text_color(lv_obj_get_child(btn, 1), col, 0);
+
+    const size_t idx = devices_.size() - 1;
+    lv_obj_add_event_cb(btn, event_cb, LV_EVENT_CLICKED, this);
+    lv_obj_set_user_data(btn, reinterpret_cast<void*>(static_cast<intptr_t>(idx)));
+}
+
+void BtDevicesScreen::set_connected(const uint8_t addr[6], bool connected) {
+    // Update status label only — full refresh happens via add_device on next scan.
+    char buf[48];
+    if (connected) {
+        // Find device name.
+        for (const auto& d : devices_) {
+            if (memcmp(d.addr, addr, 6) == 0) {
+                snprintf(buf, sizeof(buf), "Connected: %s", d.name);
+                lv_label_set_text(lbl_status_, buf);
+                return;
+            }
+        }
+    }
+    lv_label_set_text(lbl_status_, "Disconnected");
+}
+
+void BtDevicesScreen::event_cb(lv_event_t* e) {
+    auto* self = static_cast<BtDevicesScreen*>(lv_event_get_user_data(e));
+    auto* btn  = static_cast<lv_obj_t*>(lv_event_get_target(e));
+    const size_t idx = static_cast<size_t>(
+        reinterpret_cast<intptr_t>(lv_obj_get_user_data(btn)));
+
+    if (idx >= self->devices_.size()) return;
+    const BtDevice& dev = self->devices_[idx];
+
+    if (dev.connected) {
+        if (self->on_disconnect_request) self->on_disconnect_request();
+    } else {
+        if (self->on_connect_request) self->on_connect_request(dev.addr);
+    }
+}

--- a/firmware/mp3_player/pico/src/ui/screens/bt_devices.h
+++ b/firmware/mp3_player/pico/src/ui/screens/bt_devices.h
@@ -1,0 +1,33 @@
+#pragma once
+#include <lvgl.h>
+#include <functional>
+#include <cstdint>
+
+// BT Devices screen — lists discovered A2DP devices (populated by ESP32 bridge).
+// Only relevant when mode is BT_SOURCE.
+
+struct BtDevice {
+    uint8_t addr[6];
+    char    name[33];
+    int8_t  rssi;
+    bool    connected;
+};
+
+class BtDevicesScreen {
+public:
+    void create(lv_obj_t* parent);
+
+    void clear_devices();
+    void add_device(const BtDevice& dev);
+    void set_connected(const uint8_t addr[6], bool connected);
+
+    std::function<void(const uint8_t addr[6])> on_connect_request;
+    std::function<void()>                       on_disconnect_request;
+
+private:
+    static void event_cb(lv_event_t* e);
+
+    lv_obj_t*             list_        = nullptr;
+    lv_obj_t*             lbl_status_  = nullptr;
+    std::vector<BtDevice> devices_;
+};

--- a/firmware/mp3_player/pico/src/ui/screens/file_browser.cpp
+++ b/firmware/mp3_player/pico/src/ui/screens/file_browser.cpp
@@ -1,0 +1,81 @@
+#include "file_browser.h"
+#include "../theme.h"
+#include <SD.h>
+#include <cstring>
+
+void FileBrowserScreen::create(lv_obj_t* parent) {
+    lv_obj_set_style_bg_color(parent, Theme::BG(), 0);
+    lv_obj_set_style_bg_opa(parent, LV_OPA_COVER, 0);
+    lv_obj_clear_flag(parent, LV_OBJ_FLAG_SCROLLABLE);
+
+    // Path label / breadcrumb.
+    lbl_path_ = lv_label_create(parent);
+    lv_obj_set_width(lbl_path_, 280);
+    lv_obj_align(lbl_path_, LV_ALIGN_TOP_LEFT, 4, 4);
+    lv_obj_set_style_text_color(lbl_path_, Theme::ACCENT(), 0);
+    lv_obj_set_style_text_font(lbl_path_, &lv_font_montserrat_12, 0);
+    lv_label_set_text(lbl_path_, "/");
+
+    // Scrollable list.
+    list_ = lv_list_create(parent);
+    lv_obj_set_size(list_, 320, 216);
+    lv_obj_align(list_, LV_ALIGN_TOP_MID, 0, 24);
+    lv_obj_set_style_bg_color(list_, Theme::BG(), 0);
+    lv_obj_set_style_border_width(list_, 0, 0);
+}
+
+void FileBrowserScreen::navigate(const std::string& path) {
+    cur_path_ = path;
+    lv_label_set_text(lbl_path_, path.c_str());
+    lv_obj_clean(list_);  // remove old list items
+
+    // Up-one-level button (not shown at root).
+    if (path != "/" && path.size() > 1) {
+        lv_obj_t* btn = lv_list_add_btn(list_, LV_SYMBOL_LEFT, ".. (up)");
+        lv_obj_set_style_text_color(lv_obj_get_child(btn, 1), Theme::TEXT_DIM(), 0);
+        lv_obj_add_event_cb(btn, list_event_cb, LV_EVENT_CLICKED, this);
+        lv_obj_set_user_data(btn, reinterpret_cast<void*>(-1));
+    }
+
+    // List directory contents.
+    SdCard sd;  // listing only — sd is already mounted globally
+    entries_ = sd.list(path);
+
+    for (size_t i = 0; i < entries_.size(); ++i) {
+        const auto& e   = entries_[i];
+        const char* icon = e.is_dir ? LV_SYMBOL_DIRECTORY : LV_SYMBOL_AUDIO;
+        lv_obj_t* btn = lv_list_add_btn(list_, icon, e.name.c_str());
+        lv_obj_set_style_text_color(lv_obj_get_child(btn, 1),
+                                    e.is_dir ? Theme::ACCENT() : Theme::TEXT(), 0);
+        lv_obj_add_event_cb(btn, list_event_cb, LV_EVENT_CLICKED, this);
+        lv_obj_set_user_data(btn, reinterpret_cast<void*>(static_cast<intptr_t>(i)));
+    }
+}
+
+void FileBrowserScreen::list_event_cb(lv_event_t* e) {
+    auto* self    = static_cast<FileBrowserScreen*>(lv_event_get_user_data(e));
+    auto* btn     = static_cast<lv_obj_t*>(lv_event_get_target(e));
+    const intptr_t idx = reinterpret_cast<intptr_t>(lv_obj_get_user_data(btn));
+
+    if (idx < 0) {
+        // Up one level.
+        const size_t slash = self->cur_path_.rfind('/');
+        std::string parent = (slash == 0) ? "/" : self->cur_path_.substr(0, slash);
+        self->navigate(parent);
+        return;
+    }
+
+    const auto& entry = self->entries_[static_cast<size_t>(idx)];
+    if (entry.is_dir) {
+        const std::string child = self->cur_path_ == "/"
+            ? "/" + entry.name
+            : self->cur_path_ + "/" + entry.name;
+        self->navigate(child);
+        if (self->on_enter_dir) self->on_enter_dir(child);
+    } else {
+        const std::string full = self->cur_path_ == "/"
+            ? "/" + entry.name
+            : self->cur_path_ + "/" + entry.name;
+        if (self->on_play) self->on_play(full);
+    }
+}

--- a/firmware/mp3_player/pico/src/ui/screens/file_browser.h
+++ b/firmware/mp3_player/pico/src/ui/screens/file_browser.h
@@ -1,0 +1,28 @@
+#pragma once
+#include <lvgl.h>
+#include <string>
+#include <functional>
+#include "../../storage/sd_card.h"
+
+// Scrollable file browser. Encoder rotate scrolls the list; select enters a
+// folder or plays a file; left button goes up one level.
+
+class FileBrowserScreen {
+public:
+    void create(lv_obj_t* parent);
+    void navigate(const std::string& path);  // load and show directory
+
+    // Fired when user selects an audio file.
+    std::function<void(const std::string& path)> on_play;
+
+    // Fired when user enters a directory (for queue building).
+    std::function<void(const std::string& dir_path)> on_enter_dir;
+
+private:
+    static void list_event_cb(lv_event_t* e);
+
+    lv_obj_t*   list_    = nullptr;
+    lv_obj_t*   lbl_path_= nullptr;
+    std::string cur_path_;
+    std::vector<DirEntry> entries_;
+};

--- a/firmware/mp3_player/pico/src/ui/screens/now_playing.cpp
+++ b/firmware/mp3_player/pico/src/ui/screens/now_playing.cpp
@@ -1,0 +1,170 @@
+#include "now_playing.h"
+#include "../theme.h"
+#include <cstdio>
+#include <cstring>
+
+static void fmt_time(char* buf, uint32_t secs) {
+    snprintf(buf, 8, "%u:%02u", secs / 60, secs % 60);
+}
+
+void NowPlayingScreen::create(lv_obj_t* parent) {
+    lv_obj_set_style_bg_color(parent, Theme::BG(), 0);
+    lv_obj_set_style_bg_opa(parent, LV_OPA_COVER, 0);
+
+    // ── Status bar ───────────────────────────────────────────────────────────
+    lv_obj_t* bar = lv_obj_create(parent);
+    lv_obj_set_size(bar, 320, 28);
+    lv_obj_set_pos(bar, 0, 0);
+    lv_obj_set_style_bg_color(bar, Theme::SURFACE(), 0);
+    lv_obj_set_style_border_width(bar, 0, 0);
+    lv_obj_set_style_pad_all(bar, 4, 0);
+    lv_obj_clear_flag(bar, LV_OBJ_FLAG_SCROLLABLE);
+
+    lv_obj_t* lbl_title_bar = lv_label_create(bar);
+    lv_label_set_text(lbl_title_bar, LV_SYMBOL_AUDIO " MP3Player");
+    lv_obj_set_style_text_color(lbl_title_bar, Theme::ACCENT(), 0);
+    lv_obj_align(lbl_title_bar, LV_ALIGN_LEFT_MID, 0, 0);
+
+    lbl_ble_ = lv_label_create(bar);
+    lv_label_set_text(lbl_ble_, "BLE");
+    lv_obj_set_style_text_color(lbl_ble_, Theme::TEXT_DIM(), 0);
+    lv_obj_align(lbl_ble_, LV_ALIGN_RIGHT_MID, -60, 0);
+
+    lbl_bt_ = lv_label_create(bar);
+    lv_label_set_text(lbl_bt_, "BT");
+    lv_obj_set_style_text_color(lbl_bt_, Theme::TEXT_DIM(), 0);
+    lv_obj_align(lbl_bt_, LV_ALIGN_RIGHT_MID, -30, 0);
+
+    lbl_vol_ = lv_label_create(bar);
+    lv_label_set_text(lbl_vol_, "80%");
+    lv_obj_set_style_text_color(lbl_vol_, Theme::TEXT(), 0);
+    lv_obj_align(lbl_vol_, LV_ALIGN_RIGHT_MID, 0, 0);
+
+    // ── Artist / Title / Album ────────────────────────────────────────────────
+    lbl_artist_ = lv_label_create(parent);
+    lv_label_set_text(lbl_artist_, "Artist");
+    lv_obj_set_style_text_color(lbl_artist_, Theme::TEXT_DIM(), 0);
+    lv_obj_set_style_text_font(lbl_artist_, &lv_font_montserrat_12, 0);
+    lv_obj_set_width(lbl_artist_, 300);
+    lv_obj_set_style_text_align(lbl_artist_, LV_TEXT_ALIGN_CENTER, 0);
+    lv_obj_align(lbl_artist_, LV_ALIGN_TOP_MID, 0, 36);
+
+    lbl_title_ = lv_label_create(parent);
+    lv_label_set_text(lbl_title_, "Track Title");
+    lv_label_set_long_mode(lbl_title_, LV_LABEL_LONG_SCROLL_CIRCULAR);
+    lv_obj_set_style_text_color(lbl_title_, Theme::TEXT(), 0);
+    lv_obj_set_style_text_font(lbl_title_, &lv_font_montserrat_18, 0);
+    lv_obj_set_width(lbl_title_, 300);
+    lv_obj_set_style_text_align(lbl_title_, LV_TEXT_ALIGN_CENTER, 0);
+    lv_obj_align(lbl_title_, LV_ALIGN_TOP_MID, 0, 55);
+
+    lbl_album_ = lv_label_create(parent);
+    lv_label_set_text(lbl_album_, "Album");
+    lv_obj_set_style_text_color(lbl_album_, Theme::TEXT_DIM(), 0);
+    lv_obj_set_style_text_font(lbl_album_, &lv_font_montserrat_12, 0);
+    lv_obj_set_width(lbl_album_, 300);
+    lv_obj_set_style_text_align(lbl_album_, LV_TEXT_ALIGN_CENTER, 0);
+    lv_obj_align(lbl_album_, LV_ALIGN_TOP_MID, 0, 82);
+
+    // ── Progress bar ─────────────────────────────────────────────────────────
+    bar_progress_ = lv_bar_create(parent);
+    lv_obj_set_size(bar_progress_, 260, 6);
+    lv_obj_align(bar_progress_, LV_ALIGN_TOP_MID, 0, 110);
+    lv_obj_set_style_bg_color(bar_progress_, Theme::BAR_BG(), 0);
+    lv_obj_set_style_bg_color(bar_progress_, Theme::ACCENT(), LV_PART_INDICATOR);
+    lv_bar_set_range(bar_progress_, 0, 1000);
+    lv_bar_set_value(bar_progress_, 0, LV_ANIM_OFF);
+
+    lbl_pos_ = lv_label_create(parent);
+    lv_label_set_text(lbl_pos_, "0:00");
+    lv_obj_set_style_text_color(lbl_pos_, Theme::TEXT_DIM(), 0);
+    lv_obj_set_style_text_font(lbl_pos_, &lv_font_montserrat_12, 0);
+    lv_obj_align(lbl_pos_, LV_ALIGN_TOP_LEFT, 20, 120);
+
+    lbl_dur_ = lv_label_create(parent);
+    lv_label_set_text(lbl_dur_, "0:00");
+    lv_obj_set_style_text_color(lbl_dur_, Theme::TEXT_DIM(), 0);
+    lv_obj_set_style_text_font(lbl_dur_, &lv_font_montserrat_12, 0);
+    lv_obj_align(lbl_dur_, LV_ALIGN_TOP_RIGHT, -20, 120);
+
+    // ── Prev / Play-Pause / Next buttons ─────────────────────────────────────
+    btn_prev_ = lv_btn_create(parent);
+    lv_obj_set_size(btn_prev_, 60, 40);
+    lv_obj_align(btn_prev_, LV_ALIGN_TOP_LEFT, 30, 145);
+    lv_obj_t* lbl_p = lv_label_create(btn_prev_);
+    lv_label_set_text(lbl_p, LV_SYMBOL_PREV);
+    lv_obj_center(lbl_p);
+
+    btn_play_ = lv_btn_create(parent);
+    lv_obj_set_size(btn_play_, 70, 44);
+    lv_obj_align(btn_play_, LV_ALIGN_TOP_MID, 0, 143);
+    lv_obj_set_style_bg_color(btn_play_, Theme::ACCENT(), 0);
+    lv_obj_t* lbl_pl = lv_label_create(btn_play_);
+    lv_label_set_text(lbl_pl, LV_SYMBOL_PLAY);
+    lv_obj_center(lbl_pl);
+
+    btn_next_ = lv_btn_create(parent);
+    lv_obj_set_size(btn_next_, 60, 40);
+    lv_obj_align(btn_next_, LV_ALIGN_TOP_RIGHT, -30, 145);
+    lv_obj_t* lbl_n = lv_label_create(btn_next_);
+    lv_label_set_text(lbl_n, LV_SYMBOL_NEXT);
+    lv_obj_center(lbl_n);
+
+    // ── Queue / shuffle info ──────────────────────────────────────────────────
+    lbl_queue_ = lv_label_create(parent);
+    lv_label_set_text(lbl_queue_, "Shuffle: OFF   Repeat: OFF   1 / 1");
+    lv_obj_set_style_text_color(lbl_queue_, Theme::TEXT_DIM(), 0);
+    lv_obj_set_style_text_font(lbl_queue_, &lv_font_montserrat_12, 0);
+    lv_obj_set_width(lbl_queue_, 300);
+    lv_obj_set_style_text_align(lbl_queue_, LV_TEXT_ALIGN_CENTER, 0);
+    lv_obj_align(lbl_queue_, LV_ALIGN_BOTTOM_MID, 0, -4);
+}
+
+void NowPlayingScreen::update(const AppState& state) {
+    char buf[64];
+
+    lv_label_set_text(lbl_artist_, state.playback.current.artist[0]
+                                   ? state.playback.current.artist : "Unknown Artist");
+    lv_label_set_text(lbl_title_,  state.playback.current.title[0]
+                                   ? state.playback.current.title  : "Unknown Track");
+    lv_label_set_text(lbl_album_,  state.playback.current.album[0]
+                                   ? state.playback.current.album  : "Unknown Album");
+
+    const uint32_t dur = state.playback.current.duration_s;
+    const uint32_t pos = state.playback.current.position_s;
+    if (dur > 0)
+        lv_bar_set_value(bar_progress_, static_cast<int32_t>(pos * 1000 / dur), LV_ANIM_OFF);
+
+    char pos_buf[8], dur_buf[8];
+    fmt_time(pos_buf, pos);
+    fmt_time(dur_buf, dur);
+    lv_label_set_text(lbl_pos_, pos_buf);
+    lv_label_set_text(lbl_dur_, dur_buf);
+
+    // Play/pause icon.
+    lv_obj_t* lbl_icon = lv_obj_get_child(btn_play_, 0);
+    lv_label_set_text(lbl_icon, state.playback.playing ? LV_SYMBOL_PAUSE : LV_SYMBOL_PLAY);
+
+    // Volume.
+    snprintf(buf, sizeof(buf), "%u%%", state.playback.volume);
+    lv_label_set_text(lbl_vol_, buf);
+
+    // BLE / BT indicators.
+    lv_obj_set_style_text_color(lbl_ble_,
+        Theme::ACCENT(), 0);  // always green if BLE stack is running
+
+    lv_obj_set_style_text_color(lbl_bt_,
+        state.bt.source_connected || state.bt.sink_connected
+        ? Theme::SUCCESS() : Theme::TEXT_DIM(), 0);
+
+    // Queue / shuffle / repeat.
+    const char* repeat_str =
+        state.playback.repeat == RepeatMode::ONE ? "ONE" :
+        state.playback.repeat == RepeatMode::ALL ? "ALL" : "OFF";
+    snprintf(buf, sizeof(buf), "Shuf: %s  Rep: %s  %u/%u",
+             state.playback.shuffled ? "ON" : "OFF",
+             repeat_str,
+             state.playback.queue_index + 1,
+             state.playback.queue_total);
+    lv_label_set_text(lbl_queue_, buf);
+}

--- a/firmware/mp3_player/pico/src/ui/screens/now_playing.h
+++ b/firmware/mp3_player/pico/src/ui/screens/now_playing.h
@@ -1,0 +1,44 @@
+#pragma once
+#include <lvgl.h>
+#include "../../app_state.h"
+
+// Now Playing screen layout (320×240):
+//
+//  ┌──────────────────────────────────────────────────┐
+//  │  ♪ MP3Player        [BLE] [BT]     vol 80%       │ h=28 status bar
+//  ├──────────────────────────────────────────────────┤
+//  │        Artist Name                               │ y=55
+//  │        Track Title (scrolls if long)             │ y=80
+//  │        Album · 4:12                              │ y=110
+//  │  ────────────────────────────────────────────    │
+//  │  1:32  ████████░░░░░░░░░░░░░░░░░░░░░░  4:12     │ y=145 seek bar
+//  │  ────────────────────────────────────────────    │
+//  │   [|◄◄]        [ ►► / ‖‖ ]        [►►|]         │ y=178
+//  │  Shuffle: ON   Repeat: ALL   7 / 43              │ y=218
+//  └──────────────────────────────────────────────────┘
+
+class NowPlayingScreen {
+public:
+    // Create LVGL objects on the given parent screen object.
+    void create(lv_obj_t* parent);
+
+    // Call ~1 Hz or whenever playback state changes.
+    void update(const AppState& state);
+
+private:
+    lv_obj_t* lbl_artist_   = nullptr;
+    lv_obj_t* lbl_title_    = nullptr;
+    lv_obj_t* lbl_album_    = nullptr;
+    lv_obj_t* bar_progress_ = nullptr;
+    lv_obj_t* lbl_pos_      = nullptr;
+    lv_obj_t* lbl_dur_      = nullptr;
+    lv_obj_t* btn_prev_     = nullptr;
+    lv_obj_t* btn_play_     = nullptr;
+    lv_obj_t* btn_next_     = nullptr;
+    lv_obj_t* lbl_queue_    = nullptr;
+    lv_obj_t* lbl_vol_      = nullptr;
+    lv_obj_t* lbl_ble_      = nullptr;
+    lv_obj_t* lbl_bt_       = nullptr;
+
+    static char fmt_time(char* buf, uint32_t secs);
+};

--- a/firmware/mp3_player/pico/src/ui/screens/settings.cpp
+++ b/firmware/mp3_player/pico/src/ui/screens/settings.cpp
@@ -1,0 +1,120 @@
+#include "settings.h"
+#include "../theme.h"
+#include <cstdio>
+
+static const char* REPEAT_OPTIONS = "OFF\nONE\nALL";
+
+void SettingsScreen::create(lv_obj_t* parent) {
+    lv_obj_set_style_bg_color(parent, Theme::BG(), 0);
+    lv_obj_set_style_bg_opa(parent, LV_OPA_COVER, 0);
+
+    lv_obj_t* list = lv_list_create(parent);
+    lv_obj_set_size(list, 320, 240);
+    lv_obj_center(list);
+    lv_obj_set_style_bg_color(list, Theme::BG(), 0);
+    lv_obj_set_style_border_width(list, 0, 0);
+
+    // ── Output mode ───────────────────────────────────────────────────────────
+    lv_list_add_text(list, "Output Mode");
+
+    btn_mode_wired_ = lv_list_add_btn(list, LV_SYMBOL_AUDIO, "Wired (PCM5102)");
+    lv_obj_add_event_cb(btn_mode_wired_, event_cb, LV_EVENT_CLICKED, this);
+    lv_obj_set_user_data(btn_mode_wired_, reinterpret_cast<void*>(0));
+
+    btn_mode_bt_src_ = lv_list_add_btn(list, LV_SYMBOL_BLUETOOTH, "BT Headphones");
+    lv_obj_add_event_cb(btn_mode_bt_src_, event_cb, LV_EVENT_CLICKED, this);
+    lv_obj_set_user_data(btn_mode_bt_src_, reinterpret_cast<void*>(1));
+
+    btn_mode_bt_sink_ = lv_list_add_btn(list, LV_SYMBOL_BLUETOOTH, "BT Sink (receive)");
+    lv_obj_add_event_cb(btn_mode_bt_sink_, event_cb, LV_EVENT_CLICKED, this);
+    lv_obj_set_user_data(btn_mode_bt_sink_, reinterpret_cast<void*>(2));
+
+    // ── Volume ────────────────────────────────────────────────────────────────
+    lv_list_add_text(list, "Volume");
+    lv_obj_t* vol_row = lv_obj_create(list);
+    lv_obj_set_size(vol_row, LV_PCT(100), 50);
+    lv_obj_set_style_bg_opa(vol_row, LV_OPA_TRANSP, 0);
+    lv_obj_set_style_border_width(vol_row, 0, 0);
+
+    slider_vol_ = lv_slider_create(vol_row);
+    lv_slider_set_range(slider_vol_, 0, 100);
+    lv_slider_set_value(slider_vol_, 80, LV_ANIM_OFF);
+    lv_obj_set_width(slider_vol_, 200);
+    lv_obj_center(slider_vol_);
+    lv_obj_set_style_bg_color(slider_vol_, Theme::ACCENT(), LV_PART_KNOB);
+    lv_obj_set_style_bg_color(slider_vol_, Theme::ACCENT(), LV_PART_INDICATOR);
+    lv_obj_add_event_cb(slider_vol_, event_cb, LV_EVENT_VALUE_CHANGED, this);
+    lv_obj_set_user_data(slider_vol_, reinterpret_cast<void*>(10));
+
+    // ── Shuffle ───────────────────────────────────────────────────────────────
+    lv_list_add_text(list, "Shuffle");
+    lv_obj_t* shuf_row = lv_obj_create(list);
+    lv_obj_set_size(shuf_row, LV_PCT(100), 50);
+    lv_obj_set_style_bg_opa(shuf_row, LV_OPA_TRANSP, 0);
+    lv_obj_set_style_border_width(shuf_row, 0, 0);
+    sw_shuffle_ = lv_switch_create(shuf_row);
+    lv_obj_center(sw_shuffle_);
+    lv_obj_add_event_cb(sw_shuffle_, event_cb, LV_EVENT_VALUE_CHANGED, this);
+    lv_obj_set_user_data(sw_shuffle_, reinterpret_cast<void*>(11));
+
+    // ── Repeat ────────────────────────────────────────────────────────────────
+    lv_list_add_text(list, "Repeat");
+    roller_repeat_ = lv_roller_create(list);
+    lv_roller_set_options(roller_repeat_, REPEAT_OPTIONS, LV_ROLLER_MODE_NORMAL);
+    lv_roller_set_visible_row_count(roller_repeat_, 1);
+    lv_obj_set_width(roller_repeat_, 120);
+    lv_obj_add_event_cb(roller_repeat_, event_cb, LV_EVENT_VALUE_CHANGED, this);
+    lv_obj_set_user_data(roller_repeat_, reinterpret_cast<void*>(12));
+
+    // ── SD info ───────────────────────────────────────────────────────────────
+    lv_list_add_text(list, "SD Card");
+    lbl_sd_info_ = lv_label_create(list);
+    lv_label_set_text(lbl_sd_info_, "Scanning...");
+    lv_obj_set_style_text_color(lbl_sd_info_, Theme::TEXT_DIM(), 0);
+    lv_obj_set_style_text_font(lbl_sd_info_, &lv_font_montserrat_12, 0);
+}
+
+void SettingsScreen::update(const AppState& state) {
+    if (!sw_shuffle_) return;
+
+    if (state.playback.shuffled)
+        lv_obj_add_state(sw_shuffle_, LV_STATE_CHECKED);
+    else
+        lv_obj_clear_state(sw_shuffle_, LV_STATE_CHECKED);
+
+    lv_roller_set_selected(roller_repeat_,
+                           static_cast<uint16_t>(state.playback.repeat), LV_ANIM_OFF);
+    lv_slider_set_value(slider_vol_, state.playback.volume, LV_ANIM_OFF);
+
+    char buf[48];
+    snprintf(buf, sizeof(buf), "%.1f GB free / %.1f GB",
+             0.0f,  // filled from SdCard at runtime
+             0.0f);
+    lv_label_set_text(lbl_sd_info_, buf);
+}
+
+void SettingsScreen::event_cb(lv_event_t* e) {
+    auto* self = static_cast<SettingsScreen*>(lv_event_get_user_data(e));
+    auto* obj  = static_cast<lv_obj_t*>(lv_event_get_target(e));
+    const intptr_t id = reinterpret_cast<intptr_t>(lv_obj_get_user_data(obj));
+
+    switch (id) {
+    case 0: if (self->on_mode_change) self->on_mode_change(AppMode::SD_PLAYBACK); break;
+    case 1: if (self->on_mode_change) self->on_mode_change(AppMode::BT_SOURCE);   break;
+    case 2: if (self->on_mode_change) self->on_mode_change(AppMode::BT_SINK);     break;
+    case 10:
+        if (self->on_volume_change)
+            self->on_volume_change(static_cast<uint8_t>(lv_slider_get_value(obj)));
+        break;
+    case 11:
+        if (self->on_shuffle_change)
+            self->on_shuffle_change(lv_obj_has_state(obj, LV_STATE_CHECKED));
+        break;
+    case 12:
+        if (self->on_repeat_change)
+            self->on_repeat_change(
+                static_cast<RepeatMode>(lv_roller_get_selected(obj)));
+        break;
+    default: break;
+    }
+}

--- a/firmware/mp3_player/pico/src/ui/screens/settings.h
+++ b/firmware/mp3_player/pico/src/ui/screens/settings.h
@@ -1,0 +1,27 @@
+#pragma once
+#include <lvgl.h>
+#include <functional>
+#include "../../app_state.h"
+
+// Settings screen — scrollable list of controls.
+class SettingsScreen {
+public:
+    void create(lv_obj_t* parent);
+    void update(const AppState& state);
+
+    std::function<void(AppMode)>   on_mode_change;
+    std::function<void(uint8_t)>   on_volume_change;
+    std::function<void(bool)>      on_shuffle_change;
+    std::function<void(RepeatMode)>on_repeat_change;
+
+private:
+    static void event_cb(lv_event_t* e);
+
+    lv_obj_t* sw_shuffle_  = nullptr;
+    lv_obj_t* roller_repeat_= nullptr;
+    lv_obj_t* slider_vol_  = nullptr;
+    lv_obj_t* lbl_sd_info_ = nullptr;
+    lv_obj_t* btn_mode_wired_   = nullptr;
+    lv_obj_t* btn_mode_bt_src_  = nullptr;
+    lv_obj_t* btn_mode_bt_sink_ = nullptr;
+};

--- a/firmware/mp3_player/pico/src/ui/theme.cpp
+++ b/firmware/mp3_player/pico/src/ui/theme.cpp
@@ -1,0 +1,15 @@
+#include "theme.h"
+
+void Theme::apply(lv_disp_t* disp) {
+    lv_theme_t* th = lv_theme_default_init(
+        disp,
+        ACCENT(),
+        ACCENT2(),
+        /*dark=*/true,
+        &lv_font_montserrat_14
+    );
+    lv_disp_set_theme(disp, th);
+
+    // Override background colour.
+    lv_obj_set_style_bg_color(lv_scr_act(), BG(), 0);
+}

--- a/firmware/mp3_player/pico/src/ui/theme.h
+++ b/firmware/mp3_player/pico/src/ui/theme.h
@@ -1,0 +1,19 @@
+#pragma once
+#include <lvgl.h>
+
+// Colour palette (RGB565 via lv_color_make).
+namespace Theme {
+    inline lv_color_t BG        () { return lv_color_make(0x10, 0x10, 0x18); }
+    inline lv_color_t SURFACE   () { return lv_color_make(0x1E, 0x1E, 0x2E); }
+    inline lv_color_t ACCENT    () { return lv_color_make(0x5E, 0x81, 0xF4); }
+    inline lv_color_t ACCENT2   () { return lv_color_make(0xA0, 0xC4, 0xFF); }
+    inline lv_color_t TEXT      () { return lv_color_make(0xE0, 0xE0, 0xF0); }
+    inline lv_color_t TEXT_DIM  () { return lv_color_make(0x70, 0x70, 0x90); }
+    inline lv_color_t SUCCESS   () { return lv_color_make(0x50, 0xFA, 0x7B); }
+    inline lv_color_t WARNING   () { return lv_color_make(0xFF, 0xB8, 0x6C); }
+    inline lv_color_t DANGER    () { return lv_color_make(0xFF, 0x55, 0x55); }
+    inline lv_color_t BAR_BG    () { return lv_color_make(0x30, 0x30, 0x50); }
+
+    // Apply base theme to LVGL display.
+    void apply(lv_disp_t* disp);
+}


### PR DESCRIPTION
## Summary

- Adds `firmware/mp3_player/` — a two-chip standalone MP3 player project, separate from the main Raspberry Pi CM5 ProtoHUD app
- **Pico 2 W** (main controller): ILI9341 2.8" TFT, LVGL 8 UI, ANO Rotary Navigation Encoder (Stemma QT / seesaw), microSD playback, BLE GATT control, native USB Mass Storage for drag-and-drop file upload
- **ESP32-WROOM-32** (BT audio bridge): Bluetooth Classic A2DP source + sink, PCM5102A I2S DAC → 3.5mm headphone jack
- Boards communicate over UART at 2 Mbps with a CRC16-framed protocol carrying both control commands and decoded PCM audio frames

## Architecture

```
Pico 2 W Core 0          Pico 2 W Core 1
─────────────────         ─────────────────────────
LVGL UI (~30 fps)         MP3/FLAC decode (minimp3/dr_flac)
ANO encoder input         → 512-sample PCM frames
BLE GATT server           → UART → ESP32 (2 Mbps)
USB MSC (TinyUSB)
App state machine

         UART GP0/GP1 ↕ ESP32 GPIO1/3

ESP32 Core 0              ESP32 Core 1
─────────────────         ──────────────────────────
UART frame handler        I2S drain task (pri 22)
A2DP source / sink        Ring buffer → PCM5102A
                          → 3.5mm jack
```

## Key Files

| Path | Purpose |
|------|---------|
| `firmware/mp3_player/README.md` | Wiring diagram, BOM, build & flash instructions |
| `firmware/mp3_player/pico/platformio.ini` | Arduino-Pico (earlephilhower) build config |
| `firmware/mp3_player/pico/src/main.cpp` | Setup, Core 1 launch, mode state machine |
| `firmware/mp3_player/pico/src/audio/sd_player.*` | minimp3 / dr_flac decode pipeline |
| `firmware/mp3_player/pico/src/bridge/esp32_bridge.*` | UART framing to/from ESP32 |
| `firmware/mp3_player/pico/src/ui/` | LVGL screens: Now Playing, File Browser, Settings, BT Devices |
| `firmware/mp3_player/esp32_bridge/src/bt_audio.*` | A2DP source/sink with clean mode-switch handoff |
| `firmware/mp3_player/esp32_bridge/src/i2s_dac.*` | PCM5102A via ESP32 I2S, ring-buffer fed |

## Before Building

Vendor the two header-only audio decoders (see `pico/src/audio/vendor/README.md`):
```sh
curl -L https://raw.githubusercontent.com/lieff/minimp3/master/minimp3.h -o minimp3.h
curl -L https://raw.githubusercontent.com/lieff/minimp3/master/minimp3_ex.h -o minimp3_ex.h
curl -L https://raw.githubusercontent.com/mackron/dr_libs/master/dr_flac.h -o dr_flac.h
```

## Test plan

- [ ] `cd firmware/mp3_player/esp32_bridge && pio run` — compiles clean
- [ ] `cd firmware/mp3_player/pico && pio run` — compiles clean
- [ ] Flash ESP32, connect PCM5102A → headphones, confirm I2S output on `CMD_AUDIO_FRAME` via serial test
- [ ] Flash Pico, rotate ANO encoder → LVGL list scrolls, BLE service visible in nRF Connect
- [ ] SD with MP3 files → audio plays on wired headphones
- [ ] Plug USB cable → SD mounts as drive on host OS, drag .mp3 file, eject, file appears in file browser
- [ ] Switch to BT Source in Settings → pair BT headphones → music plays wirelessly
- [ ] Switch to BT Sink → connect phone → Spotify plays on wired headphones

https://claude.ai/code/session_014A8NZfMi52WxR6YU2wUCvj

---
_Generated by [Claude Code](https://claude.ai/code/session_014A8NZfMi52WxR6YU2wUCvj)_