### PR TITLE
Step 15: Polish — album art, toast notifications, USB overlay

### DIFF
--- a/firmware/mp3_player/README.md
+++ b/firmware/mp3_player/README.md
@@ -12,14 +12,21 @@ Standalone embedded MP3/FLAC player using a two-chip design:
 ## Features
 
 - MP3 and FLAC playback from microSD (FAT32)
+- **ID3v2 tag display**: title, artist, album read from ID3v2.3/v2.4 frames with full UTF-8 output (ISO-8859-1, UTF-16LE/BE, UTF-8 source encodings supported); ID3v1 fallback
+- **Track duration**: read from TLEN tag → Xing/Info VBR header → CBR file-size estimate for MP3; from STREAMINFO for FLAC
+- **Cover art**: JPEG decoded and displayed from `cover.jpg` / `folder.jpg` in the album directory (80×80 canvas, JPEGDEC)
+- **5-band parametric EQ**: 60 Hz / 250 Hz / 1 kHz / 4 kHz / 12 kHz peaking filters; presets Flat / Bass Boost / Vocal / Treble
+- **Settings persistence**: volume, shuffle, repeat, and EQ preset auto-saved to `/settings.bin` on SD after each change (500 ms debounce)
+- **Backlight management**: dims to 30% after 30 s idle, turns off after 60 s; encoder input wakes to full brightness
 - **USB Mass Storage**: plug in a USB cable → SD card mounts on your computer for drag-and-drop file transfer
-- **Wired headphones**: PCM5102A DAC → 3.5mm jack
+- **Wired headphones**: PCM5102A DAC → 3.5 mm jack
 - **BT Headphones (source)**: stream music wirelessly to any A2DP Bluetooth headphone or speaker
 - **BT Receive (sink)**: receive A2DP audio from your phone → play on wired headphones
 - **BLE control**: play/pause, skip, volume, mode change from phone (nRF Connect compatible)
-- **ILI9341 320×240 TFT**: Now Playing, File Browser, Settings, BT Devices screens
+- **ILI9341 320×240 TFT**: Now Playing (album art + metadata), File Browser, Settings, BT Devices screens
 - **ANO Rotary Navigation Encoder**: rotate to scroll/volume, click to select, directional buttons to navigate screens
 - Shuffle, repeat (OFF / ONE / ALL), queue management
+- Toast notifications for volume and EQ changes
 
 ---
 
@@ -29,12 +36,12 @@ Standalone embedded MP3/FLAC player using a two-chip design:
 |------|-------|
 | Raspberry Pi Pico 2 W | RP2350 + CYW43439, ~$7 |
 | ESP32-WROOM-32 dev board | Any bare ESP32 (not S3/S2), ~$5 |
-| ILI9341 2.8" TFT (320×240) | With SPI interface, ~$8 |
+| ILI9341 2.8" TFT (320×240) | With SPI interface and LEDA/BL pin, ~$8 |
 | Adafruit ANO Rotary Navigation Encoder | Stemma QT, product #6310 |
 | PCM5102A DAC breakout | e.g. HiLetgo PCM5102A, ~$6 |
 | MicroSD breakout (SPI) | Or use the one on the TFT module |
 | MicroSD card | FAT32 formatted |
-| 3.5mm stereo jack | TRRS or TRS |
+| 3.5 mm stereo jack | TRRS or TRS |
 | Misc | Dupont wires, breadboard or custom PCB |
 
 ---
@@ -57,6 +64,7 @@ GP19 (SPI0 MOSI) →  ILI9341 MOSI  +  SD MOSI
 GP17             →  ILI9341 CS
 GP20             →  ILI9341 DC
 GP21             →  ILI9341 RST
+GP28 (PWM)       →  ILI9341 LEDA / BL  (backlight)
 GP22             →  SD card CS
 USB              →  Host computer (USB Mass Storage)
 3V3              →  ANO VIN, ILI9341 VCC, SD VCC
@@ -66,6 +74,10 @@ GND              →  All grounds
 > **SPI bus shared**: ILI9341 and SD share MOSI/MISO/SCK. CS pins are separate.
 > The firmware uses `SPI.beginTransaction()` around each access for safe arbitration.
 > Core 1 (audio decode) only touches UART — never SPI.
+
+> **Backlight (GP28)**: driven by `analogWrite()` at PWM duty 0–255. If your TFT module
+> ties LEDA to 3.3 V via a resistor, cut that trace and wire GP28 instead. If you skip
+> this connection the backlight stays on permanently at full brightness.
 
 ### ESP32-WROOM-32
 
@@ -97,8 +109,8 @@ FLT           →  GND  (normal latency filter)
 DEMP          →  GND  (de-emphasis off)
 FMT           →  GND  (I2S standard format)
 SCK           →  GND  (no system clock needed for PCM5102A)
-LINEOUT L/R   →  3.5mm stereo jack tip/ring
-AGND          →  Sleeve of 3.5mm jack
+LINEOUT L/R   →  3.5 mm stereo jack tip/ring
+AGND          →  Sleeve of 3.5 mm jack
 ```
 
 ### ANO Encoder (Stemma QT)
@@ -109,6 +121,26 @@ Connect via a Stemma QT / QWIIC 4-pin cable to the Pico's I2C0 pins:
 - **SDA** → GP4
 - **SCL** → GP5
 - **INT** → GP6 (wire manually from the INT pad on the encoder breakout)
+
+---
+
+## SD Card Layout
+
+The player scans for `.mp3` and `.flac` files recursively from `/`. Recommended structure:
+
+```
+/
+├── Artist Name/
+│   ├── Album Title/
+│   │   ├── cover.jpg       ← album art (also: Cover.jpg, folder.jpg, Folder.jpg)
+│   │   ├── 01 - Track.mp3
+│   │   └── 02 - Track.flac
+└── settings.bin             ← auto-created by firmware (do not edit)
+```
+
+**Album art**: place a JPEG named `cover.jpg`, `Cover.jpg`, `folder.jpg`, `Folder.jpg`, `album.jpg`, or `Album.jpg` in the same folder as your tracks. The image is decoded and scaled to 80×80 on the Now Playing screen.
+
+**ID3 tags**: the player reads ID3v2.3 and ID3v2.4 tags for title, artist, album, and duration. If no ID3v2 tag is present it falls back to ID3v1 (last 128 bytes). Track title falls back to the filename if no tag is found.
 
 ---
 
@@ -132,13 +164,6 @@ cd firmware/mp3_player/pico
 pio run -e rpipico2w -t upload
 ```
 
-### SD Card Preparation
-
-1. Format as FAT32.
-2. Create a `/Music` folder (or any structure — the player scans recursively).
-3. Copy `.mp3` or `.flac` files.
-4. **Eject safely** before unplugging (same as any USB drive).
-
 ### USB File Transfer
 
 1. Connect Pico USB to computer. Audio pauses automatically.
@@ -159,6 +184,59 @@ pio run -e rpipico2w -t upload
 | Down button    | File Browser screen |
 | Right button   | Settings screen |
 | Left button    | BT Devices screen |
+
+### Settings Screen
+
+| Setting | Options | Saved |
+|---------|---------|-------|
+| Output Mode | Wired / BT Headphones / BT Sink | — |
+| Volume | 0–100 (slider) | Yes |
+| Shuffle | On / Off | Yes |
+| Repeat | OFF / ONE / ALL | Yes |
+| EQ | Flat / Bass Boost / Vocal / Treble | Yes |
+
+All saved settings are written to `/settings.bin` on the SD card and restored on the next boot. A 500 ms debounce prevents rapid encoder turns from thrashing the card.
+
+---
+
+## Equalizer
+
+The 5-band parametric EQ runs on Core 1 in the audio decode pipeline, applied after volume scaling and before PCM output. Filters use standard peaking-EQ biquad coefficients (Audio EQ Cookbook, Bristow-Johnson), computed in floating point on the RP2350B’s Cortex-M33 FPU.
+
+### Band Centres
+
+| Band | Frequency | Q |
+|------|-----------|---|
+| 1 | 60 Hz | 1.0 |
+| 2 | 250 Hz | 1.0 |
+| 3 | 1 kHz | 1.0 |
+| 4 | 4 kHz | 1.0 |
+| 5 | 12 kHz | 1.0 |
+
+### Presets (gain in dB per band)
+
+| Preset | 60 Hz | 250 Hz | 1 kHz | 4 kHz | 12 kHz |
+|--------|-------|--------|-------|-------|--------|
+| Flat | 0 | 0 | 0 | 0 | 0 |
+| Bass Boost | +8 | +5 | −2 | −1 | 0 |
+| Vocal | −2 | −1 | +5 | +4 | +1 |
+| Treble | 0 | −1 | −1 | +4 | +8 |
+
+Preset changes are applied between audio frames using a lock-free atomic handoff from Core 0 to Core 1 — no audio glitch or mutex stall.
+
+---
+
+## Backlight
+
+GP28 drives the display backlight via PWM (`analogWrite`). Brightness is managed automatically based on encoder inactivity:
+
+| Idle time | Brightness |
+|-----------|------------|
+| 0–30 s | 100% (full) |
+| 30–60 s | 30% (dim) |
+| > 60 s | 0% (off) |
+
+Any encoder rotation or button press instantly restores full brightness. If GP28 is not wired to the display’s backlight pin, the screen stays on at full brightness regardless.
 
 ---
 
@@ -181,7 +259,7 @@ Service UUID: `12340000-5678-1234-5678-1234567890AB`
 ## Bluetooth Audio Notes
 
 - **Source mode** (stream to BT headphones): device advertises as `MP3Player`. Pair your headphones to it. Music streams from SD via the ESP32 A2DP source role.
-- **Sink mode** (receive from phone): device advertises as `MP3Player-In`. Connect from your phone's Bluetooth audio settings (like connecting to a speaker). Audio plays on the wired PCM5102A output.
+- **Sink mode** (receive from phone): device advertises as `MP3Player-In`. Connect from your phone’s Bluetooth audio settings (like connecting to a speaker). Audio plays on the wired PCM5102A output.
 - **A2DP source and sink cannot run simultaneously** — switch modes in Settings.
 - Mode switch takes ~1 second (BT stack handoff on ESP32).
 
@@ -191,19 +269,42 @@ Service UUID: `12340000-5678-1234-5678-1234567890AB`
 
 ```
 Pico 2 W (Core 0)              Pico 2 W (Core 1)
-────────────────────────        ──────────────────────────────
+──────────────────────        ──────────────────────────────
 LVGL UI @ ~30 fps               MP3/FLAC decode (minimp3/dr_flac)
-Encoder polling (seesaw)        ↓ 512-sample PCM frames
-BLE GATT server                 UART → ESP32 bridge
-USB MSC (TinyUSB)               @ 2 Mbps (1.4 Mbps audio net)
-Bridge poll (status RX)
-App state machine
+Encoder polling (seesaw)        ↓ read_tags(): ID3v2.3/2.4 + ID3v1
+BLE GATT server                 ↓ extract_cover_art(): JPEG → CoverArtBuf
+USB MSC (TinyUSB)               ↓ apply_volume(): integer gain
+Bridge poll (status RX)         ↓ Eq::process(): 5-band biquad FPU
+Settings persistence            ↓ UART → ESP32 bridge
+Backlight PWM (GP28)            @ 2 Mbps (1.4 Mbps audio net)
+
+Core 0 → Core 1 signals (lock-free atomics):
+  volume_.store()          → picked up per frame in decode loop
+  eq_preset_req_.store()   → picked up per frame; coefficients recomputed
+  cover_art.generation     → acquire/release fence; Core 0 renders JPEG
 
                     UART (GP0/GP1, 2 Mbps)
-                           ↕
+                           ⇕
 ESP32-WROOM (Core 0)                 ESP32-WROOM (Core 1)
-────────────────────────────         ──────────────────────────────
+────────────────────────         ──────────────────────────────
 UART frame handler                   I2S drain task (priority 22)
 BT A2DP source/sink                  Writes PCM ring buffer → I2S
-PCM5102A I2S master                  → PCM5102A → 3.5mm jack
+PCM5102A I2S master                  → PCM5102A → 3.5 mm jack
 ```
+
+### Settings file format (`/settings.bin`)
+
+10-byte binary record, XOR checksum:
+
+| Offset | Field | Notes |
+|--------|-------|-------|
+| 0–2 | Magic `PHS` | File identifier |
+| 3 | Version `0x01` | Format version |
+| 4 | Volume | 0–100 |
+| 5 | Shuffle | `0`=off, `1`=on |
+| 6 | Repeat | `0`=OFF, `1`=ONE, `2`=ALL |
+| 7 | EQ preset | `0`=Flat, `1`=Bass Boost, `2`=Vocal, `3`=Treble |
+| 8 | Reserved | `0x00` |
+| 9 | Checksum | XOR of bytes 0–8 |
+
+The file is written atomically (remove + reopen) by the `Settings::do_save()` helper after a 500 ms debounce timer. A corrupt or missing file is silently ignored and firmware defaults are used.

--- a/firmware/mp3_player/pico/include/lv_conf.h
+++ b/firmware/mp3_player/pico/include/lv_conf.h
@@ -29,10 +29,10 @@
 #define LV_USE_BAR        1
 #define LV_USE_BTN        1
 #define LV_USE_BTNMATRIX  0
-#define LV_USE_CANVAS     0
+#define LV_USE_CANVAS     1   /* album art */
 #define LV_USE_CHECKBOX   1
 #define LV_USE_DROPDOWN   1
-#define LV_USE_IMG        0
+#define LV_USE_IMG        1   /* album art */
 #define LV_USE_LABEL      1
 #define LV_USE_LINE       1
 #define LV_USE_ROLLER     0

--- a/firmware/mp3_player/pico/include/pins.h
+++ b/firmware/mp3_player/pico/include/pins.h
@@ -1,24 +1,25 @@
 #pragma once
 
-// ── SPI0 (shared: ILI9341 display + SD card) ─────────────────────────────────
+// ── SPI0 (shared: ILI9341 display + SD card) ────────────────────────────────
 static constexpr int PIN_SPI_MOSI  = 19;
 static constexpr int PIN_SPI_SCK   = 18;
 static constexpr int PIN_SPI_MISO  = 16;
 static constexpr int PIN_TFT_CS    = 17;
 static constexpr int PIN_TFT_DC    = 20;
 static constexpr int PIN_TFT_RST   = 21;
+static constexpr int PIN_TFT_BL    = 28;  // backlight LED (PWM)
 static constexpr int PIN_SD_CS     = 22;
 
-// ── I2C0 (ANO Rotary Navigation Encoder via Stemma QT) ───────────────────────
+// ── I2C0 (ANO Rotary Navigation Encoder via Stemma QT) ────────────────────
 static constexpr int PIN_I2C_SDA   =  4;
 static constexpr int PIN_I2C_SCL   =  5;
 static constexpr int PIN_ANO_INT   =  6;  // active-low interrupt
 static constexpr int ANO_I2C_ADDR  = 0x49;
 
-// ── UART0 (ESP32 bridge, 2 Mbps) ─────────────────────────────────────────────
+// ── UART0 (ESP32 bridge, 2 Mbps) ──────────────────────────────────────
 static constexpr int PIN_UART_TX   =  0;  // Pico TX → ESP32 RX (GPIO3)
 static constexpr int PIN_UART_RX   =  1;  // Pico RX ← ESP32 TX (GPIO1)
 
-// ── Miscellaneous ─────────────────────────────────────────────────────────────
+// ── Miscellaneous ─────────────────────────────────────────────────────
 // Pico 2 W built-in LED is on the CYW43 GPIO, not a direct pin.
 // Use the Arduino-Pico LED_BUILTIN define (maps to CYW43_WL_GPIO_LED_PIN).

--- a/firmware/mp3_player/pico/platformio.ini
+++ b/firmware/mp3_player/pico/platformio.ini
@@ -8,6 +8,7 @@ lib_deps =
     lvgl/lvgl @ ^8.3.11
     adafruit/Adafruit seesaw Library @ ^1.7.5
     adafruit/Adafruit BusIO @ ^1.14.5
+    bitbank2/JPEGDEC @ ^1.2.7
 
 build_flags =
     ; TFT_eSPI ILI9341 config

--- a/firmware/mp3_player/pico/src/app_state.h
+++ b/firmware/mp3_player/pico/src/app_state.h
@@ -41,6 +41,17 @@ struct BtBridgeState {
     bool    bridge_ready     = false;
 };
 
+// Cover art shared between Core 1 (fills JPEG) and Core 0 (renders to canvas).
+// Write protocol: Core 1 fills data[], stores len (relaxed), then increments
+// generation with memory_order_release. Core 0 reads generation with acquire
+// to establish the happens-before relationship before reading data[].
+struct CoverArtBuf {
+    static constexpr size_t MAX_BYTES = 16384;
+    uint8_t               data[MAX_BYTES];
+    std::atomic<int32_t>  len        { 0 };  // -1 = no art; 0 = not yet set; >0 = JPEG bytes
+    std::atomic<uint32_t> generation { 0 };  // incremented by Core 1 on each track open
+};
+
 // Shared state accessed by both cores and all tasks.
 // Hot-path fields use std::atomic; multi-field reads use the pico mutex.
 struct AppState {
@@ -53,6 +64,7 @@ struct AppState {
     // Playback (guard with mtx for multi-field reads)
     PlaybackState  playback;
     BtBridgeState  bt;
+    CoverArtBuf    cover_art;
 
     bool sd_mounted = false;
     bool usb_active = false;

--- a/firmware/mp3_player/pico/src/app_state.h
+++ b/firmware/mp3_player/pico/src/app_state.h
@@ -14,6 +14,15 @@ enum class AppMode : uint8_t {
 
 enum class RepeatMode : uint8_t { OFF = 0, ONE, ALL };
 
+enum class EqPreset : uint8_t {
+    FLAT = 0,
+    BASS_BOOST,
+    VOCAL,
+    TREBLE,
+    CUSTOM,
+    COUNT
+};
+
 struct TrackInfo {
     char    path[256]    = {};
     char    title[128]   = {};
@@ -28,6 +37,7 @@ struct PlaybackState {
     bool       shuffled  = false;
     RepeatMode repeat    = RepeatMode::OFF;
     uint8_t    volume    = 80;
+    EqPreset   eq_preset = EqPreset::FLAT;
     TrackInfo  current;
     uint16_t   queue_index = 0;
     uint16_t   queue_total = 0;

--- a/firmware/mp3_player/pico/src/audio/eq.cpp
+++ b/firmware/mp3_player/pico/src/audio/eq.cpp
@@ -1,0 +1,84 @@
+#include "eq.h"
+
+static constexpr float kPi = 3.14159265358979323846f;
+
+// Centre frequencies (Hz) for the five bands.
+const float Eq::BAND_FREQS[Eq::NUM_BANDS] = { 60.0f, 250.0f, 1000.0f, 4000.0f, 12000.0f };
+
+// Q factor per band (1.0 gives a moderate shelf width).
+const float Eq::BAND_Q[Eq::NUM_BANDS] = { 1.0f, 1.0f, 1.0f, 1.0f, 1.0f };
+
+// Preset gain tables [dB], rows indexed by EqPreset.
+// Columns: 60 Hz, 250 Hz, 1 kHz, 4 kHz, 12 kHz
+const float Eq::PRESET_GAINS[static_cast<int>(EqPreset::COUNT)][Eq::NUM_BANDS] = {
+    {  0.0f,  0.0f,  0.0f,  0.0f,  0.0f },  // FLAT
+    { +8.0f, +5.0f, -2.0f, -1.0f,  0.0f },  // BASS_BOOST
+    { -2.0f, -1.0f, +5.0f, +4.0f, +1.0f },  // VOCAL
+    {  0.0f, -1.0f, -1.0f, +4.0f, +8.0f },  // TREBLE
+    {  0.0f,  0.0f,  0.0f,  0.0f,  0.0f },  // CUSTOM (placeholder)
+};
+
+void Eq::set_sample_rate(uint32_t hz) {
+    if (hz == 0) return;
+    sample_rate_ = hz;
+    for (int b = 0; b < NUM_BANDS; ++b) recompute(b);
+}
+
+void Eq::apply_preset(EqPreset preset) {
+    const int idx = static_cast<int>(preset);
+    for (int b = 0; b < NUM_BANDS; ++b) {
+        gains_[b] = PRESET_GAINS[idx][b];
+        recompute(b);
+    }
+}
+
+void Eq::recompute(int b) {
+    const float dB = gains_[b];
+
+    // Near-zero gain → identity filter (no history corruption).
+    if (dB > -0.05f && dB < 0.05f) {
+        for (int ch = 0; ch < MAX_CH; ++ch) {
+            auto& f = filters_[ch][b];
+            f.b0 = 1.0f; f.b1 = 0.0f; f.b2 = 0.0f;
+            f.a1 = 0.0f; f.a2 = 0.0f;
+        }
+        return;
+    }
+
+    // Peaking EQ coefficients from Audio EQ Cookbook (Bristow-Johnson).
+    const float A     = std::pow(10.0f, dB / 40.0f);
+    const float w0    = 2.0f * kPi * BAND_FREQS[b] / static_cast<float>(sample_rate_);
+    const float cosw  = std::cos(w0);
+    const float alpha = std::sin(w0) / (2.0f * BAND_Q[b]);
+    const float a0inv = 1.0f / (1.0f + alpha / A);
+
+    const float b0 = (1.0f + alpha * A) * a0inv;
+    const float b1 = (-2.0f * cosw)     * a0inv;
+    const float b2 = (1.0f - alpha * A) * a0inv;
+    const float a1 = (-2.0f * cosw)     * a0inv;  // same as b1
+    const float a2 = (1.0f - alpha / A) * a0inv;
+
+    for (int ch = 0; ch < MAX_CH; ++ch) {
+        auto& f    = filters_[ch][b];
+        f.b0 = b0; f.b1 = b1; f.b2 = b2;
+        f.a1 = a1; f.a2 = a2;
+        // Intentionally preserve state (x1,x2,y1,y2) to avoid clicks on change.
+    }
+}
+
+void Eq::process(int16_t* pcm, size_t sample_pairs, int channels) {
+    if (!enabled || channels < 1) return;
+    const int ch_count = channels < MAX_CH ? channels : MAX_CH;
+
+    for (size_t i = 0; i < sample_pairs; ++i) {
+        for (int ch = 0; ch < ch_count; ++ch) {
+            float s = static_cast<float>(pcm[i * channels + ch]);
+            for (int b = 0; b < NUM_BANDS; ++b)
+                s = filters_[ch][b].process(s);
+            // Hard-clip to int16 range.
+            if      (s >  32767.0f) s =  32767.0f;
+            else if (s < -32768.0f) s = -32768.0f;
+            pcm[i * channels + ch] = static_cast<int16_t>(s);
+        }
+    }
+}

--- a/firmware/mp3_player/pico/src/audio/eq.h
+++ b/firmware/mp3_player/pico/src/audio/eq.h
@@ -1,0 +1,58 @@
+#pragma once
+#include <cstdint>
+#include <cmath>
+
+enum class EqPreset : uint8_t {
+    FLAT      = 0,
+    BASS_BOOST,
+    VOCAL,
+    TREBLE,
+    CUSTOM,      // user-tuned (not settable via UI in this release)
+    COUNT
+};
+
+// Single biquad filter, Direct Form I.
+struct EqBiquad {
+    float b0 = 1.0f, b1 = 0.0f, b2 = 0.0f;  // numerator (normalised)
+    float a1 = 0.0f, a2 = 0.0f;              // denominator (normalised, sign-positive)
+    float x1 = 0.0f, x2 = 0.0f;
+    float y1 = 0.0f, y2 = 0.0f;
+
+    inline float process(float x) {
+        const float y = b0*x + b1*x1 + b2*x2 - a1*y1 - a2*y2;
+        x2 = x1; x1 = x;
+        y2 = y1; y1 = y;
+        return y;
+    }
+};
+
+// 5-band peaking-EQ (Audio EQ Cookbook, Bristow-Johnson).
+// Lives on Core 1 inside SdPlayer; not thread-safe — call set_eq_preset()
+// from Core 0 via SdPlayer::set_eq_preset(), which writes an atomic flag
+// that Core 1 picks up between frames.
+class Eq {
+public:
+    static constexpr int NUM_BANDS = 5;
+    static constexpr int MAX_CH    = 2;  // stereo
+
+    // Centre frequencies, Q factors, preset gains [dB].
+    static const float BAND_FREQS[NUM_BANDS];  // Hz: 60,250,1k,4k,12k
+    static const float BAND_Q[NUM_BANDS];
+    static const float PRESET_GAINS[static_cast<int>(EqPreset::COUNT)][NUM_BANDS];
+
+    bool enabled = true;
+
+    void set_sample_rate(uint32_t hz);
+    void apply_preset(EqPreset preset);
+
+    // Process interleaved stereo (or mono) s16le in-place.
+    // sample_pairs = number of audio frames; channels = 1 or 2.
+    void process(int16_t* pcm, size_t sample_pairs, int channels);
+
+private:
+    void recompute(int band);
+
+    EqBiquad filters_[MAX_CH][NUM_BANDS] = {};
+    float    gains_[NUM_BANDS]           = {};
+    uint32_t sample_rate_                = 44100;
+};

--- a/firmware/mp3_player/pico/src/audio/sd_player.cpp
+++ b/firmware/mp3_player/pico/src/audio/sd_player.cpp
@@ -26,8 +26,6 @@ static uint32_t be32(const uint8_t b[4]) {
 }
 
 // ── ID3v2 text decoding ────────────────────────────────────────────────────
-// Converts an ID3v2 text frame payload to null-terminated UTF-8 in dst.
-// enc: 0=ISO-8859-1, 1=UTF-16 w/BOM, 2=UTF-16BE, 3=UTF-8.
 static void decode_id3_text(uint8_t enc, const uint8_t* raw, size_t len,
                              char* dst, size_t cap) {
     if (cap == 0) return;
@@ -48,24 +46,20 @@ static void decode_id3_text(uint8_t enc, const uint8_t* raw, size_t len,
                 dst[di++] = static_cast<char>(0x80 | (cp & 0x3F));
             }
         }
-        // Supplementary planes omitted — not needed for music metadata.
     };
 
     if (enc == 0) {
-        // ISO-8859-1: code points equal Unicode code points.
         for (size_t i = 0; i < len; ++i) {
             uint8_t c = raw[i];
             if (c == 0) break;
             emit_utf8(c);
         }
     } else if (enc == 3) {
-        // UTF-8 passthrough.
         for (size_t i = 0; i < len; ++i) {
             if (raw[i] == 0) break;
             if (di + 1 < cap) dst[di++] = static_cast<char>(raw[i]);
         }
     } else {
-        // UTF-16 (enc=1 w/BOM, enc=2 BE w/o BOM).
         size_t start = 0;
         bool be_order = (enc == 2);
         if (enc == 1 && len >= 2) {
@@ -84,13 +78,10 @@ static void decode_id3_text(uint8_t enc, const uint8_t* raw, size_t len,
 }
 
 // ── MP3 duration estimation ────────────────────────────────────────────────
-// MPEG1 Layer3 bitrate table (kbps), indexed by the 4-bit header field.
 static const uint16_t k_mpeg1_l3_kbps[16] = {
     0, 32, 40, 48, 56, 64, 80, 96, 112, 128, 160, 192, 224, 256, 320, 0
 };
 
-// Estimate MP3 playback duration by inspecting the Xing/Info VBR header or
-// falling back to CBR file-size arithmetic.
 static uint32_t estimate_mp3_duration(File& f, uint32_t audio_start,
                                       uint32_t file_size) {
     if (!f.seek(audio_start)) return 0;
@@ -99,19 +90,18 @@ static uint32_t estimate_mp3_duration(File& f, uint32_t audio_start,
     const size_t n = f.read(scan_buf, sizeof(scan_buf));
     if (n < 4) return 0;
 
-    // Find first valid MPEG Layer3 sync word.
     uint8_t  hdr[4] = {};
     uint32_t frame_file_offset = audio_start;
     bool found = false;
     for (size_t i = 0; i + 4 <= n; ++i) {
         if (scan_buf[i] != 0xFF) continue;
         const uint8_t b1 = scan_buf[i + 1];
-        if ((b1 & 0xE0) != 0xE0) continue;     // not sync
-        if ((b1 & 0x06) != 0x02) continue;     // not Layer3
-        if ((b1 & 0x18) == 0x08) continue;     // reserved MPEG version
+        if ((b1 & 0xE0) != 0xE0) continue;
+        if ((b1 & 0x06) != 0x02) continue;
+        if ((b1 & 0x18) == 0x08) continue;
         const uint8_t br_idx = (scan_buf[i + 2] >> 4) & 0x0F;
         if (br_idx == 0 || br_idx == 15) continue;
-        if (((scan_buf[i + 2] >> 2) & 0x03) == 3) continue;  // reserved sample rate
+        if (((scan_buf[i + 2] >> 2) & 0x03) == 3) continue;
         memcpy(hdr, scan_buf + i, 4);
         frame_file_offset = audio_start + static_cast<uint32_t>(i);
         found = true;
@@ -119,7 +109,7 @@ static uint32_t estimate_mp3_duration(File& f, uint32_t audio_start,
     }
     if (!found) return 0;
 
-    const uint8_t mpeg_ver = (hdr[1] >> 3) & 0x03;  // 3=MPEG1, 2=MPEG2, 0=MPEG2.5
+    const uint8_t mpeg_ver = (hdr[1] >> 3) & 0x03;
     const bool    is_mono  = ((hdr[3] >> 6) & 0x03) == 3;
     const uint8_t sr_idx   = (hdr[2] >> 2) & 0x03;
 
@@ -131,18 +121,16 @@ static uint32_t estimate_mp3_duration(File& f, uint32_t audio_start,
                                : k_sr25[sr_idx];
     if (sample_rate == 0) return 0;
 
-    // Side-info sizes: MPEG1 stereo=32 mono=17, MPEG2/2.5 stereo=17 mono=9.
     const uint8_t si_sz = (mpeg_ver == 3) ? (is_mono ? 17u : 32u)
                                            : (is_mono ?  9u : 17u);
 
-    // Seek to the Xing/Info tag position (right after frame header + side info).
     if (!f.seek(frame_file_offset + 4 + si_sz)) return 0;
     uint8_t xhdr[8];
     if (f.read(xhdr, 8) != 8) return 0;
 
     if (memcmp(xhdr, "Xing", 4) == 0 || memcmp(xhdr, "Info", 4) == 0) {
         const uint32_t xflags = be32(xhdr + 4);
-        if (xflags & 0x01) {  // bit 0 = total frame count present
+        if (xflags & 0x01) {
             uint8_t tf[4];
             if (f.read(tf, 4) == 4) {
                 const uint32_t total_frames = be32(tf);
@@ -152,7 +140,6 @@ static uint32_t estimate_mp3_duration(File& f, uint32_t audio_start,
         }
     }
 
-    // CBR fallback: audio_bytes / (bitrate_bps / 8).
     const uint8_t  br_idx     = (hdr[2] >> 4) & 0x0F;
     const uint32_t br_kbps    = k_mpeg1_l3_kbps[br_idx];
     if (br_kbps == 0) return 0;
@@ -213,7 +200,8 @@ void SdPlayer::decode_mp3(File& f) {
     static uint8_t  file_buf[16384];
     static int16_t  pcm_buf[DECODE_BUF_SAMPLES];
     size_t   buf_filled = 0;
-    uint64_t total_pcm_samples = 0;  // 64-bit to avoid integer-division truncation
+    uint64_t total_pcm_samples = 0;
+    uint32_t last_hz = 0;
 
     for (;;) {
         if (stop_req_.load() || skip_next_.load() || skip_prev_.load()) break;
@@ -235,8 +223,19 @@ void SdPlayer::decode_mp3(File& f) {
         buf_filled -= info.frame_bytes;
         memmove(file_buf, file_buf + info.frame_bytes, buf_filled);
 
+        // Sync EQ sample rate on first frame or sample-rate change.
+        if (info.hz != 0 && info.hz != last_hz) {
+            last_hz = info.hz;
+            eq_.set_sample_rate(info.hz);
+        }
+
+        // Apply any pending EQ preset change from Core 0.
+        const uint8_t preq = eq_preset_req_.exchange(0xFF);
+        if (preq != 0xFF) eq_.apply_preset(static_cast<EqPreset>(preq));
+
         if (samples > 0) {
             apply_volume(pcm_buf, static_cast<size_t>(samples) * info.channels);
+            eq_.process(pcm_buf, static_cast<size_t>(samples), info.channels);
             if (on_pcm_frame) on_pcm_frame(pcm_buf, static_cast<size_t>(samples));
 
             total_pcm_samples += static_cast<uint64_t>(samples);
@@ -266,16 +265,24 @@ void SdPlayer::decode_flac(File& f) {
 
     static int16_t pcm_buf[DECODE_BUF_SAMPLES];
     constexpr drflac_uint64 CHUNK = DECODE_BUF_SAMPLES / 2;
-    uint64_t total_pcm_frames = 0;  // 64-bit to avoid integer-division truncation
+    uint64_t total_pcm_frames = 0;
+
+    // Prime EQ sample rate from STREAMINFO.
+    if (pFlac->sampleRate > 0) eq_.set_sample_rate(pFlac->sampleRate);
 
     for (;;) {
         if (stop_req_.load() || skip_next_.load() || skip_prev_.load()) break;
         if (!playing_.load()) { sleep_ms(5); continue; }
 
+        // Apply any pending EQ preset change from Core 0.
+        const uint8_t preq = eq_preset_req_.exchange(0xFF);
+        if (preq != 0xFF) eq_.apply_preset(static_cast<EqPreset>(preq));
+
         const drflac_uint64 got = drflac_read_pcm_frames_s16(pFlac, CHUNK, pcm_buf);
         if (got == 0) break;
 
         apply_volume(pcm_buf, static_cast<size_t>(got) * pFlac->channels);
+        eq_.process(pcm_buf, static_cast<size_t>(got), pFlac->channels);
         if (on_pcm_frame) on_pcm_frame(pcm_buf, static_cast<size_t>(got));
 
         total_pcm_frames += got;
@@ -294,7 +301,6 @@ bool SdPlayer::open_track(const std::string& path) {
     strncpy(info.path, path.c_str(), sizeof(info.path) - 1);
     read_tags(path, info);
 
-    // FLAC: get exact duration from STREAMINFO metadata block.
     const char* ext = strrchr(path.c_str(), '.');
     if (ext && strcasecmp(ext, ".flac") == 0 && info.duration_s == 0) {
         File fmeta = SD.open(path.c_str(), FILE_READ);
@@ -310,7 +316,7 @@ bool SdPlayer::open_track(const std::string& path) {
         }
     }
 
-    extract_cover_art(path);  // fills state_.cover_art before mutex section
+    extract_cover_art(path);
 
     mutex_enter_blocking(&state_.mtx);
     state_.playback.current = info;
@@ -336,27 +342,23 @@ void SdPlayer::read_tags(const std::string& path, TrackInfo& out) {
     const char* dot = strrchr(path.c_str(), '.');
     const bool is_mp3 = dot && strcasecmp(dot, ".mp3") == 0;
 
-    uint32_t id3v2_end = 0;  // byte offset where audio data begins (0 if no ID3v2)
+    uint32_t id3v2_end = 0;
 
-    // ── ID3v2 ──────────────────────────────────────────────────────────────
     uint8_t id3_hdr[10];
     if (f.read(id3_hdr, 10) == 10 &&
         id3_hdr[0] == 'I' && id3_hdr[1] == 'D' && id3_hdr[2] == '3') {
 
-        const uint8_t  ver     = id3_hdr[3];
-        const uint8_t  flags   = id3_hdr[5];
-        const uint32_t tag_sz  = syncsafe_to_uint32(id3_hdr + 6);
+        const uint8_t  ver    = id3_hdr[3];
+        const uint8_t  flags  = id3_hdr[5];
+        const uint32_t tag_sz = syncsafe_to_uint32(id3_hdr + 6);
         id3v2_end = 10 + tag_sz;
 
         if (ver == 3 || ver == 4) {
             uint32_t pos = 10;
 
-            // Skip extended header if present (flags bit 6).
             if (flags & 0x40) {
                 uint8_t exhdr[4];
                 if (f.read(exhdr, 4) == 4) {
-                    // v2.4: syncsafe size includes itself.
-                    // v2.3: big-endian size excludes itself (add the 4 we just read).
                     const uint32_t exsz = (ver == 4) ? syncsafe_to_uint32(exhdr)
                                                      : (4 + be32(exhdr));
                     f.seek(pos + exsz);
@@ -364,12 +366,12 @@ void SdPlayer::read_tags(const std::string& path, TrackInfo& out) {
                 }
             }
 
-            static uint8_t payload[512];  // static: Core 1 only, non-reentrant
+            static uint8_t payload[512];
 
             while (pos + 10 <= id3v2_end) {
                 uint8_t fhdr[10];
                 if (f.read(fhdr, 10) != 10) break;
-                if (fhdr[0] == 0) break;  // zero-padding reached
+                if (fhdr[0] == 0) break;
 
                 const uint32_t fsize = (ver == 4) ? syncsafe_to_uint32(fhdr + 4)
                                                    : be32(fhdr + 4);
@@ -413,14 +415,12 @@ void SdPlayer::read_tags(const std::string& path, TrackInfo& out) {
         }
     }
 
-    // ── ID3v1 fallback ─────────────────────────────────────────────────────
     if ((out.title[0] == '\0' || out.artist[0] == '\0' || out.album[0] == '\0')
         && file_size >= 128) {
         f.seek(file_size - 128);
         uint8_t tag[128];
         if (f.read(tag, 128) == 128 &&
             tag[0] == 'T' && tag[1] == 'A' && tag[2] == 'G') {
-            // Strip trailing spaces/nulls from fixed-width ID3v1 fields.
             auto strip = [](char* s, size_t n) {
                 for (int i = static_cast<int>(n) - 1; i >= 0; --i) {
                     if (s[i] == ' ' || s[i] == '\0') s[i] = '\0'; else break;
@@ -438,13 +438,11 @@ void SdPlayer::read_tags(const std::string& path, TrackInfo& out) {
         }
     }
 
-    // ── MP3 duration ───────────────────────────────────────────────────────
     if (is_mp3 && out.duration_s == 0)
         out.duration_s = estimate_mp3_duration(f, id3v2_end, file_size);
 
     f.close();
 
-    // Filename fallback for title.
     if (out.title[0] == '\0') {
         const char* slash = strrchr(path.c_str(), '/');
         const char* name  = slash ? slash + 1 : path.c_str();
@@ -501,6 +499,13 @@ void SdPlayer::set_volume(uint8_t vol) {
     volume_.store(vol > 100 ? 100 : vol);
     mutex_enter_blocking(&state_.mtx);
     state_.playback.volume = volume_.load();
+    mutex_exit(&state_.mtx);
+}
+
+void SdPlayer::set_eq_preset(EqPreset p) {
+    eq_preset_req_.store(static_cast<uint8_t>(p));
+    mutex_enter_blocking(&state_.mtx);
+    state_.playback.eq_preset = p;
     mutex_exit(&state_.mtx);
 }
 

--- a/firmware/mp3_player/pico/src/audio/sd_player.cpp
+++ b/firmware/mp3_player/pico/src/audio/sd_player.cpp
@@ -142,6 +142,7 @@ bool SdPlayer::open_track(const std::string& path) {
     TrackInfo info;
     strncpy(info.path, path.c_str(), sizeof(info.path) - 1);
     read_tags(path, info);
+    extract_cover_art(path);  // fills state_.cover_art before mutex section
 
     mutex_enter_blocking(&state_.mtx);
     state_.playback.current = info;
@@ -186,7 +187,43 @@ void SdPlayer::read_tags(const std::string& path, TrackInfo& out) {
     }
 }
 
-// ── Thread-safe controls ──────────────────────────────────────────────────────
+void SdPlayer::extract_cover_art(const std::string& track_path) {
+    CoverArtBuf& art = state_.cover_art;
+
+    // Compute the directory containing this track.
+    const size_t slash = track_path.rfind('/');
+    const std::string dir = (slash != std::string::npos)
+                            ? track_path.substr(0, slash)
+                            : std::string("/");
+
+    // Common cover art filenames, tried in order.
+    static const char* const k_names[] = {
+        "cover.jpg", "Cover.jpg", "folder.jpg", "Folder.jpg",
+        "album.jpg", "Album.jpg", nullptr
+    };
+
+    for (const char* const* n = k_names; *n; ++n) {
+        const std::string p = dir + "/" + *n;
+        File f = SD.open(p.c_str(), FILE_READ);
+        if (!f) continue;
+
+        const size_t got = f.read(art.data, CoverArtBuf::MAX_BYTES);
+        f.close();
+
+        // Validate JPEG SOI marker (FF D8).
+        if (got >= 4 && art.data[0] == 0xFF && art.data[1] == 0xD8) {
+            art.len.store(static_cast<int32_t>(got), std::memory_order_relaxed);
+            art.generation.fetch_add(1, std::memory_order_release);
+            return;
+        }
+    }
+
+    // No art found for this track.
+    art.len.store(-1, std::memory_order_relaxed);
+    art.generation.fetch_add(1, std::memory_order_release);
+}
+
+// ── Thread-safe controls ───────────────────────────────────────────────────
 
 void SdPlayer::play()   { playing_.store(true); }
 void SdPlayer::pause()  { playing_.store(false); }

--- a/firmware/mp3_player/pico/src/audio/sd_player.cpp
+++ b/firmware/mp3_player/pico/src/audio/sd_player.cpp
@@ -13,6 +13,156 @@
 #define DR_FLAC_NO_STDIO
 #include "vendor/dr_flac.h"
 
+// ── Syncsafe / big-endian helpers ─────────────────────────────────────────
+
+static uint32_t syncsafe_to_uint32(const uint8_t b[4]) {
+    return ((uint32_t)b[0] << 21) | ((uint32_t)b[1] << 14) |
+           ((uint32_t)b[2] << 7)  | b[3];
+}
+
+static uint32_t be32(const uint8_t b[4]) {
+    return ((uint32_t)b[0] << 24) | ((uint32_t)b[1] << 16) |
+           ((uint32_t)b[2] << 8)  | b[3];
+}
+
+// ── ID3v2 text decoding ────────────────────────────────────────────────────
+// Converts an ID3v2 text frame payload to null-terminated UTF-8 in dst.
+// enc: 0=ISO-8859-1, 1=UTF-16 w/BOM, 2=UTF-16BE, 3=UTF-8.
+static void decode_id3_text(uint8_t enc, const uint8_t* raw, size_t len,
+                             char* dst, size_t cap) {
+    if (cap == 0) return;
+    size_t di = 0;
+
+    auto emit_utf8 = [&](uint32_t cp) {
+        if (cp < 0x80) {
+            if (di + 1 < cap) dst[di++] = static_cast<char>(cp);
+        } else if (cp < 0x800) {
+            if (di + 2 < cap) {
+                dst[di++] = static_cast<char>(0xC0 | (cp >> 6));
+                dst[di++] = static_cast<char>(0x80 | (cp & 0x3F));
+            }
+        } else if (cp < 0x10000) {
+            if (di + 3 < cap) {
+                dst[di++] = static_cast<char>(0xE0 | (cp >> 12));
+                dst[di++] = static_cast<char>(0x80 | ((cp >> 6) & 0x3F));
+                dst[di++] = static_cast<char>(0x80 | (cp & 0x3F));
+            }
+        }
+        // Supplementary planes omitted — not needed for music metadata.
+    };
+
+    if (enc == 0) {
+        // ISO-8859-1: code points equal Unicode code points.
+        for (size_t i = 0; i < len; ++i) {
+            uint8_t c = raw[i];
+            if (c == 0) break;
+            emit_utf8(c);
+        }
+    } else if (enc == 3) {
+        // UTF-8 passthrough.
+        for (size_t i = 0; i < len; ++i) {
+            if (raw[i] == 0) break;
+            if (di + 1 < cap) dst[di++] = static_cast<char>(raw[i]);
+        }
+    } else {
+        // UTF-16 (enc=1 w/BOM, enc=2 BE w/o BOM).
+        size_t start = 0;
+        bool be_order = (enc == 2);
+        if (enc == 1 && len >= 2) {
+            if      (raw[0] == 0xFE && raw[1] == 0xFF) { be_order = true;  start = 2; }
+            else if (raw[0] == 0xFF && raw[1] == 0xFE) { be_order = false; start = 2; }
+        }
+        for (size_t i = start; i + 1 < len; i += 2) {
+            uint16_t cp = be_order
+                ? (static_cast<uint16_t>(raw[i]) << 8 | raw[i + 1])
+                : (static_cast<uint16_t>(raw[i + 1]) << 8 | raw[i]);
+            if (cp == 0) break;
+            emit_utf8(cp);
+        }
+    }
+    dst[di] = '\0';
+}
+
+// ── MP3 duration estimation ────────────────────────────────────────────────
+// MPEG1 Layer3 bitrate table (kbps), indexed by the 4-bit header field.
+static const uint16_t k_mpeg1_l3_kbps[16] = {
+    0, 32, 40, 48, 56, 64, 80, 96, 112, 128, 160, 192, 224, 256, 320, 0
+};
+
+// Estimate MP3 playback duration by inspecting the Xing/Info VBR header or
+// falling back to CBR file-size arithmetic.
+static uint32_t estimate_mp3_duration(File& f, uint32_t audio_start,
+                                      uint32_t file_size) {
+    if (!f.seek(audio_start)) return 0;
+
+    static uint8_t scan_buf[4096];
+    const size_t n = f.read(scan_buf, sizeof(scan_buf));
+    if (n < 4) return 0;
+
+    // Find first valid MPEG Layer3 sync word.
+    uint8_t  hdr[4] = {};
+    uint32_t frame_file_offset = audio_start;
+    bool found = false;
+    for (size_t i = 0; i + 4 <= n; ++i) {
+        if (scan_buf[i] != 0xFF) continue;
+        const uint8_t b1 = scan_buf[i + 1];
+        if ((b1 & 0xE0) != 0xE0) continue;     // not sync
+        if ((b1 & 0x06) != 0x02) continue;     // not Layer3
+        if ((b1 & 0x18) == 0x08) continue;     // reserved MPEG version
+        const uint8_t br_idx = (scan_buf[i + 2] >> 4) & 0x0F;
+        if (br_idx == 0 || br_idx == 15) continue;
+        if (((scan_buf[i + 2] >> 2) & 0x03) == 3) continue;  // reserved sample rate
+        memcpy(hdr, scan_buf + i, 4);
+        frame_file_offset = audio_start + static_cast<uint32_t>(i);
+        found = true;
+        break;
+    }
+    if (!found) return 0;
+
+    const uint8_t mpeg_ver = (hdr[1] >> 3) & 0x03;  // 3=MPEG1, 2=MPEG2, 0=MPEG2.5
+    const bool    is_mono  = ((hdr[3] >> 6) & 0x03) == 3;
+    const uint8_t sr_idx   = (hdr[2] >> 2) & 0x03;
+
+    const uint32_t k_sr1[4]  = { 44100, 48000, 32000, 0 };
+    const uint32_t k_sr2[4]  = { 22050, 24000, 16000, 0 };
+    const uint32_t k_sr25[4] = { 11025, 12000,  8000, 0 };
+    const uint32_t sample_rate = (mpeg_ver == 3) ? k_sr1[sr_idx]
+                               : (mpeg_ver == 2) ? k_sr2[sr_idx]
+                               : k_sr25[sr_idx];
+    if (sample_rate == 0) return 0;
+
+    // Side-info sizes: MPEG1 stereo=32 mono=17, MPEG2/2.5 stereo=17 mono=9.
+    const uint8_t si_sz = (mpeg_ver == 3) ? (is_mono ? 17u : 32u)
+                                           : (is_mono ?  9u : 17u);
+
+    // Seek to the Xing/Info tag position (right after frame header + side info).
+    if (!f.seek(frame_file_offset + 4 + si_sz)) return 0;
+    uint8_t xhdr[8];
+    if (f.read(xhdr, 8) != 8) return 0;
+
+    if (memcmp(xhdr, "Xing", 4) == 0 || memcmp(xhdr, "Info", 4) == 0) {
+        const uint32_t xflags = be32(xhdr + 4);
+        if (xflags & 0x01) {  // bit 0 = total frame count present
+            uint8_t tf[4];
+            if (f.read(tf, 4) == 4) {
+                const uint32_t total_frames = be32(tf);
+                if (total_frames > 0)
+                    return static_cast<uint32_t>((uint64_t)total_frames * 1152 / sample_rate);
+            }
+        }
+    }
+
+    // CBR fallback: audio_bytes / (bitrate_bps / 8).
+    const uint8_t  br_idx     = (hdr[2] >> 4) & 0x0F;
+    const uint32_t br_kbps    = k_mpeg1_l3_kbps[br_idx];
+    if (br_kbps == 0) return 0;
+    const uint32_t audio_bytes = (file_size > frame_file_offset)
+                                 ? (file_size - frame_file_offset) : 0;
+    return static_cast<uint32_t>((uint64_t)audio_bytes * 8 / (br_kbps * 1000));
+}
+
+// ── SdPlayer implementation ────────────────────────────────────────────────
+
 SdPlayer::SdPlayer(AppState& state) : state_(state) {
     mutex_init(&queue_mtx_);
 }
@@ -24,10 +174,8 @@ void SdPlayer::run() {
             continue;
         }
 
-        // Reload queue if requested from Core 0.
         if (queue_dirty_.load()) {
             queue_dirty_.store(false);
-            // queue_ was updated under queue_mtx_ by load_queue().
         }
 
         if (queue_.empty()) {
@@ -38,7 +186,6 @@ void SdPlayer::run() {
 
         const std::string path = queue_.current();
         if (open_track(path)) {
-            // Identify format by extension.
             const char* ext = strrchr(path.c_str(), '.');
             bool is_flac = ext && (strcasecmp(ext, ".flac") == 0);
 
@@ -54,7 +201,6 @@ void SdPlayer::run() {
         if (skip_next_.load())  { skip_next_.store(false); }
         if (skip_prev_.load())  { skip_prev_.store(false); queue_.prev(); queue_.prev(); }
 
-        // Advance queue on natural end-of-track.
         if (!queue_.next(state_.playback.repeat))
             playing_.store(false);
     }
@@ -66,39 +212,40 @@ void SdPlayer::decode_mp3(File& f) {
 
     static uint8_t  file_buf[16384];
     static int16_t  pcm_buf[DECODE_BUF_SAMPLES];
-    size_t buf_filled = 0;
+    size_t   buf_filled = 0;
+    uint64_t total_pcm_samples = 0;  // 64-bit to avoid integer-division truncation
 
     for (;;) {
         if (stop_req_.load() || skip_next_.load() || skip_prev_.load()) break;
 
         if (!playing_.load()) { sleep_ms(5); continue; }
 
-        // Refill file buffer.
         const size_t space = sizeof(file_buf) - buf_filled;
         if (space > 0 && f.available()) {
             const size_t got = f.read(file_buf + buf_filled, space);
             buf_filled += got;
         }
-        if (buf_filled == 0) break;  // EOF
+        if (buf_filled == 0) break;
 
         mp3dec_frame_info_t info;
-        const int samples = mp3dec_decode_frame(&dec, file_buf, static_cast<int>(buf_filled),
-                                                 pcm_buf, &info);
-        if (info.frame_bytes == 0) break;  // sync error / EOF
+        const int samples = mp3dec_decode_frame(&dec, file_buf,
+                                                static_cast<int>(buf_filled),
+                                                pcm_buf, &info);
+        if (info.frame_bytes == 0) break;
         buf_filled -= info.frame_bytes;
         memmove(file_buf, file_buf + info.frame_bytes, buf_filled);
 
         if (samples > 0) {
             apply_volume(pcm_buf, static_cast<size_t>(samples) * info.channels);
             if (on_pcm_frame) on_pcm_frame(pcm_buf, static_cast<size_t>(samples));
-        }
 
-        // Update position.
-        if (info.hz > 0 && samples > 0) {
-            mutex_enter_blocking(&state_.mtx);
-            state_.playback.current.position_s =
-                state_.playback.current.position_s + samples / info.hz;
-            mutex_exit(&state_.mtx);
+            total_pcm_samples += static_cast<uint64_t>(samples);
+            if (info.hz > 0) {
+                mutex_enter_blocking(&state_.mtx);
+                state_.playback.current.position_s =
+                    static_cast<uint32_t>(total_pcm_samples / info.hz);
+                mutex_exit(&state_.mtx);
+            }
         }
     }
 }
@@ -118,7 +265,8 @@ void SdPlayer::decode_flac(File& f) {
     if (!pFlac) return;
 
     static int16_t pcm_buf[DECODE_BUF_SAMPLES];
-    constexpr drflac_uint64 CHUNK = DECODE_BUF_SAMPLES / 2;  // sample pairs
+    constexpr drflac_uint64 CHUNK = DECODE_BUF_SAMPLES / 2;
+    uint64_t total_pcm_frames = 0;  // 64-bit to avoid integer-division truncation
 
     for (;;) {
         if (stop_req_.load() || skip_next_.load() || skip_prev_.load()) break;
@@ -130,10 +278,13 @@ void SdPlayer::decode_flac(File& f) {
         apply_volume(pcm_buf, static_cast<size_t>(got) * pFlac->channels);
         if (on_pcm_frame) on_pcm_frame(pcm_buf, static_cast<size_t>(got));
 
-        mutex_enter_blocking(&state_.mtx);
-        if (pFlac->sampleRate > 0)
-            state_.playback.current.position_s += static_cast<uint32_t>(got / pFlac->sampleRate);
-        mutex_exit(&state_.mtx);
+        total_pcm_frames += got;
+        if (pFlac->sampleRate > 0) {
+            mutex_enter_blocking(&state_.mtx);
+            state_.playback.current.position_s =
+                static_cast<uint32_t>(total_pcm_frames / pFlac->sampleRate);
+            mutex_exit(&state_.mtx);
+        }
     }
     drflac_close(pFlac);
 }
@@ -142,6 +293,23 @@ bool SdPlayer::open_track(const std::string& path) {
     TrackInfo info;
     strncpy(info.path, path.c_str(), sizeof(info.path) - 1);
     read_tags(path, info);
+
+    // FLAC: get exact duration from STREAMINFO metadata block.
+    const char* ext = strrchr(path.c_str(), '.');
+    if (ext && strcasecmp(ext, ".flac") == 0 && info.duration_s == 0) {
+        File fmeta = SD.open(path.c_str(), FILE_READ);
+        if (fmeta) {
+            drflac* pf = drflac_open(drflac_read_cb, drflac_seek_cb, &fmeta, nullptr);
+            if (pf) {
+                if (pf->sampleRate > 0)
+                    info.duration_s = static_cast<uint32_t>(
+                        pf->totalPCMFrameCount / pf->sampleRate);
+                drflac_close(pf);
+            }
+            fmeta.close();
+        }
+    }
+
     extract_cover_art(path);  // fills state_.cover_art before mutex section
 
     mutex_enter_blocking(&state_.mtx);
@@ -161,42 +329,140 @@ void SdPlayer::apply_volume(int16_t* pcm, size_t samples) {
 }
 
 void SdPlayer::read_tags(const std::string& path, TrackInfo& out) {
-    // Minimal ID3v1 (last 128 bytes of file): TAG + 30-byte title + 30-byte artist + ...
     File f = SD.open(path.c_str(), FILE_READ);
     if (!f) return;
-    const size_t fsize = f.size();
-    if (fsize >= 128) {
-        f.seek(fsize - 128);
-        uint8_t tag[128];
-        f.read(tag, 128);
-        if (tag[0] == 'T' && tag[1] == 'A' && tag[2] == 'G') {
-            memcpy(out.title,  tag +  3, 30);  out.title[30]  = '\0';
-            memcpy(out.artist, tag + 33, 30);  out.artist[30] = '\0';
-            memcpy(out.album,  tag + 63, 30);  out.album[30]  = '\0';
+    const uint32_t file_size = static_cast<uint32_t>(f.size());
+
+    const char* dot = strrchr(path.c_str(), '.');
+    const bool is_mp3 = dot && strcasecmp(dot, ".mp3") == 0;
+
+    uint32_t id3v2_end = 0;  // byte offset where audio data begins (0 if no ID3v2)
+
+    // ── ID3v2 ──────────────────────────────────────────────────────────────
+    uint8_t id3_hdr[10];
+    if (f.read(id3_hdr, 10) == 10 &&
+        id3_hdr[0] == 'I' && id3_hdr[1] == 'D' && id3_hdr[2] == '3') {
+
+        const uint8_t  ver     = id3_hdr[3];
+        const uint8_t  flags   = id3_hdr[5];
+        const uint32_t tag_sz  = syncsafe_to_uint32(id3_hdr + 6);
+        id3v2_end = 10 + tag_sz;
+
+        if (ver == 3 || ver == 4) {
+            uint32_t pos = 10;
+
+            // Skip extended header if present (flags bit 6).
+            if (flags & 0x40) {
+                uint8_t exhdr[4];
+                if (f.read(exhdr, 4) == 4) {
+                    // v2.4: syncsafe size includes itself.
+                    // v2.3: big-endian size excludes itself (add the 4 we just read).
+                    const uint32_t exsz = (ver == 4) ? syncsafe_to_uint32(exhdr)
+                                                     : (4 + be32(exhdr));
+                    f.seek(pos + exsz);
+                    pos += exsz;
+                }
+            }
+
+            static uint8_t payload[512];  // static: Core 1 only, non-reentrant
+
+            while (pos + 10 <= id3v2_end) {
+                uint8_t fhdr[10];
+                if (f.read(fhdr, 10) != 10) break;
+                if (fhdr[0] == 0) break;  // zero-padding reached
+
+                const uint32_t fsize = (ver == 4) ? syncsafe_to_uint32(fhdr + 4)
+                                                   : be32(fhdr + 4);
+                pos += 10;
+                if (fsize == 0 || pos + fsize > id3v2_end) {
+                    f.seek(pos + fsize);
+                    pos += fsize;
+                    continue;
+                }
+
+                const bool is_tit2 = memcmp(fhdr, "TIT2", 4) == 0;
+                const bool is_tpe1 = memcmp(fhdr, "TPE1", 4) == 0;
+                const bool is_talb = memcmp(fhdr, "TALB", 4) == 0;
+                const bool is_tlen = memcmp(fhdr, "TLEN", 4) == 0;
+
+                if ((is_tit2 || is_tpe1 || is_talb || is_tlen) && fsize >= 2) {
+                    const size_t to_read = fsize < sizeof(payload) ? fsize : sizeof(payload);
+                    const size_t got = f.read(payload, to_read);
+                    if (fsize > sizeof(payload)) f.seek(pos + fsize);
+
+                    if (got >= 2) {
+                        char tmp[128];
+                        decode_id3_text(payload[0], payload + 1, got - 1, tmp, sizeof(tmp));
+
+                        if (is_tit2 && out.title[0]  == '\0')
+                            strncpy(out.title,  tmp, sizeof(out.title)  - 1);
+                        if (is_tpe1 && out.artist[0] == '\0')
+                            strncpy(out.artist, tmp, sizeof(out.artist) - 1);
+                        if (is_talb && out.album[0]  == '\0')
+                            strncpy(out.album,  tmp, sizeof(out.album)  - 1);
+                        if (is_tlen && out.duration_s == 0) {
+                            const long ms = atol(tmp);
+                            if (ms > 0) out.duration_s = static_cast<uint32_t>(ms / 1000);
+                        }
+                    }
+                } else {
+                    f.seek(pos + fsize);
+                }
+                pos += fsize;
+            }
         }
     }
+
+    // ── ID3v1 fallback ─────────────────────────────────────────────────────
+    if ((out.title[0] == '\0' || out.artist[0] == '\0' || out.album[0] == '\0')
+        && file_size >= 128) {
+        f.seek(file_size - 128);
+        uint8_t tag[128];
+        if (f.read(tag, 128) == 128 &&
+            tag[0] == 'T' && tag[1] == 'A' && tag[2] == 'G') {
+            // Strip trailing spaces/nulls from fixed-width ID3v1 fields.
+            auto strip = [](char* s, size_t n) {
+                for (int i = static_cast<int>(n) - 1; i >= 0; --i) {
+                    if (s[i] == ' ' || s[i] == '\0') s[i] = '\0'; else break;
+                }
+            };
+            if (out.title[0]  == '\0') {
+                memcpy(out.title,  tag +  3, 30); out.title[30]  = '\0'; strip(out.title,  30);
+            }
+            if (out.artist[0] == '\0') {
+                memcpy(out.artist, tag + 33, 30); out.artist[30] = '\0'; strip(out.artist, 30);
+            }
+            if (out.album[0]  == '\0') {
+                memcpy(out.album,  tag + 63, 30); out.album[30]  = '\0'; strip(out.album,  30);
+            }
+        }
+    }
+
+    // ── MP3 duration ───────────────────────────────────────────────────────
+    if (is_mp3 && out.duration_s == 0)
+        out.duration_s = estimate_mp3_duration(f, id3v2_end, file_size);
+
     f.close();
 
-    // Fallback: use filename stripped of extension as title.
+    // Filename fallback for title.
     if (out.title[0] == '\0') {
         const char* slash = strrchr(path.c_str(), '/');
         const char* name  = slash ? slash + 1 : path.c_str();
-        const char* dot   = strrchr(name, '.');
-        const size_t len  = dot ? static_cast<size_t>(dot - name) : strlen(name);
-        strncpy(out.title, name, len < sizeof(out.title) - 1 ? len : sizeof(out.title) - 1);
+        const char* ddot  = strrchr(name, '.');
+        const size_t len  = ddot ? static_cast<size_t>(ddot - name) : strlen(name);
+        const size_t cap  = sizeof(out.title) - 1;
+        strncpy(out.title, name, len < cap ? len : cap);
     }
 }
 
 void SdPlayer::extract_cover_art(const std::string& track_path) {
     CoverArtBuf& art = state_.cover_art;
 
-    // Compute the directory containing this track.
     const size_t slash = track_path.rfind('/');
     const std::string dir = (slash != std::string::npos)
                             ? track_path.substr(0, slash)
                             : std::string("/");
 
-    // Common cover art filenames, tried in order.
     static const char* const k_names[] = {
         "cover.jpg", "Cover.jpg", "folder.jpg", "Folder.jpg",
         "album.jpg", "Album.jpg", nullptr
@@ -210,7 +476,6 @@ void SdPlayer::extract_cover_art(const std::string& track_path) {
         const size_t got = f.read(art.data, CoverArtBuf::MAX_BYTES);
         f.close();
 
-        // Validate JPEG SOI marker (FF D8).
         if (got >= 4 && art.data[0] == 0xFF && art.data[1] == 0xD8) {
             art.len.store(static_cast<int32_t>(got), std::memory_order_relaxed);
             art.generation.fetch_add(1, std::memory_order_release);
@@ -218,7 +483,6 @@ void SdPlayer::extract_cover_art(const std::string& track_path) {
         }
     }
 
-    // No art found for this track.
     art.len.store(-1, std::memory_order_relaxed);
     art.generation.fetch_add(1, std::memory_order_release);
 }

--- a/firmware/mp3_player/pico/src/audio/sd_player.h
+++ b/firmware/mp3_player/pico/src/audio/sd_player.h
@@ -46,6 +46,9 @@ private:
     bool open_track(const std::string& path);
     void apply_volume(int16_t* pcm, size_t samples);
     void read_tags(const std::string& path, TrackInfo& out);
+    // Scans for cover.jpg / folder.jpg in the track directory and fills
+    // state_.cover_art. Increments generation (release) so Core 0 sees the data.
+    void extract_cover_art(const std::string& track_path);
 
     AppState& state_;
 

--- a/firmware/mp3_player/pico/src/audio/sd_player.h
+++ b/firmware/mp3_player/pico/src/audio/sd_player.h
@@ -5,6 +5,7 @@
 #include <atomic>
 #include "track_queue.h"
 #include "../app_state.h"
+#include "eq.h"
 
 // MP3/FLAC decoder running on Core 1.
 // Reads compressed audio from SD, decodes frame-by-frame, and calls
@@ -28,6 +29,7 @@ public:
     void skip_next();
     void skip_prev();
     void set_volume(uint8_t vol_0_100);   // applied as integer gain shift
+    void set_eq_preset(EqPreset p);       // picked up by Core 1 between frames
     void load_queue(TrackQueue q, bool play_immediately = true);
     void jump_to(size_t queue_index);
 
@@ -46,21 +48,21 @@ private:
     bool open_track(const std::string& path);
     void apply_volume(int16_t* pcm, size_t samples);
     void read_tags(const std::string& path, TrackInfo& out);
-    // Scans for cover.jpg / folder.jpg in the track directory and fills
-    // state_.cover_art. Increments generation (release) so Core 0 sees the data.
     void extract_cover_art(const std::string& track_path);
 
     AppState& state_;
+    Eq        eq_;
 
     TrackQueue queue_;
     TrackInfo  current_info_;
 
-    std::atomic<bool>    playing_      { false };
-    std::atomic<bool>    skip_next_    { false };
-    std::atomic<bool>    skip_prev_    { false };
-    std::atomic<bool>    stop_req_     { false };
-    std::atomic<bool>    queue_dirty_  { false };
-    std::atomic<uint8_t> volume_       { 80 };
+    std::atomic<bool>    playing_        { false };
+    std::atomic<bool>    skip_next_      { false };
+    std::atomic<bool>    skip_prev_      { false };
+    std::atomic<bool>    stop_req_       { false };
+    std::atomic<bool>    queue_dirty_    { false };
+    std::atomic<uint8_t> volume_         { 80 };
+    std::atomic<uint8_t> eq_preset_req_  { 0xFF };  // 0xFF = no change pending
 
     mutex_t queue_mtx_;
 

--- a/firmware/mp3_player/pico/src/main.cpp
+++ b/firmware/mp3_player/pico/src/main.cpp
@@ -107,12 +107,6 @@ static void apply_mode_switch(AppMode target) {
     g_state.mode_switch_pending.store(false);
 }
 
-// Called from NowPlayingScreen::update() (Core 0) when the track changes.
-// Separate from Toast::show() to keep now_playing.cpp free of toast.h dependency.
-void Toast_show_from_update(const char* title) {
-    Toast::show(title);
-}
-
 // ── Setup ────────────────────────────────────────────────────────────────
 
 void setup() {
@@ -164,7 +158,7 @@ void setup() {
         g_bridge.send_audio_frame(pcm, pairs);
     };
     g_player.on_track_changed = [](const TrackInfo& info) {
-        g_ble.notify_track(info);  // BLE notification (not LVGL — safe from Core 1)
+        g_ble.notify_track(info);  // BLE AVRCP notification (safe from Core 1)
     };
 
     // Display + LVGL.
@@ -205,7 +199,6 @@ void setup() {
         auto tracks = sd.collect_tracks(path.substr(0, path.rfind('/')));
         TrackQueue q;
         q.load(tracks, g_state.playback.shuffled);
-        // Jump to the selected file.
         for (size_t i = 0; i < tracks.size(); ++i) {
             if (tracks[i] == path) { q.jump(i); break; }
         }
@@ -221,6 +214,7 @@ void setup() {
     g_scr_settings.on_volume_change = [](uint8_t v) {
         g_player.set_volume(v);
         g_bridge.set_volume(v);
+        // Toast::show() is safe here: this callback fires inside lv_task_handler().
         char buf[24];
         snprintf(buf, sizeof(buf), "Volume: %u%%", v);
         Toast::show(buf, 1500);
@@ -304,7 +298,7 @@ void loop() {
     // Drive toast slide-out timer.
     Toast::task();
 
-    // Update Now Playing screen ~1 Hz (cheap string ops + art refresh).
+    // Update Now Playing screen ~1 Hz (cheap string ops + cover art refresh).
     static uint32_t last_ui_update = 0;
     const uint32_t now = millis();
     if (now - last_ui_update >= 1000) {

--- a/firmware/mp3_player/pico/src/main.cpp
+++ b/firmware/mp3_player/pico/src/main.cpp
@@ -50,7 +50,6 @@ static lv_obj_t* g_scr_bt_obj       = nullptr;
 void setup1() { /* Core 1 stack is ready */ }
 
 void loop1() {
-    // SdPlayer::run() never returns; it blocks waiting for play state.
     g_player.run();
 }
 
@@ -64,7 +63,6 @@ static void apply_mode_switch(AppMode target) {
     const AppMode current = g_state.mode.load();
     if (target == current) return;
 
-    // Stop current mode.
     switch (current) {
     case AppMode::SD_PLAYBACK:
         g_player.pause();
@@ -74,10 +72,9 @@ static void apply_mode_switch(AppMode target) {
     case AppMode::BT_SINK:
         g_player.pause();
         g_bridge.bt_stop();
-        vTaskDelay(pdMS_TO_TICKS(700));  // BT stack teardown
+        vTaskDelay(pdMS_TO_TICKS(700));
         break;
     case AppMode::USB_MSC:
-        // USB MSC mode is exited automatically when cable disconnects.
         break;
     default: break;
     }
@@ -113,19 +110,16 @@ static void apply_mode_switch(AppMode target) {
 void setup() {
     g_state.init();
 
-    // I2C for ANO encoder (400 kHz Fast Mode).
     Wire.setSDA(PIN_I2C_SDA);
     Wire.setSCL(PIN_I2C_SCL);
     Wire.begin();
     Wire.setClock(400000);
 
-    // SPI for ILI9341 + SD.
     SPI.setRX(PIN_SPI_MISO);
     SPI.setTX(PIN_SPI_MOSI);
     SPI.setSCK(PIN_SPI_SCK);
     SPI.begin();
 
-    // SD card.
     if (g_sd.begin(PIN_SD_CS)) {
         g_state.sd_mounted = true;
 
@@ -142,7 +136,6 @@ void setup() {
         }
     }
 
-    // UART bridge to ESP32.
     g_bridge.begin();
     g_bridge.on_bt_connected = [](bool /*connected*/, const char* name) {
         AppLock lk(g_state);
@@ -158,26 +151,22 @@ void setup() {
         g_state.bt.sink_connected   = false;
     };
 
-    // Apply stored volume to player and bridge now that bridge is initialized.
+    // Apply stored volume and EQ to player and bridge.
     g_player.set_volume(g_state.playback.volume);
+    g_player.set_eq_preset(g_state.playback.eq_preset);
     g_bridge.set_volume(g_state.playback.volume);
 
-    // SdPlayer output → bridge.
     g_player.on_pcm_frame = [](const int16_t* pcm, size_t pairs) {
         g_bridge.send_audio_frame(pcm, pairs);
     };
     g_player.on_track_changed = [](const TrackInfo& info) {
-        g_ble.notify_track(info);  // BLE AVRCP notification (safe from Core 1)
+        g_ble.notify_track(info);
     };
 
-    // Display + LVGL.
     g_display.begin();
-
-    // Toast and charging overlay live on lv_layer_top(); init after lv_init().
     Toast::init();
     ChargingOverlay::init();
 
-    // Create LVGL screens.
     g_scr_now_obj      = lv_obj_create(nullptr);
     g_scr_files_obj    = lv_obj_create(nullptr);
     g_scr_settings_obj = lv_obj_create(nullptr);
@@ -190,19 +179,17 @@ void setup() {
 
     lv_scr_load(g_scr_now_obj);
 
-    // Encoder navigation wiring.
     g_encoder.on_up    = []() { switch_screen(g_scr_now_obj);      };
     g_encoder.on_down  = []() { switch_screen(g_scr_files_obj);    };
     g_encoder.on_right = []() { switch_screen(g_scr_settings_obj); };
     g_encoder.on_left  = []() { switch_screen(g_scr_bt_obj);       };
     g_encoder.on_select_long = []() {
         g_player.toggle();
-        g_bridge.play();  // or pause — bridge mirrors player state
+        g_bridge.play();
     };
     if (!g_encoder.begin(PIN_ANO_INT))
-        ; // encoder not found — continue without it
+        ;
 
-    // File browser callbacks.
     g_scr_files.on_play = [](const std::string& path) {
         SdCard sd;
         auto tracks = sd.collect_tracks(path.substr(0, path.rfind('/')));
@@ -215,7 +202,6 @@ void setup() {
         switch_screen(g_scr_now_obj);
     };
 
-    // Settings callbacks.
     g_scr_settings.on_mode_change = [](AppMode m) {
         g_state.requested_mode.store(m);
         g_state.mode_switch_pending.store(true);
@@ -223,28 +209,39 @@ void setup() {
     g_scr_settings.on_volume_change = [](uint8_t v) {
         g_player.set_volume(v);
         g_bridge.set_volume(v);
-        // Toast::show() is safe here: callback fires inside lv_task_handler() on Core 0.
         char buf[24];
         snprintf(buf, sizeof(buf), "Volume: %u%%", v);
         Toast::show(buf, 1500);
-        Settings::request_save({v, g_state.playback.shuffled, g_state.playback.repeat});
+        Settings::request_save({v, g_state.playback.shuffled,
+                                g_state.playback.repeat, g_state.playback.eq_preset});
     };
     g_scr_settings.on_shuffle_change = [](bool s) {
         {
             AppLock lk(g_state);
             g_state.playback.shuffled = s;
         }
-        Settings::request_save({g_state.playback.volume, s, g_state.playback.repeat});
+        Settings::request_save({g_state.playback.volume, s,
+                                g_state.playback.repeat, g_state.playback.eq_preset});
     };
     g_scr_settings.on_repeat_change = [](RepeatMode r) {
         {
             AppLock lk(g_state);
             g_state.playback.repeat = r;
         }
-        Settings::request_save({g_state.playback.volume, g_state.playback.shuffled, r});
+        Settings::request_save({g_state.playback.volume, g_state.playback.shuffled,
+                                r, g_state.playback.eq_preset});
+    };
+    g_scr_settings.on_eq_change = [](EqPreset p) {
+        g_player.set_eq_preset(p);  // thread-safe: writes atomic, Core 1 picks up
+        char buf[24];
+        const char* names[] = {"Flat", "Bass Boost", "Vocal", "Treble", "Custom"};
+        snprintf(buf, sizeof(buf), "EQ: %s",
+                 names[static_cast<int>(p) < 5 ? static_cast<int>(p) : 0]);
+        Toast::show(buf, 1500);
+        Settings::request_save({g_state.playback.volume, g_state.playback.shuffled,
+                                g_state.playback.repeat, p});
     };
 
-    // BLE.
     g_ble.begin("MP3Player");
     g_ble.on_play_pause = [](bool play) {
         if (play) { g_player.play(); g_bridge.play(); }
@@ -262,7 +259,6 @@ void setup() {
         g_state.mode_switch_pending.store(true);
     };
 
-    // USB MSC — SD hands off to TinyUSB when cable is plugged.
     g_msc.on_msc_start = []() {
         g_player.pause();
         g_bridge.mute(true);
@@ -280,7 +276,6 @@ void setup() {
     };
     g_msc.begin(PIN_SD_CS);
 
-    // Start audio playback if SD is ready.
     if (g_state.sd_mounted)
         g_player.play();
 }
@@ -288,12 +283,10 @@ void setup() {
 // ── Main loop (Core 0) ──────────────────────────────────────────────────
 
 void loop() {
-    // Handle pending mode switches (requested by UI or BLE).
     if (g_state.mode_switch_pending.load()) {
         apply_mode_switch(g_state.requested_mode.load());
     }
 
-    // Show / hide USB overlay when USB MSC state changes.
     static bool s_last_usb = false;
     const bool  usb_now    = g_state.usb_active;
     if (usb_now != s_last_usb) {
@@ -301,23 +294,13 @@ void loop() {
         ChargingOverlay::set_visible(usb_now);
     }
 
-    // Drive USB MSC and BLE.
     g_msc.task();
     g_ble.task();
-
-    // Poll UART bridge for status frames from ESP32.
     g_bridge.poll();
-
-    // Update LVGL + encoder + display at ~30 fps.
     g_display.task();
-
-    // Drive toast slide-out timer.
     Toast::task();
-
-    // Flush debounced settings writes to SD.
     Settings::task();
 
-    // Update Now Playing screen ~1 Hz (cheap string ops + cover art refresh).
     static uint32_t last_ui_update = 0;
     const uint32_t now = millis();
     if (now - last_ui_update >= 1000) {
@@ -326,6 +309,5 @@ void loop() {
         g_scr_settings.update(g_state);
     }
 
-    // Tiny yield so FreeRTOS idle task can run.
     vTaskDelay(1);
 }

--- a/firmware/mp3_player/pico/src/main.cpp
+++ b/firmware/mp3_player/pico/src/main.cpp
@@ -14,13 +14,15 @@
 #include "input/encoder.h"
 #include "ble/ble_control.h"
 #include "ui/display.h"
+#include "ui/toast.h"
 #include "ui/screens/now_playing.h"
 #include "ui/screens/file_browser.h"
 #include "ui/screens/settings.h"
 #include "ui/screens/bt_devices.h"
+#include "ui/screens/charging_overlay.h"
 #include "../include/pins.h"
 
-// ── Global instances ──────────────────────────────────────────────────────────
+// ── Global instances ─────────────────────────────────────────────────────
 
 static AppState         g_state;
 static SdCard           g_sd;
@@ -32,17 +34,17 @@ static UsbMsc           g_msc;
 static Display          g_display(g_state, g_encoder);
 
 // UI screens (created on their LVGL parent objects in setup()).
-static NowPlayingScreen g_scr_now;
+static NowPlayingScreen  g_scr_now;
 static FileBrowserScreen g_scr_files;
-static SettingsScreen   g_scr_settings;
-static BtDevicesScreen  g_scr_bt;
+static SettingsScreen    g_scr_settings;
+static BtDevicesScreen   g_scr_bt;
 
-static lv_obj_t* g_scr_now_obj     = nullptr;
-static lv_obj_t* g_scr_files_obj   = nullptr;
-static lv_obj_t* g_scr_settings_obj= nullptr;
-static lv_obj_t* g_scr_bt_obj      = nullptr;
+static lv_obj_t* g_scr_now_obj      = nullptr;
+static lv_obj_t* g_scr_files_obj    = nullptr;
+static lv_obj_t* g_scr_settings_obj = nullptr;
+static lv_obj_t* g_scr_bt_obj       = nullptr;
 
-// ── Core 1 — audio decode loop ────────────────────────────────────────────────
+// ── Core 1 — audio decode loop ────────────────────────────────────────────
 
 void setup1() { /* Core 1 stack is ready */ }
 
@@ -51,7 +53,7 @@ void loop1() {
     g_player.run();
 }
 
-// ── Helpers ───────────────────────────────────────────────────────────────────
+// ── Helpers ─────────────────────────────────────────────────────────────
 
 static void switch_screen(lv_obj_t* scr) {
     lv_scr_load_anim(scr, LV_SCR_LOAD_ANIM_FADE_ON, 150, 0, false);
@@ -105,7 +107,13 @@ static void apply_mode_switch(AppMode target) {
     g_state.mode_switch_pending.store(false);
 }
 
-// ── Setup ─────────────────────────────────────────────────────────────────────
+// Called from NowPlayingScreen::update() (Core 0) when the track changes.
+// Separate from Toast::show() to keep now_playing.cpp free of toast.h dependency.
+void Toast_show_from_update(const char* title) {
+    Toast::show(title);
+}
+
+// ── Setup ────────────────────────────────────────────────────────────────
 
 void setup() {
     g_state.init();
@@ -156,11 +164,15 @@ void setup() {
         g_bridge.send_audio_frame(pcm, pairs);
     };
     g_player.on_track_changed = [](const TrackInfo& info) {
-        g_ble.notify_track(info);
+        g_ble.notify_track(info);  // BLE notification (not LVGL — safe from Core 1)
     };
 
     // Display + LVGL.
     g_display.begin();
+
+    // Toast and charging overlay live on lv_layer_top(); init after lv_init().
+    Toast::init();
+    ChargingOverlay::init();
 
     // Create LVGL screens.
     g_scr_now_obj      = lv_obj_create(nullptr);
@@ -209,6 +221,9 @@ void setup() {
     g_scr_settings.on_volume_change = [](uint8_t v) {
         g_player.set_volume(v);
         g_bridge.set_volume(v);
+        char buf[24];
+        snprintf(buf, sizeof(buf), "Volume: %u%%", v);
+        Toast::show(buf, 1500);
     };
     g_scr_settings.on_shuffle_change = [](bool s) {
         AppLock lk(g_state);
@@ -260,12 +275,20 @@ void setup() {
         g_player.play();
 }
 
-// ── Main loop (Core 0) ────────────────────────────────────────────────────────
+// ── Main loop (Core 0) ───────────────────────────────────────────────────
 
 void loop() {
     // Handle pending mode switches (requested by UI or BLE).
     if (g_state.mode_switch_pending.load()) {
         apply_mode_switch(g_state.requested_mode.load());
+    }
+
+    // Show / hide USB overlay when USB MSC state changes.
+    static bool s_last_usb = false;
+    const bool  usb_now    = g_state.usb_active;
+    if (usb_now != s_last_usb) {
+        s_last_usb = usb_now;
+        ChargingOverlay::set_visible(usb_now);
     }
 
     // Drive USB MSC and BLE.
@@ -278,14 +301,16 @@ void loop() {
     // Update LVGL + encoder + display at ~30 fps.
     g_display.task();
 
-    // Update Now Playing screen ~1 Hz (cheap string ops).
+    // Drive toast slide-out timer.
+    Toast::task();
+
+    // Update Now Playing screen ~1 Hz (cheap string ops + art refresh).
     static uint32_t last_ui_update = 0;
     const uint32_t now = millis();
     if (now - last_ui_update >= 1000) {
         last_ui_update = now;
-        AppState* s = &g_state;  // snapshot under lock not needed for display
-        g_scr_now.update(*s);
-        g_scr_settings.update(*s);
+        g_scr_now.update(g_state);
+        g_scr_settings.update(g_state);
     }
 
     // Tiny yield so FreeRTOS idle task can run.

--- a/firmware/mp3_player/pico/src/main.cpp
+++ b/firmware/mp3_player/pico/src/main.cpp
@@ -7,6 +7,7 @@
 #include <freertos/task.h>
 
 #include "app_state.h"
+#include "settings.h"
 #include "audio/sd_player.h"
 #include "bridge/esp32_bridge.h"
 #include "storage/sd_card.h"
@@ -44,7 +45,7 @@ static lv_obj_t* g_scr_files_obj    = nullptr;
 static lv_obj_t* g_scr_settings_obj = nullptr;
 static lv_obj_t* g_scr_bt_obj       = nullptr;
 
-// ── Core 1 — audio decode loop ────────────────────────────────────────────
+// ── Core 1 — audio decode loop ──────────────────────────────────────────────
 
 void setup1() { /* Core 1 stack is ready */ }
 
@@ -53,7 +54,7 @@ void loop1() {
     g_player.run();
 }
 
-// ── Helpers ─────────────────────────────────────────────────────────────
+// ── Helpers ──────────────────────────────────────────────────────────
 
 static void switch_screen(lv_obj_t* scr) {
     lv_scr_load_anim(scr, LV_SCR_LOAD_ANIM_FADE_ON, 150, 0, false);
@@ -107,7 +108,7 @@ static void apply_mode_switch(AppMode target) {
     g_state.mode_switch_pending.store(false);
 }
 
-// ── Setup ────────────────────────────────────────────────────────────────
+// ── Setup ────────────────────────────────────────────────────────────
 
 void setup() {
     g_state.init();
@@ -127,9 +128,13 @@ void setup() {
     // SD card.
     if (g_sd.begin(PIN_SD_CS)) {
         g_state.sd_mounted = true;
+
+        // Restore persisted settings before building the queue.
+        Settings::load(g_state.playback);
+
         const auto tracks = g_sd.collect_tracks("/");
         TrackQueue q;
-        q.load(tracks, false);
+        q.load(tracks, g_state.playback.shuffled);
         g_player.load_queue(std::move(q), false);
         {
             AppLock lk(g_state);
@@ -152,6 +157,10 @@ void setup() {
         g_state.bt.source_connected = false;
         g_state.bt.sink_connected   = false;
     };
+
+    // Apply stored volume to player and bridge now that bridge is initialized.
+    g_player.set_volume(g_state.playback.volume);
+    g_bridge.set_volume(g_state.playback.volume);
 
     // SdPlayer output → bridge.
     g_player.on_pcm_frame = [](const int16_t* pcm, size_t pairs) {
@@ -207,25 +216,32 @@ void setup() {
     };
 
     // Settings callbacks.
-    g_scr_settings.on_mode_change   = [](AppMode m) {
+    g_scr_settings.on_mode_change = [](AppMode m) {
         g_state.requested_mode.store(m);
         g_state.mode_switch_pending.store(true);
     };
     g_scr_settings.on_volume_change = [](uint8_t v) {
         g_player.set_volume(v);
         g_bridge.set_volume(v);
-        // Toast::show() is safe here: this callback fires inside lv_task_handler().
+        // Toast::show() is safe here: callback fires inside lv_task_handler() on Core 0.
         char buf[24];
         snprintf(buf, sizeof(buf), "Volume: %u%%", v);
         Toast::show(buf, 1500);
+        Settings::request_save({v, g_state.playback.shuffled, g_state.playback.repeat});
     };
     g_scr_settings.on_shuffle_change = [](bool s) {
-        AppLock lk(g_state);
-        g_state.playback.shuffled = s;
+        {
+            AppLock lk(g_state);
+            g_state.playback.shuffled = s;
+        }
+        Settings::request_save({g_state.playback.volume, s, g_state.playback.repeat});
     };
     g_scr_settings.on_repeat_change = [](RepeatMode r) {
-        AppLock lk(g_state);
-        g_state.playback.repeat = r;
+        {
+            AppLock lk(g_state);
+            g_state.playback.repeat = r;
+        }
+        Settings::request_save({g_state.playback.volume, g_state.playback.shuffled, r});
     };
 
     // BLE.
@@ -234,14 +250,14 @@ void setup() {
         if (play) { g_player.play(); g_bridge.play(); }
         else       { g_player.pause(); g_bridge.pause(); }
     };
-    g_ble.on_skip      = [](int8_t dir) {
+    g_ble.on_skip = [](int8_t dir) {
         if (dir > 0) g_player.skip_next(); else g_player.skip_prev();
     };
-    g_ble.on_volume    = [](uint8_t v) {
+    g_ble.on_volume = [](uint8_t v) {
         g_player.set_volume(v);
         g_bridge.set_volume(v);
     };
-    g_ble.on_mode      = [](AppMode m) {
+    g_ble.on_mode = [](AppMode m) {
         g_state.requested_mode.store(m);
         g_state.mode_switch_pending.store(true);
     };
@@ -269,7 +285,7 @@ void setup() {
         g_player.play();
 }
 
-// ── Main loop (Core 0) ───────────────────────────────────────────────────
+// ── Main loop (Core 0) ──────────────────────────────────────────────────
 
 void loop() {
     // Handle pending mode switches (requested by UI or BLE).
@@ -297,6 +313,9 @@ void loop() {
 
     // Drive toast slide-out timer.
     Toast::task();
+
+    // Flush debounced settings writes to SD.
+    Settings::task();
 
     // Update Now Playing screen ~1 Hz (cheap string ops + cover art refresh).
     static uint32_t last_ui_update = 0;

--- a/firmware/mp3_player/pico/src/settings.cpp
+++ b/firmware/mp3_player/pico/src/settings.cpp
@@ -1,0 +1,70 @@
+#include "settings.h"
+#include <SD.h>
+#include <Arduino.h>
+
+Settings::Data  Settings::s_pending_     = {};
+bool            Settings::s_dirty_       = false;
+uint32_t        Settings::s_last_req_ms_ = 0;
+
+// Binary record layout (10 bytes):
+//   [0..2]  magic: 'P' 'H' 'S'
+//   [3]     version: 0x01
+//   [4]     volume  (0-100)
+//   [5]     shuffled (0/1)
+//   [6]     repeat  (RepeatMode)
+//   [7..8]  reserved (0)
+//   [9]     XOR checksum of bytes 0..8
+static constexpr uint8_t MAGIC[3] = {'P', 'H', 'S'};
+static constexpr uint8_t VERSION  = 0x01;
+
+void Settings::load(PlaybackState& out) {
+    File f = SD.open(PATH, FILE_READ);
+    if (!f) return;
+    uint8_t buf[10];
+    const size_t n = f.read(buf, 10);
+    f.close();
+    if (n != 10) return;
+    if (buf[0] != MAGIC[0] || buf[1] != MAGIC[1] || buf[2] != MAGIC[2]) return;
+    if (buf[3] != VERSION) return;
+    uint8_t csum = 0;
+    for (int i = 0; i < 9; ++i) csum ^= buf[i];
+    if (csum != buf[9]) return;
+
+    if (buf[4] <= 100) out.volume = buf[4];
+    out.shuffled = (buf[5] != 0);
+    if (buf[6] <= static_cast<uint8_t>(RepeatMode::ALL))
+        out.repeat = static_cast<RepeatMode>(buf[6]);
+}
+
+void Settings::request_save(Data d) {
+    s_pending_     = d;
+    s_dirty_       = true;
+    s_last_req_ms_ = millis();
+}
+
+void Settings::task() {
+    if (!s_dirty_) return;
+    if (millis() - s_last_req_ms_ < DEBOUNCE_MS) return;
+    s_dirty_ = false;
+    do_save(s_pending_);
+}
+
+void Settings::do_save(const Data& in) {
+    uint8_t buf[10] = {};
+    buf[0] = MAGIC[0]; buf[1] = MAGIC[1]; buf[2] = MAGIC[2];
+    buf[3] = VERSION;
+    buf[4] = in.volume;
+    buf[5] = in.shuffled ? 1u : 0u;
+    buf[6] = static_cast<uint8_t>(in.repeat);
+    // buf[7] and buf[8] are reserved, already 0
+    uint8_t csum = 0;
+    for (int i = 0; i < 9; ++i) csum ^= buf[i];
+    buf[9] = csum;
+
+    // Overwrite existing file (SD library FILE_WRITE truncates on open).
+    SD.remove(PATH);
+    File f = SD.open(PATH, FILE_WRITE);
+    if (!f) return;
+    f.write(buf, 10);
+    f.close();
+}

--- a/firmware/mp3_player/pico/src/settings.cpp
+++ b/firmware/mp3_player/pico/src/settings.cpp
@@ -11,8 +11,9 @@ uint32_t        Settings::s_last_req_ms_ = 0;
 //   [3]     version: 0x01
 //   [4]     volume  (0-100)
 //   [5]     shuffled (0/1)
-//   [6]     repeat  (RepeatMode)
-//   [7..8]  reserved (0)
+//   [6]     repeat  (RepeatMode cast to uint8_t)
+//   [7]     eq_preset (EqPreset cast to uint8_t)
+//   [8]     reserved (0)
 //   [9]     XOR checksum of bytes 0..8
 static constexpr uint8_t MAGIC[3] = {'P', 'H', 'S'};
 static constexpr uint8_t VERSION  = 0x01;
@@ -34,6 +35,8 @@ void Settings::load(PlaybackState& out) {
     out.shuffled = (buf[5] != 0);
     if (buf[6] <= static_cast<uint8_t>(RepeatMode::ALL))
         out.repeat = static_cast<RepeatMode>(buf[6]);
+    if (buf[7] < static_cast<uint8_t>(EqPreset::COUNT))
+        out.eq_preset = static_cast<EqPreset>(buf[7]);
 }
 
 void Settings::request_save(Data d) {
@@ -56,12 +59,12 @@ void Settings::do_save(const Data& in) {
     buf[4] = in.volume;
     buf[5] = in.shuffled ? 1u : 0u;
     buf[6] = static_cast<uint8_t>(in.repeat);
-    // buf[7] and buf[8] are reserved, already 0
+    buf[7] = static_cast<uint8_t>(in.eq_preset);
+    // buf[8] reserved = 0
     uint8_t csum = 0;
     for (int i = 0; i < 9; ++i) csum ^= buf[i];
     buf[9] = csum;
 
-    // Overwrite existing file (SD library FILE_WRITE truncates on open).
     SD.remove(PATH);
     File f = SD.open(PATH, FILE_WRITE);
     if (!f) return;

--- a/firmware/mp3_player/pico/src/settings.h
+++ b/firmware/mp3_player/pico/src/settings.h
@@ -1,0 +1,34 @@
+#pragma once
+#include <cstdint>
+#include "app_state.h"
+
+// Persists playback preferences to /settings.bin on the SD card.
+// Uses a 500 ms debounce so rapid encoder turns don't thrash the card.
+struct Settings {
+    static constexpr const char* PATH = "/settings.bin";
+
+    // Fields that survive a power cycle.
+    struct Data {
+        uint8_t    volume;    // 0-100
+        bool       shuffled;
+        RepeatMode repeat;
+    };
+
+    // Populate out from SD. Silently leaves out unchanged on missing/corrupt file.
+    static void load(PlaybackState& out);
+
+    // Queue a write. Actual SD write happens in task() after DEBOUNCE_MS quiet.
+    static void request_save(Data d);
+
+    // Call once per loop() iteration.
+    static void task();
+
+private:
+    static void do_save(const Data& d);
+
+    static Data     s_pending_;
+    static bool     s_dirty_;
+    static uint32_t s_last_req_ms_;
+
+    static constexpr uint32_t DEBOUNCE_MS = 500;
+};

--- a/firmware/mp3_player/pico/src/settings.h
+++ b/firmware/mp3_player/pico/src/settings.h
@@ -12,6 +12,7 @@ struct Settings {
         uint8_t    volume;    // 0-100
         bool       shuffled;
         RepeatMode repeat;
+        EqPreset   eq_preset;
     };
 
     // Populate out from SD. Silently leaves out unchanged on missing/corrupt file.

--- a/firmware/mp3_player/pico/src/ui/album_art.cpp
+++ b/firmware/mp3_player/pico/src/ui/album_art.cpp
@@ -1,0 +1,81 @@
+#include "album_art.h"
+#include "theme.h"
+#include <JPEGDEC.h>
+
+lv_color_t AlbumArt::s_px_buf_[AlbumArt::W * AlbumArt::H];
+
+static JPEGDEC s_jpeg;
+
+// JPEGDEC MCU draw callback — writes decoded RGB565 blocks into the canvas buffer.
+// Pixel type is set to RGB565_BIG_ENDIAN which matches LV_COLOR_16_SWAP=1.
+static int jpeg_draw_cb(JPEGDRAW* pDraw) {
+    lv_color_t* buf = AlbumArt::px_buf();
+    uint16_t*   src = pDraw->pPixels;
+    for (int row = 0; row < pDraw->iHeight; row++) {
+        for (int col = 0; col < pDraw->iWidth; col++) {
+            int px_x = pDraw->x + col;
+            int px_y = pDraw->y + row;
+            if (px_x < AlbumArt::W && px_y < AlbumArt::H && px_x >= 0 && px_y >= 0)
+                buf[px_y * AlbumArt::W + px_x].full = src[row * pDraw->iWidth + col];
+        }
+    }
+    return 1;
+}
+
+void AlbumArt::create(lv_obj_t* parent, int x, int y) {
+    canvas_ = lv_canvas_create(parent);
+    lv_canvas_set_buffer(canvas_, s_px_buf_, W, H, LV_IMG_CF_TRUE_COLOR);
+    lv_obj_set_pos(canvas_, x, y);
+    show_placeholder();
+}
+
+bool AlbumArt::load_jpeg(const uint8_t* jpeg_data, size_t len) {
+    if (!canvas_ || !jpeg_data || len < 4) return false;
+
+    lv_canvas_fill_bg(canvas_, lv_color_black(), LV_OPA_COVER);
+    s_jpeg.setPixelType(RGB565_BIG_ENDIAN);
+
+    if (!s_jpeg.openRAM(const_cast<uint8_t*>(jpeg_data), static_cast<int>(len), jpeg_draw_cb)) {
+        show_placeholder();
+        return false;
+    }
+
+    // Pick scale so the decoded output fits within W×H.
+    const int iw = s_jpeg.getWidth();
+    const int ih = s_jpeg.getHeight();
+    int scale;
+    if      (iw > W * 4 || ih > H * 4)  scale = JPEG_SCALE_EIGHTH;
+    else if (iw > W * 2 || ih > H * 2)  scale = JPEG_SCALE_QUARTER;
+    else if (iw > W     || ih > H)       scale = JPEG_SCALE_HALF;
+    else                                  scale = JPEG_SCALE_FULL;
+
+    // Centre the scaled image in the 80×80 canvas.
+    const int divisor = 1 << scale;
+    const int off_x   = (W - iw / divisor) / 2;
+    const int off_y   = (H - ih / divisor) / 2;
+
+    s_jpeg.decode(off_x > 0 ? off_x : 0, off_y > 0 ? off_y : 0, scale);
+    s_jpeg.close();
+    lv_obj_invalidate(canvas_);
+    return true;
+}
+
+void AlbumArt::show_placeholder() {
+    if (!canvas_) return;
+    lv_canvas_fill_bg(canvas_, Theme::SURFACE(), LV_OPA_COVER);
+
+    lv_draw_rect_dsc_t rect_dsc;
+    lv_draw_rect_dsc_init(&rect_dsc);
+    rect_dsc.bg_color = Theme::ACCENT();
+    rect_dsc.bg_opa   = LV_OPA_20;
+    rect_dsc.radius   = 6;
+    lv_canvas_draw_rect(canvas_, 2, 2, W - 4, H - 4, &rect_dsc);
+
+    lv_draw_label_dsc_t lbl_dsc;
+    lv_draw_label_dsc_init(&lbl_dsc);
+    lbl_dsc.color = Theme::TEXT_DIM();
+    lbl_dsc.font  = &lv_font_montserrat_24;
+    lv_canvas_draw_text(canvas_, (W / 2) - 12, (H / 2) - 14, 30, &lbl_dsc, LV_SYMBOL_AUDIO);
+
+    lv_obj_invalidate(canvas_);
+}

--- a/firmware/mp3_player/pico/src/ui/album_art.h
+++ b/firmware/mp3_player/pico/src/ui/album_art.h
@@ -1,0 +1,30 @@
+#pragma once
+#include <lvgl.h>
+#include <cstdint>
+#include <cstddef>
+
+// Renders JPEG album art into an 80×80 LVGL canvas using JPEGDEC.
+// Singleton: only one active decode at a time (static pixel buffer).
+// Call create() once in NowPlayingScreen::create(), then load_jpeg() or
+// show_placeholder() whenever the track changes.
+class AlbumArt {
+public:
+    static constexpr int W = 80;
+    static constexpr int H = 80;
+
+    // Create the LVGL canvas widget at (x, y) inside parent.
+    void create(lv_obj_t* parent, int x, int y);
+
+    // Decode jpeg_data[len] and draw into canvas.
+    bool load_jpeg(const uint8_t* jpeg_data, size_t len);
+
+    // Fill canvas with a placeholder music-note graphic.
+    void show_placeholder();
+
+    // Exposed so the static JPEGDEC draw callback can write pixels.
+    static lv_color_t* px_buf() { return s_px_buf_; }
+
+private:
+    lv_obj_t*         canvas_  = nullptr;
+    static lv_color_t s_px_buf_[W * H];
+};

--- a/firmware/mp3_player/pico/src/ui/display.cpp
+++ b/firmware/mp3_player/pico/src/ui/display.cpp
@@ -1,11 +1,14 @@
 #include "display.h"
 #include "theme.h"
+#include "../../../include/pins.h"
 #include <Arduino.h>
 
 lv_color_t Display::buf1_[320 * Display::BUF_LINES];
 lv_color_t Display::buf2_[320 * Display::BUF_LINES];
-int        Display::enc_delta_  = 0;
-bool       Display::enc_select_ = false;
+int        Display::enc_delta_           = 0;
+bool       Display::enc_select_          = false;
+uint32_t   Display::s_last_activity_ms_ = 0;
+uint8_t    Display::s_brightness_pct_   = 100;
 
 Display::Display(AppState& state, AnoEncoder& enc)
     : state_(state), enc_(enc) {}
@@ -15,6 +18,11 @@ bool Display::begin() {
     tft_.setRotation(1);  // landscape: 320×240
     tft_.fillScreen(TFT_BLACK);
     tft_.initDMA();
+
+    // Backlight: full brightness at startup.
+    pinMode(PIN_TFT_BL, OUTPUT);
+    set_brightness(100);
+    s_last_activity_ms_ = millis();
 
     lv_init();
 
@@ -40,15 +48,42 @@ bool Display::begin() {
     enc_.on_rotate = [](int delta) { enc_delta_ += delta; };
     enc_.on_select = []() { enc_select_ = true; };
 
-    // 1 ms system tick via Arduino-Pico hardware timer.
-    // Arduino-Pico calls millis() which is already driven by SysTick;
-    // update LVGL tick from task() instead.
     return true;
 }
 
+void Display::set_brightness(uint8_t pct) {
+    s_brightness_pct_ = pct > 100 ? 100 : pct;
+    // Map 0-100% to 0-255 PWM duty cycle (0% stays 0, 100% is full 255).
+    const uint8_t duty = (s_brightness_pct_ == 0) ? 0
+                       : (s_brightness_pct_ >= 100) ? 255
+                       : static_cast<uint8_t>(s_brightness_pct_ * 255u / 100u);
+    analogWrite(PIN_TFT_BL, duty);
+}
+
+void Display::on_activity() {
+    s_last_activity_ms_ = millis();
+    if (s_brightness_pct_ < 100) {
+        set_brightness(100);
+    }
+}
+
 void Display::task() {
-    lv_tick_inc(33);       // ~30 fps nominal tick
-    enc_.poll();           // read seesaw; fires enc_ callbacks above
+    lv_tick_inc(33);   // ~30 fps nominal tick
+    enc_.poll();       // read seesaw; fires enc_ callbacks above
+
+    // Any encoder activity resets the inactivity timer and wakes the screen.
+    if (enc_delta_ != 0 || enc_select_) {
+        on_activity();
+    }
+
+    // Backlight power management: dim → off based on inactivity.
+    const uint32_t idle_ms = millis() - s_last_activity_ms_;
+    if (idle_ms >= OFF_TIMEOUT_MS) {
+        if (s_brightness_pct_ != 0) set_brightness(0);
+    } else if (idle_ms >= DIM_TIMEOUT_MS) {
+        if (s_brightness_pct_ > 30) set_brightness(30);
+    }
+
     lv_task_handler();
 }
 

--- a/firmware/mp3_player/pico/src/ui/display.h
+++ b/firmware/mp3_player/pico/src/ui/display.h
@@ -8,8 +8,10 @@
 // Two 320×20-line draw buffers in static RAM (~25 KB total).
 // Flush uses TFT_eSPI::pushImageDMA for DMA-backed transfers.
 //
-// Call begin() once from setup() (Core 0).
-// Call task()  from the UI FreeRTOS task at ~30 fps.
+// Backlight PWM on PIN_TFT_BL (GPIO 28):
+//   - Dims to 30% after DIM_TIMEOUT_MS of no encoder input.
+//   - Turns off after OFF_TIMEOUT_MS of no encoder input.
+//   - Any encoder rotation or press wakes the screen immediately.
 
 class Display {
 public:
@@ -17,6 +19,16 @@ public:
 
     bool begin();
     void task();  // drives lv_task_handler() and encoder input
+
+    // Set backlight level 0–100 (0 = off, 100 = full).
+    static void set_brightness(uint8_t pct);
+
+    // Call on any user-visible interaction to reset the inactivity timer.
+    void on_activity();
+
+    // Inactivity thresholds.
+    static constexpr uint32_t DIM_TIMEOUT_MS = 30000;  // 30 s → dim to 30%
+    static constexpr uint32_t OFF_TIMEOUT_MS = 60000;  // 60 s → backlight off
 
 private:
     static void flush_cb(lv_disp_drv_t* drv, const lv_area_t* area, lv_color_t* color_p);
@@ -39,4 +51,8 @@ private:
     // Encoder state passed to LVGL indev callback.
     static int    enc_delta_;
     static bool   enc_select_;
+
+    // Backlight state (Core 0 only).
+    static uint32_t s_last_activity_ms_;
+    static uint8_t  s_brightness_pct_;
 };

--- a/firmware/mp3_player/pico/src/ui/screens/charging_overlay.cpp
+++ b/firmware/mp3_player/pico/src/ui/screens/charging_overlay.cpp
@@ -1,0 +1,48 @@
+#include "charging_overlay.h"
+#include "../theme.h"
+
+lv_obj_t* ChargingOverlay::s_overlay_ = nullptr;
+bool      ChargingOverlay::s_visible_  = false;
+
+void ChargingOverlay::init() {
+    lv_obj_t* layer = lv_layer_top();
+
+    s_overlay_ = lv_obj_create(layer);
+    lv_obj_set_size(s_overlay_, 320, 240);
+    lv_obj_set_pos(s_overlay_, 0, 0);
+    lv_obj_set_style_bg_color(s_overlay_, lv_color_black(), 0);
+    lv_obj_set_style_bg_opa(s_overlay_, LV_OPA_90, 0);
+    lv_obj_set_style_border_width(s_overlay_, 0, 0);
+    lv_obj_clear_flag(s_overlay_, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_add_flag(s_overlay_, LV_OBJ_FLAG_HIDDEN);
+
+    // Animated spinner arc.
+    lv_obj_t* spinner = lv_spinner_create(s_overlay_, 1200, 60);
+    lv_obj_set_size(spinner, 80, 80);
+    lv_obj_align(spinner, LV_ALIGN_CENTER, 0, -28);
+    lv_obj_set_style_arc_width(spinner, 6, LV_PART_INDICATOR);
+    lv_obj_set_style_arc_color(spinner, Theme::ACCENT(), LV_PART_INDICATOR);
+    lv_obj_set_style_arc_width(spinner, 6, LV_PART_MAIN);
+    lv_obj_set_style_arc_color(spinner, Theme::SURFACE(), LV_PART_MAIN);
+
+    lv_obj_t* lbl = lv_label_create(s_overlay_);
+    lv_label_set_text(lbl, LV_SYMBOL_USB "  USB Connected");
+    lv_obj_set_style_text_color(lbl, lv_color_white(), 0);
+    lv_obj_set_style_text_font(lbl, &lv_font_montserrat_18, 0);
+    lv_obj_align(lbl, LV_ALIGN_CENTER, 0, 44);
+
+    lv_obj_t* hint = lv_label_create(s_overlay_);
+    lv_label_set_text(hint, "Eject SD card to resume");
+    lv_obj_set_style_text_color(hint, Theme::TEXT_DIM(), 0);
+    lv_obj_set_style_text_font(hint, &lv_font_montserrat_12, 0);
+    lv_obj_align(hint, LV_ALIGN_CENTER, 0, 76);
+}
+
+void ChargingOverlay::set_visible(bool visible) {
+    if (!s_overlay_) return;
+    s_visible_ = visible;
+    if (visible)
+        lv_obj_clear_flag(s_overlay_, LV_OBJ_FLAG_HIDDEN);
+    else
+        lv_obj_add_flag(s_overlay_, LV_OBJ_FLAG_HIDDEN);
+}

--- a/firmware/mp3_player/pico/src/ui/screens/charging_overlay.h
+++ b/firmware/mp3_player/pico/src/ui/screens/charging_overlay.h
@@ -1,0 +1,16 @@
+#pragma once
+#include <lvgl.h>
+
+// Full-screen overlay shown when USB MSC mode is active.
+// Drawn on lv_layer_top() so it appears above all screens.
+// Call init() once after lv_init(), set_visible() on USB state changes.
+class ChargingOverlay {
+public:
+    static void init();
+    static void set_visible(bool visible);
+    static bool is_visible() { return s_visible_; }
+
+private:
+    static lv_obj_t* s_overlay_;
+    static bool      s_visible_;
+};

--- a/firmware/mp3_player/pico/src/ui/screens/now_playing.cpp
+++ b/firmware/mp3_player/pico/src/ui/screens/now_playing.cpp
@@ -1,6 +1,7 @@
 #include "now_playing.h"
 #include "../theme.h"
 #include "../album_art.h"
+#include "../toast.h"
 #include <cstdio>
 #include <cstring>
 
@@ -46,7 +47,7 @@ void NowPlayingScreen::create(lv_obj_t* parent) {
     // ── Album art (80×80, x=8, y=32) ───────────────────────────────────
     s_art.create(parent, 8, 32);
 
-    // ── Track info (right of art, x=96) ───────────────────────────────
+    // ── Track info (right of art, x=96, w=218) ──────────────────────────
     lbl_artist_ = lv_label_create(parent);
     lv_label_set_text(lbl_artist_, "Artist");
     lv_label_set_long_mode(lbl_artist_, LV_LABEL_LONG_DOT);
@@ -126,19 +127,20 @@ void NowPlayingScreen::create(lv_obj_t* parent) {
 }
 
 void NowPlayingScreen::update(const AppState& state) {
-    // Refresh album art when Core 1 signals a new track (generation change).
+    // Refresh album art and show toast when Core 1 opens a new track.
+    // update() runs inside lv_task_handler() on Core 0, so Toast::show() is safe.
     const uint32_t gen = state.cover_art.generation.load(std::memory_order_acquire);
     if (gen != last_art_gen_) {
         last_art_gen_ = gen;
         const int32_t len = state.cover_art.len.load(std::memory_order_relaxed);
-        if (len > 0) {
+        if (len > 0)
             s_art.load_jpeg(state.cover_art.data, static_cast<size_t>(len));
-        } else {
+        else
             s_art.show_placeholder();
-        }
-        // Toast the track title whenever the art generation changes (i.e. track changed).
+
+        // Toast the track title on every track change.
         const char* title = state.playback.current.title;
-        Toast_show_from_update(title[0] ? title : state.playback.current.path);
+        Toast::show(title[0] ? title : "Unknown Track");
     }
 
     char buf[64];

--- a/firmware/mp3_player/pico/src/ui/screens/now_playing.cpp
+++ b/firmware/mp3_player/pico/src/ui/screens/now_playing.cpp
@@ -1,7 +1,10 @@
 #include "now_playing.h"
 #include "../theme.h"
+#include "../album_art.h"
 #include <cstdio>
 #include <cstring>
+
+static AlbumArt s_art;
 
 static void fmt_time(char* buf, uint32_t secs) {
     snprintf(buf, 8, "%u:%02u", secs / 60, secs % 60);
@@ -11,7 +14,7 @@ void NowPlayingScreen::create(lv_obj_t* parent) {
     lv_obj_set_style_bg_color(parent, Theme::BG(), 0);
     lv_obj_set_style_bg_opa(parent, LV_OPA_COVER, 0);
 
-    // ── Status bar ───────────────────────────────────────────────────────────
+    // ── Status bar ───────────────────────────────────────────────────
     lv_obj_t* bar = lv_obj_create(parent);
     lv_obj_set_size(bar, 320, 28);
     lv_obj_set_pos(bar, 0, 0);
@@ -40,36 +43,38 @@ void NowPlayingScreen::create(lv_obj_t* parent) {
     lv_obj_set_style_text_color(lbl_vol_, Theme::TEXT(), 0);
     lv_obj_align(lbl_vol_, LV_ALIGN_RIGHT_MID, 0, 0);
 
-    // ── Artist / Title / Album ────────────────────────────────────────────────
+    // ── Album art (80×80, x=8, y=32) ───────────────────────────────────
+    s_art.create(parent, 8, 32);
+
+    // ── Track info (right of art, x=96) ───────────────────────────────
     lbl_artist_ = lv_label_create(parent);
     lv_label_set_text(lbl_artist_, "Artist");
+    lv_label_set_long_mode(lbl_artist_, LV_LABEL_LONG_DOT);
     lv_obj_set_style_text_color(lbl_artist_, Theme::TEXT_DIM(), 0);
     lv_obj_set_style_text_font(lbl_artist_, &lv_font_montserrat_12, 0);
-    lv_obj_set_width(lbl_artist_, 300);
-    lv_obj_set_style_text_align(lbl_artist_, LV_TEXT_ALIGN_CENTER, 0);
-    lv_obj_align(lbl_artist_, LV_ALIGN_TOP_MID, 0, 36);
+    lv_obj_set_width(lbl_artist_, 218);
+    lv_obj_set_pos(lbl_artist_, 96, 34);
 
     lbl_title_ = lv_label_create(parent);
     lv_label_set_text(lbl_title_, "Track Title");
     lv_label_set_long_mode(lbl_title_, LV_LABEL_LONG_SCROLL_CIRCULAR);
     lv_obj_set_style_text_color(lbl_title_, Theme::TEXT(), 0);
-    lv_obj_set_style_text_font(lbl_title_, &lv_font_montserrat_18, 0);
-    lv_obj_set_width(lbl_title_, 300);
-    lv_obj_set_style_text_align(lbl_title_, LV_TEXT_ALIGN_CENTER, 0);
-    lv_obj_align(lbl_title_, LV_ALIGN_TOP_MID, 0, 55);
+    lv_obj_set_style_text_font(lbl_title_, &lv_font_montserrat_14, 0);
+    lv_obj_set_width(lbl_title_, 218);
+    lv_obj_set_pos(lbl_title_, 96, 52);
 
     lbl_album_ = lv_label_create(parent);
     lv_label_set_text(lbl_album_, "Album");
+    lv_label_set_long_mode(lbl_album_, LV_LABEL_LONG_DOT);
     lv_obj_set_style_text_color(lbl_album_, Theme::TEXT_DIM(), 0);
     lv_obj_set_style_text_font(lbl_album_, &lv_font_montserrat_12, 0);
-    lv_obj_set_width(lbl_album_, 300);
-    lv_obj_set_style_text_align(lbl_album_, LV_TEXT_ALIGN_CENTER, 0);
-    lv_obj_align(lbl_album_, LV_ALIGN_TOP_MID, 0, 82);
+    lv_obj_set_width(lbl_album_, 218);
+    lv_obj_set_pos(lbl_album_, 96, 74);
 
-    // ── Progress bar ─────────────────────────────────────────────────────────
+    // ── Progress bar ──────────────────────────────────────────────
     bar_progress_ = lv_bar_create(parent);
-    lv_obj_set_size(bar_progress_, 260, 6);
-    lv_obj_align(bar_progress_, LV_ALIGN_TOP_MID, 0, 110);
+    lv_obj_set_size(bar_progress_, 280, 6);
+    lv_obj_align(bar_progress_, LV_ALIGN_TOP_MID, 0, 118);
     lv_obj_set_style_bg_color(bar_progress_, Theme::BAR_BG(), 0);
     lv_obj_set_style_bg_color(bar_progress_, Theme::ACCENT(), LV_PART_INDICATOR);
     lv_bar_set_range(bar_progress_, 0, 1000);
@@ -79,25 +84,25 @@ void NowPlayingScreen::create(lv_obj_t* parent) {
     lv_label_set_text(lbl_pos_, "0:00");
     lv_obj_set_style_text_color(lbl_pos_, Theme::TEXT_DIM(), 0);
     lv_obj_set_style_text_font(lbl_pos_, &lv_font_montserrat_12, 0);
-    lv_obj_align(lbl_pos_, LV_ALIGN_TOP_LEFT, 20, 120);
+    lv_obj_align(lbl_pos_, LV_ALIGN_TOP_LEFT, 20, 128);
 
     lbl_dur_ = lv_label_create(parent);
     lv_label_set_text(lbl_dur_, "0:00");
     lv_obj_set_style_text_color(lbl_dur_, Theme::TEXT_DIM(), 0);
     lv_obj_set_style_text_font(lbl_dur_, &lv_font_montserrat_12, 0);
-    lv_obj_align(lbl_dur_, LV_ALIGN_TOP_RIGHT, -20, 120);
+    lv_obj_align(lbl_dur_, LV_ALIGN_TOP_RIGHT, -20, 128);
 
-    // ── Prev / Play-Pause / Next buttons ─────────────────────────────────────
+    // ── Prev / Play-Pause / Next buttons ───────────────────────────────
     btn_prev_ = lv_btn_create(parent);
     lv_obj_set_size(btn_prev_, 60, 40);
-    lv_obj_align(btn_prev_, LV_ALIGN_TOP_LEFT, 30, 145);
+    lv_obj_align(btn_prev_, LV_ALIGN_TOP_LEFT, 30, 150);
     lv_obj_t* lbl_p = lv_label_create(btn_prev_);
     lv_label_set_text(lbl_p, LV_SYMBOL_PREV);
     lv_obj_center(lbl_p);
 
     btn_play_ = lv_btn_create(parent);
     lv_obj_set_size(btn_play_, 70, 44);
-    lv_obj_align(btn_play_, LV_ALIGN_TOP_MID, 0, 143);
+    lv_obj_align(btn_play_, LV_ALIGN_TOP_MID, 0, 148);
     lv_obj_set_style_bg_color(btn_play_, Theme::ACCENT(), 0);
     lv_obj_t* lbl_pl = lv_label_create(btn_play_);
     lv_label_set_text(lbl_pl, LV_SYMBOL_PLAY);
@@ -105,12 +110,12 @@ void NowPlayingScreen::create(lv_obj_t* parent) {
 
     btn_next_ = lv_btn_create(parent);
     lv_obj_set_size(btn_next_, 60, 40);
-    lv_obj_align(btn_next_, LV_ALIGN_TOP_RIGHT, -30, 145);
+    lv_obj_align(btn_next_, LV_ALIGN_TOP_RIGHT, -30, 150);
     lv_obj_t* lbl_n = lv_label_create(btn_next_);
     lv_label_set_text(lbl_n, LV_SYMBOL_NEXT);
     lv_obj_center(lbl_n);
 
-    // ── Queue / shuffle info ──────────────────────────────────────────────────
+    // ── Queue / shuffle info ──────────────────────────────────────────
     lbl_queue_ = lv_label_create(parent);
     lv_label_set_text(lbl_queue_, "Shuffle: OFF   Repeat: OFF   1 / 1");
     lv_obj_set_style_text_color(lbl_queue_, Theme::TEXT_DIM(), 0);
@@ -121,6 +126,21 @@ void NowPlayingScreen::create(lv_obj_t* parent) {
 }
 
 void NowPlayingScreen::update(const AppState& state) {
+    // Refresh album art when Core 1 signals a new track (generation change).
+    const uint32_t gen = state.cover_art.generation.load(std::memory_order_acquire);
+    if (gen != last_art_gen_) {
+        last_art_gen_ = gen;
+        const int32_t len = state.cover_art.len.load(std::memory_order_relaxed);
+        if (len > 0) {
+            s_art.load_jpeg(state.cover_art.data, static_cast<size_t>(len));
+        } else {
+            s_art.show_placeholder();
+        }
+        // Toast the track title whenever the art generation changes (i.e. track changed).
+        const char* title = state.playback.current.title;
+        Toast_show_from_update(title[0] ? title : state.playback.current.path);
+    }
+
     char buf[64];
 
     lv_label_set_text(lbl_artist_, state.playback.current.artist[0]
@@ -150,9 +170,7 @@ void NowPlayingScreen::update(const AppState& state) {
     lv_label_set_text(lbl_vol_, buf);
 
     // BLE / BT indicators.
-    lv_obj_set_style_text_color(lbl_ble_,
-        Theme::ACCENT(), 0);  // always green if BLE stack is running
-
+    lv_obj_set_style_text_color(lbl_ble_, Theme::ACCENT(), 0);
     lv_obj_set_style_text_color(lbl_bt_,
         state.bt.source_connected || state.bt.sink_connected
         ? Theme::SUCCESS() : Theme::TEXT_DIM(), 0);

--- a/firmware/mp3_player/pico/src/ui/screens/now_playing.h
+++ b/firmware/mp3_player/pico/src/ui/screens/now_playing.h
@@ -4,25 +4,21 @@
 
 // Now Playing screen layout (320×240):
 //
-//  ┌──────────────────────────────────────────────────┐
+//  ┌────────────────────────────────────────────────┐
 //  │  ♪ MP3Player        [BLE] [BT]     vol 80%       │ h=28 status bar
-//  ├──────────────────────────────────────────────────┤
-//  │        Artist Name                               │ y=55
-//  │        Track Title (scrolls if long)             │ y=80
-//  │        Album · 4:12                              │ y=110
+//  ├────────────────────────────────────────────────┤
+//  │ [────]  Artist Name                           │ y=32 art (80×80)
+//  │ [ art]  Track Title (scrolls if long)        │ y=52 title
+//  │ [────]  Album                                 │ y=74 album
 //  │  ────────────────────────────────────────────    │
-//  │  1:32  ████████░░░░░░░░░░░░░░░░░░░░░░  4:12     │ y=145 seek bar
-//  │  ────────────────────────────────────────────    │
-//  │   [|◄◄]        [ ►► / ‖‖ ]        [►►|]         │ y=178
-//  │  Shuffle: ON   Repeat: ALL   7 / 43              │ y=218
-//  └──────────────────────────────────────────────────┘
+//  │  1:32  ████████░░░░░░░░░░░░░░░░░░░░░░  4:12     │ y=118 seek bar
+//  │   [|◄◄]       [ ►► / ‖‖ ]       [►►|]         │ y=148
+//  │  Shuffle: ON   Repeat: ALL   7 / 43              │ bottom
+//  └────────────────────────────────────────────────┘
 
 class NowPlayingScreen {
 public:
-    // Create LVGL objects on the given parent screen object.
     void create(lv_obj_t* parent);
-
-    // Call ~1 Hz or whenever playback state changes.
     void update(const AppState& state);
 
 private:
@@ -40,5 +36,6 @@ private:
     lv_obj_t* lbl_ble_      = nullptr;
     lv_obj_t* lbl_bt_       = nullptr;
 
-    static char fmt_time(char* buf, uint32_t secs);
+    // Generation counter from CoverArtBuf; UINT32_MAX forces load on first update.
+    uint32_t last_art_gen_  = 0xFFFFFFFFu;
 };

--- a/firmware/mp3_player/pico/src/ui/screens/settings.cpp
+++ b/firmware/mp3_player/pico/src/ui/screens/settings.cpp
@@ -3,6 +3,7 @@
 #include <cstdio>
 
 static const char* REPEAT_OPTIONS = "OFF\nONE\nALL";
+static const char* EQ_OPTIONS     = "Flat\nBass Boost\nVocal\nTreble";
 
 void SettingsScreen::create(lv_obj_t* parent) {
     lv_obj_set_style_bg_color(parent, Theme::BG(), 0);
@@ -14,7 +15,7 @@ void SettingsScreen::create(lv_obj_t* parent) {
     lv_obj_set_style_bg_color(list, Theme::BG(), 0);
     lv_obj_set_style_border_width(list, 0, 0);
 
-    // ── Output mode ───────────────────────────────────────────────────────────
+    // ── Output mode ──────────────────────────────────────────────────────────────
     lv_list_add_text(list, "Output Mode");
 
     btn_mode_wired_ = lv_list_add_btn(list, LV_SYMBOL_AUDIO, "Wired (PCM5102)");
@@ -29,7 +30,7 @@ void SettingsScreen::create(lv_obj_t* parent) {
     lv_obj_add_event_cb(btn_mode_bt_sink_, event_cb, LV_EVENT_CLICKED, this);
     lv_obj_set_user_data(btn_mode_bt_sink_, reinterpret_cast<void*>(2));
 
-    // ── Volume ────────────────────────────────────────────────────────────────
+    // ── Volume ─────────────────────────────────────────────────────────────────
     lv_list_add_text(list, "Volume");
     lv_obj_t* vol_row = lv_obj_create(list);
     lv_obj_set_size(vol_row, LV_PCT(100), 50);
@@ -57,7 +58,7 @@ void SettingsScreen::create(lv_obj_t* parent) {
     lv_obj_add_event_cb(sw_shuffle_, event_cb, LV_EVENT_VALUE_CHANGED, this);
     lv_obj_set_user_data(sw_shuffle_, reinterpret_cast<void*>(11));
 
-    // ── Repeat ────────────────────────────────────────────────────────────────
+    // ── Repeat ───────────────────────────────────────────────────────────────
     lv_list_add_text(list, "Repeat");
     roller_repeat_ = lv_roller_create(list);
     lv_roller_set_options(roller_repeat_, REPEAT_OPTIONS, LV_ROLLER_MODE_NORMAL);
@@ -66,7 +67,16 @@ void SettingsScreen::create(lv_obj_t* parent) {
     lv_obj_add_event_cb(roller_repeat_, event_cb, LV_EVENT_VALUE_CHANGED, this);
     lv_obj_set_user_data(roller_repeat_, reinterpret_cast<void*>(12));
 
-    // ── SD info ───────────────────────────────────────────────────────────────
+    // ── EQ preset ──────────────────────────────────────────────────────────
+    lv_list_add_text(list, "EQ");
+    roller_eq_ = lv_roller_create(list);
+    lv_roller_set_options(roller_eq_, EQ_OPTIONS, LV_ROLLER_MODE_NORMAL);
+    lv_roller_set_visible_row_count(roller_eq_, 1);
+    lv_obj_set_width(roller_eq_, 160);
+    lv_obj_add_event_cb(roller_eq_, event_cb, LV_EVENT_VALUE_CHANGED, this);
+    lv_obj_set_user_data(roller_eq_, reinterpret_cast<void*>(13));
+
+    // ── SD info ─────────────────────────────────────────────────────────────
     lv_list_add_text(list, "SD Card");
     lbl_sd_info_ = lv_label_create(list);
     lv_label_set_text(lbl_sd_info_, "Scanning...");
@@ -84,11 +94,13 @@ void SettingsScreen::update(const AppState& state) {
 
     lv_roller_set_selected(roller_repeat_,
                            static_cast<uint16_t>(state.playback.repeat), LV_ANIM_OFF);
+    lv_roller_set_selected(roller_eq_,
+                           static_cast<uint16_t>(state.playback.eq_preset), LV_ANIM_OFF);
     lv_slider_set_value(slider_vol_, state.playback.volume, LV_ANIM_OFF);
 
     char buf[48];
     snprintf(buf, sizeof(buf), "%.1f GB free / %.1f GB",
-             0.0f,  // filled from SdCard at runtime
+             0.0f,
              0.0f);
     lv_label_set_text(lbl_sd_info_, buf);
 }
@@ -114,6 +126,11 @@ void SettingsScreen::event_cb(lv_event_t* e) {
         if (self->on_repeat_change)
             self->on_repeat_change(
                 static_cast<RepeatMode>(lv_roller_get_selected(obj)));
+        break;
+    case 13:
+        if (self->on_eq_change)
+            self->on_eq_change(
+                static_cast<EqPreset>(lv_roller_get_selected(obj)));
         break;
     default: break;
     }

--- a/firmware/mp3_player/pico/src/ui/screens/settings.h
+++ b/firmware/mp3_player/pico/src/ui/screens/settings.h
@@ -9,18 +9,20 @@ public:
     void create(lv_obj_t* parent);
     void update(const AppState& state);
 
-    std::function<void(AppMode)>   on_mode_change;
-    std::function<void(uint8_t)>   on_volume_change;
-    std::function<void(bool)>      on_shuffle_change;
-    std::function<void(RepeatMode)>on_repeat_change;
+    std::function<void(AppMode)>    on_mode_change;
+    std::function<void(uint8_t)>    on_volume_change;
+    std::function<void(bool)>       on_shuffle_change;
+    std::function<void(RepeatMode)> on_repeat_change;
+    std::function<void(EqPreset)>   on_eq_change;
 
 private:
     static void event_cb(lv_event_t* e);
 
-    lv_obj_t* sw_shuffle_  = nullptr;
+    lv_obj_t* sw_shuffle_   = nullptr;
     lv_obj_t* roller_repeat_= nullptr;
-    lv_obj_t* slider_vol_  = nullptr;
-    lv_obj_t* lbl_sd_info_ = nullptr;
+    lv_obj_t* roller_eq_    = nullptr;
+    lv_obj_t* slider_vol_   = nullptr;
+    lv_obj_t* lbl_sd_info_  = nullptr;
     lv_obj_t* btn_mode_wired_   = nullptr;
     lv_obj_t* btn_mode_bt_src_  = nullptr;
     lv_obj_t* btn_mode_bt_sink_ = nullptr;

--- a/firmware/mp3_player/pico/src/ui/toast.cpp
+++ b/firmware/mp3_player/pico/src/ui/toast.cpp
@@ -1,0 +1,72 @@
+#include "toast.h"
+
+lv_obj_t* Toast::s_cont_      = nullptr;
+lv_obj_t* Toast::s_label_     = nullptr;
+uint32_t  Toast::s_hide_tick_ = 0;
+bool      Toast::s_visible_   = false;
+
+static constexpr lv_coord_t TOAST_Y_HIDDEN = 240;  // off-screen below display
+static constexpr lv_coord_t TOAST_Y_SHOWN  = 198;  // 6 px above bottom edge
+
+void Toast::init() {
+    lv_obj_t* layer = lv_layer_top();
+
+    s_cont_ = lv_obj_create(layer);
+    lv_obj_set_size(s_cont_, 300, 36);
+    lv_obj_set_pos(s_cont_, 10, TOAST_Y_HIDDEN);
+    lv_obj_set_style_bg_color(s_cont_, lv_color_hex(0x1E1E1E), 0);
+    lv_obj_set_style_bg_opa(s_cont_, LV_OPA_90, 0);
+    lv_obj_set_style_border_width(s_cont_, 0, 0);
+    lv_obj_set_style_radius(s_cont_, 8, 0);
+    lv_obj_set_style_pad_all(s_cont_, 4, 0);
+    lv_obj_clear_flag(s_cont_, LV_OBJ_FLAG_SCROLLABLE);
+
+    s_label_ = lv_label_create(s_cont_);
+    lv_label_set_long_mode(s_label_, LV_LABEL_LONG_SCROLL_CIRCULAR);
+    lv_obj_set_width(s_label_, 290);
+    lv_obj_set_style_text_color(s_label_, lv_color_white(), 0);
+    lv_obj_set_style_text_font(s_label_, &lv_font_montserrat_14, 0);
+    lv_obj_align(s_label_, LV_ALIGN_CENTER, 0, 0);
+}
+
+void Toast::anim_y_cb(void* obj, int32_t v) {
+    lv_obj_set_y(static_cast<lv_obj_t*>(obj), v);
+}
+
+void Toast::slide_out_ready_cb(lv_anim_t* a) {
+    // Snap to hidden position after animation completes.
+    lv_obj_set_y(static_cast<lv_obj_t*>(a->var), TOAST_Y_HIDDEN);
+}
+
+void Toast::show(const char* msg, uint32_t duration_ms) {
+    if (!s_cont_ || !msg) return;
+    lv_label_set_text(s_label_, msg);
+    s_hide_tick_ = lv_tick_get() + duration_ms;
+    s_visible_   = true;
+
+    lv_anim_t a;
+    lv_anim_init(&a);
+    lv_anim_set_var(&a, s_cont_);
+    lv_anim_set_exec_cb(&a, anim_y_cb);
+    lv_anim_set_values(&a, lv_obj_get_y(s_cont_), TOAST_Y_SHOWN);
+    lv_anim_set_time(&a, 200);
+    lv_anim_set_path_cb(&a, lv_anim_path_ease_out);
+    lv_anim_start(&a);
+}
+
+void Toast::task() {
+    if (!s_visible_ || !s_cont_) return;
+    if (lv_tick_get() < s_hide_tick_) return;
+
+    s_visible_ = false;
+
+    lv_anim_t a;
+    lv_anim_init(&a);
+    lv_anim_set_var(&a, s_cont_);
+    lv_anim_set_exec_cb(&a, anim_y_cb);
+    lv_anim_set_values(&a, TOAST_Y_SHOWN, TOAST_Y_HIDDEN);
+    lv_anim_set_time(&a, 160);
+    lv_anim_set_path_cb(&a, lv_anim_path_ease_in);
+    lv_anim_set_ready_cb(&a, slide_out_ready_cb);
+    lv_anim_start(&a);
+}

--- a/firmware/mp3_player/pico/src/ui/toast.h
+++ b/firmware/mp3_player/pico/src/ui/toast.h
@@ -1,0 +1,24 @@
+#pragma once
+#include <lvgl.h>
+
+// Slide-up toast notification rendered on lv_layer_top() (above all screens).
+//
+// Usage:
+//   Toast::init();          // once, after lv_init()
+//   Toast::show("text");    // from Core 0 / LVGL context only
+//   Toast::task();          // every display loop iteration to drive slide-out
+class Toast {
+public:
+    static void init();
+    static void show(const char* msg, uint32_t duration_ms = 2000);
+    static void task();   // drives the auto-hide timer and slide-out animation
+
+private:
+    static void anim_y_cb(void* obj, int32_t v);
+    static void slide_out_ready_cb(lv_anim_t* a);
+
+    static lv_obj_t* s_cont_;
+    static lv_obj_t* s_label_;
+    static uint32_t  s_hide_tick_;
+    static bool      s_visible_;
+};


### PR DESCRIPTION
## Summary

- **Album art**: `AlbumArt` class decodes JPEG cover images (cover.jpg / folder.jpg / album.jpg) into an 80×80 LVGL canvas using [JPEGDEC](https://github.com/bitbank2/JPEGDEC). Art sits to the left of artist/title/album in the Now Playing screen; a placeholder music-note graphic shows when no art is found.
- **Toast notifications**: `Toast` draws a 300×36 pill on `lv_layer_top()` (above all screens). Slide-in/out is driven by `lv_anim` (ease-out 200 ms in, ease-in 160 ms out). Fires on every track change (detected via `CoverArtBuf::generation`) and on volume changes from the Settings screen.
- **USB / charging overlay**: `ChargingOverlay` draws a 90%-opaque full-screen overlay on `lv_layer_top()` with a spinning `lv_spinner` arc and "USB Connected / Eject SD card to resume" text. Shown/hidden in `loop()` when `g_state.usb_active` transitions.

## Architecture notes

**Cross-core cover art handoff** (`AppState::CoverArtBuf`):
- Core 1 (`SdPlayer::extract_cover_art`) fills `data[]`, stores `len` (relaxed), then `generation.fetch_add(1, release)`.
- Core 0 (`NowPlayingScreen::update`) loads `generation` (acquire) — establishes happens-before — then reads `data[]` and `len`.
- No mutex needed; worst case is one frame of stale art if a very short track plays twice before the 1 Hz UI tick.

**LVGL thread safety**: `Toast::show()` and `ChargingOverlay::set_visible()` are only called from Core 0 contexts (inside `lv_task_handler()` or the `loop()` function). `on_track_changed` fires on Core 1 but only calls `g_ble.notify_track()` — no LVGL.

## Test plan

- [ ] Build with PlatformIO (`pio run -e rpipico2w`) — no errors
- [ ] Flash and verify placeholder art shows on startup before SD scan completes
- [ ] Place a `cover.jpg` in a music folder; confirm art loads on that track and placeholder shows on tracks without art
- [ ] Observe toast slides up on each track change and fades after 2 s
- [ ] Change volume in Settings; confirm "Volume: N%" toast appears for 1.5 s
- [ ] Plug USB cable; confirm charging overlay appears and music stops
- [ ] Unplug USB cable; confirm overlay hides and music resumes

---
_Generated by [Claude Code](https://claude.ai/code/session_01B2abFkxcMAqFf1jCADQQgJ)_