### PR TITLE
Add USB Cam 3, dynamic camera menu, and dev/debug monitoring features

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,18 @@ endif()
 set(CMAKE_CXX_FLAGS_RELEASE "-O2")
 set(CMAKE_CXX_FLAGS_DEBUG   "-g -DDEBUG")
 
+# ── Git hash compile definition ───────────────────────────────────────────────
+
+execute_process(
+    COMMAND git -C ${CMAKE_SOURCE_DIR} rev-parse --short HEAD
+    OUTPUT_VARIABLE GIT_HASH_STR
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+)
+if(NOT GIT_HASH_STR)
+    set(GIT_HASH_STR "unknown")
+endif()
+
 # ── Dependencies ──────────────────────────────────────────────────────────────
 
 find_package(PkgConfig REQUIRED)
@@ -126,6 +138,11 @@ set(SOURCES
     src/audio/audio_engine.cpp
     src/post_process.cpp
     src/sensor/mpu9250.cpp
+    src/sys/system_monitor.cpp
+    src/net/wifi_monitor.cpp
+    src/net/ping_monitor.cpp
+    src/net/bt_monitor.cpp
+    src/crash_reporter.cpp
 )
 
 add_executable(protohud ${SOURCES})
@@ -163,6 +180,10 @@ target_compile_options(protohud PRIVATE
     ${EGL_CFLAGS_OTHER}
     ${GLES_CFLAGS_OTHER}
     ${GLFW3_CFLAGS_OTHER}
+)
+
+target_compile_definitions(protohud PRIVATE
+    GIT_HASH="${GIT_HASH_STR}"
 )
 
 # Ensure libglasses.so is found at runtime relative to the binary

--- a/config/config.json
+++ b/config/config.json
@@ -51,6 +51,21 @@
       "exposure_time": 157,
       "auto_wb": true,
       "wb_temp": 4600
+    },
+    "usb_cam_3": {
+      "device": "",
+      "width": 1280,
+      "height": 720,
+      "fps": 30,
+      "brightness": 1.0,
+      "dynamic_framerate": false,
+      "auto_exposure": true,
+      "exposure_time": 157,
+      "auto_wb": true,
+      "wb_temp": 4600,
+      "flip": false,
+      "auto_brightness": false,
+      "auto_brightness_target": 100.0
     }
   },
   "serial": {

--- a/config/config.json
+++ b/config/config.json
@@ -215,5 +215,11 @@
     "show_date":       false,
     "font_scale":      1.5,
     "manual_offset_s": 0
+  },
+  "system": {
+    "ping_host":  "8.8.8.8",
+    "wifi_iface": "wlan0",
+    "ssh_port":   22,
+    "crash_dir":  "/tmp"
   }
 }

--- a/src/app_state.h
+++ b/src/app_state.h
@@ -112,6 +112,8 @@ struct SystemHealth {
     bool audio_ok        = false;  // Spatial audio engine running
     bool android_mirror  = false;  // scrcpy connected and streaming
     bool mpu9250_ok      = false;  // MPU-9250 backup compass running
+    bool wifi_ok         = false;  // Wi-Fi associated
+    bool ssh_active      = false;  // SSH daemon is running
     // Render-thread-only: connected AND overlay enabled
     bool cam_usb1_overlay = false;
     bool cam_usb2_overlay = false;
@@ -189,6 +191,46 @@ struct TimerAlarmState {
     int    custom_timer_sec = 0;      // custom timer seconds (0–59)
 };
 
+// ── System metrics ────────────────────────────────────────────────────────────
+static constexpr int kSysHistLen  = 60;
+static constexpr int kPingHistLen = 30;
+
+struct SysMetrics {
+    uint64_t uptime_s     = 0;
+    float    cpu_pct      = 0.f;      // 0–100
+    float    ram_used_mb  = 0.f;
+    float    ram_total_mb = 0.f;
+    float    cpu_history [kSysHistLen]  = {};
+    float    ram_history [kSysHistLen]  = {};
+    int      history_head = 0;
+};
+
+struct WifiState {
+    bool        connected  = false;
+    std::string ssid;
+    std::string ip;
+    int         signal_dbm = -100;
+};
+
+struct PingState {
+    bool        reachable    = false;
+    float       latency_ms   = 0.f;
+    float       history[kPingHistLen] = {};
+    int         history_head = 0;
+    std::string host;
+};
+
+struct BtDevice {
+    std::string name;
+    std::string mac;
+    bool        connected = false;
+};
+
+struct SshState {
+    bool active = false;
+    int  port   = 22;
+};
+
 // ── Master state ──────────────────────────────────────────────────────────────
 // Mutable fields are updated from serial/camera threads and read by the
 // render thread.  Callers must hold the mutex for any multi-field access.
@@ -238,6 +280,13 @@ struct AppState {
         IM_COL32(255,  60,  60, 255),  // 6 red
         IM_COL32(255, 255, 255, 255),  // 7 white
     };
+
+    // System monitor / network / Bluetooth state
+    SysMetrics             sys_metrics;
+    WifiState              wifi;
+    PingState              ping;
+    SshState               ssh;
+    std::vector<BtDevice>  bt_devices;
 
     // Cached XR display control values (no SDK getter; updated when menu writes).
     int xr_brightness     = 5;   // 1–7; mirrors last xr->set_brightness() call

--- a/src/app_state.h
+++ b/src/app_state.h
@@ -108,12 +108,14 @@ struct SystemHealth {
     bool cam_owl_right   = false;
     bool cam_usb1        = false;
     bool cam_usb2        = false;
+    bool cam_usb3        = false;
     bool audio_ok        = false;  // Spatial audio engine running
     bool android_mirror  = false;  // scrcpy connected and streaming
     bool mpu9250_ok      = false;  // MPU-9250 backup compass running
     // Render-thread-only: connected AND overlay enabled
     bool cam_usb1_overlay = false;
     bool cam_usb2_overlay = false;
+    bool cam_usb3_overlay = false;
 };
 
 struct AudioState {

--- a/src/camera/camera_manager.cpp
+++ b/src/camera/camera_manager.cpp
@@ -97,6 +97,7 @@ static bool open_v4l2(cv::VideoCapture& cap, const UsbCamConfig& cfg,
 
 bool CameraManager::init(const CamConfig& left, const CamConfig& right,
                          const UsbCamConfig& usb1, const UsbCamConfig& usb2,
+                         const UsbCamConfig& usb3,
                          const char* nv12_vs, const char* nv12_fs) {
     // ── libcamera manager (shared between both DmaCamera instances) ───────────
     lcam_mgr_ = std::make_unique<libcamera::CameraManager>();
@@ -126,14 +127,19 @@ bool CameraManager::init(const CamConfig& left, const CamConfig& right,
     // ── USB cameras (OpenCV) ──────────────────────────────────────────────────
     usb1_cfg_ = usb1;
     usb2_cfg_ = usb2;
+    usb3_cfg_ = usb3;
     usb1_brightness_ = usb1.brightness;
     usb2_brightness_ = usb2.brightness;
+    usb3_brightness_ = usb3.brightness;
     usb1_flip_                   = usb1.flip;
     usb2_flip_                   = usb2.flip;
+    usb3_flip_                   = usb3.flip;
     usb1_auto_brightness_        = usb1.auto_brightness;
     usb1_auto_brightness_target_ = usb1.auto_brightness_target;
     usb2_auto_brightness_        = usb2.auto_brightness;
     usb2_auto_brightness_target_ = usb2.auto_brightness_target;
+    usb3_auto_brightness_        = usb3.auto_brightness;
+    usb3_auto_brightness_target_ = usb3.auto_brightness_target;
 
     // Scan /dev/video0-63 and list non-ISP capture nodes
     std::cerr << "[cam] USB cameras found:\n";
@@ -150,17 +156,20 @@ bool CameraManager::init(const CamConfig& left, const CamConfig& right,
 
     usb1_ok_ = !usb1.device.empty() && open_v4l2(usb_cap1_, usb1, "usb1");
     usb2_ok_ = !usb2.device.empty() && open_v4l2(usb_cap2_, usb2, "usb2");
+    usb3_ok_ = !usb3.device.empty() && open_v4l2(usb_cap3_, usb3, "usb3");
 
     // Auto-scan: if a camera failed to open with the configured path, probe all
     // /dev/video* nodes (before the capture thread starts) to find a working one.
     auto startup_scan = [&](cv::VideoCapture& cap, std::atomic<bool>& ok_flag,
                              UsbCamConfig& cfg, const char* name,
-                             const std::string& skip_path) {
+                             std::initializer_list<std::string> skip_paths) {
         if (ok_flag) return;
         std::cerr << "[cam] " << name << ": auto-scanning for a camera...\n";
         for (int dev = 0; dev < 64; dev++) {
             std::string path = "/dev/video" + std::to_string(dev);
-            if (path == skip_path) continue;
+            bool skip = false;
+            for (const auto& s : skip_paths) if (!s.empty() && path == s) { skip = true; break; }
+            if (skip) continue;
             if (!is_usb_capture_device(path)) continue;
             UsbCamConfig try_cfg = cfg;
             try_cfg.device = path;
@@ -177,17 +186,18 @@ bool CameraManager::init(const CamConfig& left, const CamConfig& right,
         }
         std::cerr << "[cam] " << name << ": auto-scan found no working camera\n";
     };
-    startup_scan(usb_cap1_, usb1_ok_, usb1_cfg_, "usb1", "");
-    startup_scan(usb_cap2_, usb2_ok_, usb2_cfg_, "usb2", usb1_cfg_.device);
+    startup_scan(usb_cap1_, usb1_ok_, usb1_cfg_, "usb1", {});
+    startup_scan(usb_cap2_, usb2_ok_, usb2_cfg_, "usb2", {usb1_cfg_.device});
+    startup_scan(usb_cap3_, usb3_ok_, usb3_cfg_, "usb3", {usb1_cfg_.device, usb2_cfg_.device});
 
     // Start thread whenever USB devices are configured so open/close can work
     // later even if the cameras were not available at startup.
-    if (!usb1.device.empty() || !usb2.device.empty()) {
+    if (!usb1.device.empty() || !usb2.device.empty() || !usb3.device.empty()) {
         running_ = true;
         usb_thread_ = std::thread(&CameraManager::usb_capture_thread, this);
     }
 
-    return owl_left_ok() || owl_right_ok() || usb1_ok_ || usb2_ok_;
+    return owl_left_ok() || owl_right_ok() || usb1_ok_ || usb2_ok_ || usb3_ok_;
 }
 
 void CameraManager::shutdown() {
@@ -199,10 +209,12 @@ void CameraManager::shutdown() {
 
     usb_cap1_.release();
     usb_cap2_.release();
+    usb_cap3_.release();
 
     // Clean up GL textures allocated for USB cams (must be called from render thread)
     if (usb1_slot_.tex) { glDeleteTextures(1, &usb1_slot_.tex); usb1_slot_.tex = 0; }
     if (usb2_slot_.tex) { glDeleteTextures(1, &usb2_slot_.tex); usb2_slot_.tex = 0; }
+    if (usb3_slot_.tex) { glDeleteTextures(1, &usb3_slot_.tex); usb3_slot_.tex = 0; }
 
     if (lcam_mgr_) { lcam_mgr_->stop(); lcam_mgr_.reset(); }
 }
@@ -232,7 +244,8 @@ void CameraManager::usb_capture_thread() {
     cv::Mat frame, rgba;
     int frames1 = 0, empty1 = 0, consec1 = 0;
     int frames2 = 0, empty2 = 0, consec2 = 0;
-    int luma_tick1 = 0, luma_tick2 = 0;
+    int frames3 = 0, empty3 = 0, consec3 = 0;
+    int luma_tick1 = 0, luma_tick2 = 0, luma_tick3 = 0;
 
     // Consecutive empty reads before declaring a camera disconnected.
     // At ~30fps with near-instant V4L2 failures this triggers in ~1 s.
@@ -313,6 +326,9 @@ void CameraManager::usb_capture_thread() {
         any      |= capture(usb_cap2_, usb2_cap_mtx_, usb2_slot_, usb2_ok_,
                             frames2, empty2, consec2, usb2_brightness_, usb2_flip_,
                             usb2_auto_brightness_, usb2_auto_brightness_target_, luma_tick2, "usb2");
+        any      |= capture(usb_cap3_, usb3_cap_mtx_, usb3_slot_, usb3_ok_,
+                            frames3, empty3, consec3, usb3_brightness_, usb3_flip_,
+                            usb3_auto_brightness_, usb3_auto_brightness_target_, luma_tick3, "usb3");
 
         // Auto-reconnect: periodically reopen disconnected cameras when enabled.
         auto now = std::chrono::steady_clock::now();
@@ -329,6 +345,13 @@ void CameraManager::usb_capture_thread() {
             consec2 = 0; empty2 = 0;
             std::cerr << "[cam] usb2: auto-reconnect attempt\n";
             open_usb2();
+        }
+        if (usb3_reconnect_ && !usb3_ok_ && !usb3_cfg_.device.empty() &&
+            now - usb3_last_retry_ >= kReconnectInterval) {
+            usb3_last_retry_ = now;
+            consec3 = 0; empty3 = 0;
+            std::cerr << "[cam] usb3: auto-reconnect attempt\n";
+            open_usb3();
         }
 
         if (!any)
@@ -376,6 +399,25 @@ void CameraManager::close_usb2() {
     std::cerr << "[cam] usb2: closed\n";
 }
 
+void CameraManager::open_usb3() {
+    std::lock_guard<std::mutex> lk(usb3_cap_mtx_);
+    if (usb3_cfg_.device.empty()) {
+        std::cerr << "[cam] usb3: no device configured\n"; return;
+    }
+    if (usb_cap3_.isOpened()) {
+        std::cerr << "[cam] usb3: already open\n"; return;
+    }
+    usb3_ok_ = open_v4l2(usb_cap3_, usb3_cfg_, "usb3");
+}
+
+void CameraManager::close_usb3() {
+    usb3_reconnect_ = false;   // explicit close — don't auto-reopen
+    std::lock_guard<std::mutex> lk(usb3_cap_mtx_);
+    usb_cap3_.release();
+    usb3_ok_ = false;
+    std::cerr << "[cam] usb3: closed\n";
+}
+
 // ── USB texture upload (render thread) ────────────────────────────────────────
 // Creates or reallocates the GL texture if dimensions changed, then uploads pixels.
 
@@ -408,7 +450,8 @@ void CameraManager::upload_texture(GLuint& tex, int w, int h,
 // at least one USB slot is now open. Returns true if this slot is now open.
 
 bool CameraManager::scan_usb(cv::VideoCapture& cap, std::atomic<bool>& ok,
-                              const UsbCamConfig& cfg)
+                              UsbCamConfig& cfg,
+                              const std::vector<std::string>& skip_paths)
 {
     // Stop the capture thread so nothing else is calling cap.read()
     running_ = false;
@@ -419,6 +462,9 @@ bool CameraManager::scan_usb(cv::VideoCapture& cap, std::atomic<bool>& ok,
 
     for (int dev = 0; dev < 64; dev++) {
         std::string path = "/dev/video" + std::to_string(dev);
+        bool skip = false;
+        for (const auto& s : skip_paths) if (!s.empty() && path == s) { skip = true; break; }
+        if (skip) continue;
         if (!is_usb_capture_device(path)) continue;
         UsbCamConfig test_cfg = cfg;
         test_cfg.device = path;
@@ -426,6 +472,7 @@ bool CameraManager::scan_usb(cv::VideoCapture& cap, std::atomic<bool>& ok,
             cv::Mat test;
             if (cap.read(test) && !test.empty()) {
                 std::cerr << "[cam] USB scan found device at " << path << "\n";
+                cfg.device = path;
                 ok = true;
                 break;
             }
@@ -439,8 +486,8 @@ bool CameraManager::scan_usb(cv::VideoCapture& cap, std::atomic<bool>& ok,
                   << "    sudo usermod -aG video $USER  (then log out and back in)\n";
     }
 
-    // Restart the capture thread if either slot is now usable
-    if (usb1_ok_ || usb2_ok_) {
+    // Restart the capture thread if any slot is now usable
+    if (usb1_ok_ || usb2_ok_ || usb3_ok_) {
         running_ = true;
         usb_thread_ = std::thread(&CameraManager::usb_capture_thread, this);
     }
@@ -449,7 +496,8 @@ bool CameraManager::scan_usb(cv::VideoCapture& cap, std::atomic<bool>& ok,
 }
 
 bool CameraManager::scan_usb1() { return scan_usb(usb_cap1_, usb1_ok_, usb1_cfg_); }
-bool CameraManager::scan_usb2() { return scan_usb(usb_cap2_, usb2_ok_, usb2_cfg_); }
+bool CameraManager::scan_usb2() { return scan_usb(usb_cap2_, usb2_ok_, usb2_cfg_, {usb1_cfg_.device}); }
+bool CameraManager::scan_usb3() { return scan_usb(usb_cap3_, usb3_ok_, usb3_cfg_, {usb1_cfg_.device, usb2_cfg_.device}); }
 
 static void v4l2_set_ctrl(const std::string& dev, uint32_t id, int32_t val) {
     int fd = open(dev.c_str(), O_RDWR);
@@ -460,6 +508,7 @@ static void v4l2_set_ctrl(const std::string& dev, uint32_t id, int32_t val) {
 }
 void CameraManager::set_usb1_ctrl(uint32_t id, int32_t val) { v4l2_set_ctrl(usb1_cfg_.device, id, val); }
 void CameraManager::set_usb2_ctrl(uint32_t id, int32_t val) { v4l2_set_ctrl(usb2_cfg_.device, id, val); }
+void CameraManager::set_usb3_ctrl(uint32_t id, int32_t val) { v4l2_set_ctrl(usb3_cfg_.device, id, val); }
 
 bool CameraManager::get_usb1(GLuint& out) {
     std::lock_guard<std::mutex> lk(usb1_slot_.mtx);
@@ -476,5 +525,14 @@ bool CameraManager::get_usb2(GLuint& out) {
     upload_texture(usb2_slot_.tex, usb2_slot_.w, usb2_slot_.h, usb2_slot_.buf.data());
     usb2_slot_.dirty = false;
     out = usb2_slot_.tex;
+    return true;
+}
+
+bool CameraManager::get_usb3(GLuint& out) {
+    std::lock_guard<std::mutex> lk(usb3_slot_.mtx);
+    if (!usb3_slot_.dirty || usb3_slot_.buf.empty()) { out = usb3_slot_.tex; return false; }
+    upload_texture(usb3_slot_.tex, usb3_slot_.w, usb3_slot_.h, usb3_slot_.buf.data());
+    usb3_slot_.dirty = false;
+    out = usb3_slot_.tex;
     return true;
 }

--- a/src/camera/camera_manager.h
+++ b/src/camera/camera_manager.h
@@ -58,6 +58,7 @@ public:
 
     bool init(const CamConfig& left, const CamConfig& right,
               const UsbCamConfig& usb1, const UsbCamConfig& usb2,
+              const UsbCamConfig& usb3,
               const char* nv12_vs_path, const char* nv12_fs_path);
     void shutdown();
 
@@ -72,6 +73,7 @@ public:
     // Returns true if a new frame was uploaded this call.
     bool get_usb1(GLuint& out);
     bool get_usb2(GLuint& out);
+    bool get_usb3(GLuint& out);
 
     // ── Resolution hot-swap ───────────────────────────────────────────────────
     // Reconfigures both OWLsight cameras to the given resolution and fps.
@@ -93,6 +95,8 @@ public:
     void close_usb1();
     void open_usb2();
     void close_usb2();
+    void open_usb3();
+    void close_usb3();
 
     // ── USB camera scan ───────────────────────────────────────────────────────
     // Stops the capture thread, probes /dev/video0..N until a device opens,
@@ -100,12 +104,14 @@ public:
     // Returns true if the slot is now open.
     bool scan_usb1();
     bool scan_usb2();
+    bool scan_usb3();
 
     // ── Status ────────────────────────────────────────────────────────────────
     bool owl_left_ok()  const { return owl_left_  && owl_left_->is_ok();  }
     bool owl_right_ok() const { return owl_right_ && owl_right_->is_ok(); }
     bool usb1_ok()      const { return usb1_ok_; }
     bool usb2_ok()      const { return usb2_ok_; }
+    bool usb3_ok()      const { return usb3_ok_; }
 
     // ── Auto-reconnect ────────────────────────────────────────────────────────
     // When enabled, the capture thread will attempt to reopen a disconnected
@@ -113,18 +119,23 @@ public:
     // camera so an explicit close stays closed.
     void set_usb1_reconnect(bool v) { usb1_reconnect_ = v; }
     void set_usb2_reconnect(bool v) { usb2_reconnect_ = v; }
+    void set_usb3_reconnect(bool v) { usb3_reconnect_ = v; }
     bool usb1_reconnect_enabled() const { return usb1_reconnect_; }
     bool usb2_reconnect_enabled() const { return usb2_reconnect_; }
+    bool usb3_reconnect_enabled() const { return usb3_reconnect_; }
 
     // ── USB brightness (software multiplier, safe to call from any thread) ────
     void  set_usb1_brightness(float v) { usb1_brightness_ = v; }
     void  set_usb2_brightness(float v) { usb2_brightness_ = v; }
+    void  set_usb3_brightness(float v) { usb3_brightness_ = v; }
     float usb1_brightness()      const { return usb1_brightness_.load(); }
     float usb2_brightness()      const { return usb2_brightness_.load(); }
+    float usb3_brightness()      const { return usb3_brightness_.load(); }
 
     // ── USB V4L2 control (applies ioctl live; camera may briefly drop frames) ─
     void set_usb1_ctrl(uint32_t id, int32_t value);
     void set_usb2_ctrl(uint32_t id, int32_t value);
+    void set_usb3_ctrl(uint32_t id, int32_t value);
 
     // ── USB config access (for menu read-back and config-save persistence) ────
     void update_usb1_cfg(const UsbCamConfig& c) {
@@ -139,8 +150,15 @@ public:
         usb2_auto_brightness_        = c.auto_brightness;
         usb2_auto_brightness_target_ = c.auto_brightness_target;
     }
+    void update_usb3_cfg(const UsbCamConfig& c) {
+        usb3_cfg_ = c;
+        usb3_flip_                   = c.flip;
+        usb3_auto_brightness_        = c.auto_brightness;
+        usb3_auto_brightness_target_ = c.auto_brightness_target;
+    }
     const UsbCamConfig& usb1_cfg() const { return usb1_cfg_; }
     const UsbCamConfig& usb2_cfg() const { return usb2_cfg_; }
+    const UsbCamConfig& usb3_cfg() const { return usb3_cfg_; }
 
 private:
     void usb_capture_thread();
@@ -148,7 +166,8 @@ private:
     void upload_texture(GLuint& tex, int w, int h, const unsigned char* rgba);
     // Stop the capture thread, probe video devices, restart thread.
     bool scan_usb(cv::VideoCapture& cap, std::atomic<bool>& ok,
-                  const UsbCamConfig& cfg);
+                  UsbCamConfig& cfg,
+                  const std::vector<std::string>& skip_paths = {});
 
     // Shared libcamera camera manager (one per process)
     std::unique_ptr<libcamera::CameraManager> lcam_mgr_;
@@ -158,16 +177,19 @@ private:
     std::unique_ptr<DmaCamera> owl_right_;
 
     // USB cameras (OpenCV capture)
-    UsbCamConfig     usb1_cfg_, usb2_cfg_;
-    cv::VideoCapture usb_cap1_, usb_cap2_;
-    std::mutex       usb1_cap_mtx_, usb2_cap_mtx_;
+    UsbCamConfig     usb1_cfg_, usb2_cfg_, usb3_cfg_;
+    cv::VideoCapture usb_cap1_, usb_cap2_, usb_cap3_;
+    std::mutex       usb1_cap_mtx_, usb2_cap_mtx_, usb3_cap_mtx_;
     std::atomic<bool> usb1_ok_ { false };
     std::atomic<bool> usb2_ok_ { false };
+    std::atomic<bool> usb3_ok_ { false };
     std::atomic<bool> usb1_reconnect_ { false };
     std::atomic<bool> usb2_reconnect_ { false };
+    std::atomic<bool> usb3_reconnect_ { false };
     // Written only by the capture thread; no extra sync needed.
     std::chrono::steady_clock::time_point usb1_last_retry_ {};
     std::chrono::steady_clock::time_point usb2_last_retry_ {};
+    std::chrono::steady_clock::time_point usb3_last_retry_ {};
 
     // Per-USB-camera slot: capture thread writes buf/w/h, render thread uploads
     struct TexSlot {
@@ -179,16 +201,20 @@ private:
         int                 w = 0, h = 0;
         bool                dirty = false;
     };
-    TexSlot usb1_slot_, usb2_slot_;
+    TexSlot usb1_slot_, usb2_slot_, usb3_slot_;
 
     std::atomic<float> usb1_brightness_ { 1.0f };
     std::atomic<float> usb2_brightness_ { 1.0f };
+    std::atomic<float> usb3_brightness_ { 1.0f };
     std::atomic<bool>  usb1_flip_       { false };
     std::atomic<bool>  usb2_flip_       { false };
+    std::atomic<bool>  usb3_flip_       { false };
     std::atomic<bool>  usb1_auto_brightness_        { false };
     std::atomic<bool>  usb2_auto_brightness_        { false };
+    std::atomic<bool>  usb3_auto_brightness_        { false };
     std::atomic<float> usb1_auto_brightness_target_ { 100.f };
     std::atomic<float> usb2_auto_brightness_target_ { 100.f };
+    std::atomic<float> usb3_auto_brightness_target_ { 100.f };
 
     std::atomic<bool> running_ { false };
     std::thread       usb_thread_;

--- a/src/crash_reporter.cpp
+++ b/src/crash_reporter.cpp
@@ -1,0 +1,154 @@
+#include "crash_reporter.h"
+
+#include <csignal>
+#include <cstdio>
+#include <cstring>
+#include <ctime>
+#include <execinfo.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+// ── Globals set by install() — read only inside signal handler ────────────────
+static const AppState* g_state     = nullptr;
+static char            g_crash_dir[256] = "/tmp";
+static char            g_git_hash[64]   = "unknown";
+
+static const char* sig_name(int sig) {
+    switch (sig) {
+        case SIGSEGV: return "SIGSEGV";
+        case SIGABRT: return "SIGABRT";
+        case SIGFPE:  return "SIGFPE";
+        case SIGILL:  return "SIGILL";
+        case SIGBUS:  return "SIGBUS";
+        default:      return "UNKNOWN";
+    }
+}
+
+// Async-signal-safe integer-to-decimal writer into a buffer.
+static int u64_to_str(char* buf, uint64_t v) {
+    if (v == 0) { buf[0] = '0'; return 1; }
+    char tmp[20]; int len = 0;
+    while (v > 0) { tmp[len++] = '0' + (v % 10); v /= 10; }
+    for (int i = 0; i < len; ++i) buf[i] = tmp[len - 1 - i];
+    return len;
+}
+
+// Write crash report from child process (no malloc restrictions here after fork).
+static void write_report_child(int sig) {
+    // Build filename: /tmp/protohud_crash_<epoch>.json
+    time_t now = time(nullptr);
+    char path[512];
+    snprintf(path, sizeof(path), "%s/protohud_crash_%lld.json",
+             g_crash_dir, static_cast<long long>(now));
+
+    FILE* f = fopen(path, "w");
+    if (!f) return;
+
+    // Capture backtrace (safe in child after fork)
+    void* bt[64];
+    int   bt_depth = backtrace(bt, 64);
+
+    // Snapshot health — no mutex needed (parent is dead/suspended)
+    bool cam_usb1 = false, cam_usb2 = false, cam_usb3 = false;
+    bool teensy   = false, lora = false, audio = false, wifi = false;
+    uint64_t uptime_s = 0;
+    float    cpu_pct  = 0.f;
+    float    ram_used = 0.f, ram_total = 0.f;
+    if (g_state) {
+        cam_usb1  = g_state->health.cam_usb1;
+        cam_usb2  = g_state->health.cam_usb2;
+        cam_usb3  = g_state->health.cam_usb3;
+        teensy    = g_state->health.teensy_ok;
+        lora      = g_state->health.lora_ok;
+        audio     = g_state->health.audio_ok;
+        wifi      = g_state->health.wifi_ok;
+        uptime_s  = g_state->sys_metrics.uptime_s;
+        cpu_pct   = g_state->sys_metrics.cpu_pct;
+        ram_used  = g_state->sys_metrics.ram_used_mb;
+        ram_total = g_state->sys_metrics.ram_total_mb;
+    }
+
+    // Write structured JSON
+    fprintf(f, "{\n");
+    fprintf(f, "  \"signal\": \"%s\",\n", sig_name(sig));
+    fprintf(f, "  \"timestamp\": %lld,\n", static_cast<long long>(now));
+    fprintf(f, "  \"git_hash\": \"%s\",\n", g_git_hash);
+    fprintf(f, "  \"uptime_s\": %llu,\n", static_cast<unsigned long long>(uptime_s));
+    fprintf(f, "  \"cpu_pct\": %.1f,\n", static_cast<double>(cpu_pct));
+    fprintf(f, "  \"ram_used_mb\": %.0f,\n", static_cast<double>(ram_used));
+    fprintf(f, "  \"ram_total_mb\": %.0f,\n", static_cast<double>(ram_total));
+    fprintf(f, "  \"health\": {\n");
+    fprintf(f, "    \"cam_usb1\": %s,\n", cam_usb1 ? "true" : "false");
+    fprintf(f, "    \"cam_usb2\": %s,\n", cam_usb2 ? "true" : "false");
+    fprintf(f, "    \"cam_usb3\": %s,\n", cam_usb3 ? "true" : "false");
+    fprintf(f, "    \"teensy\": %s,\n",   teensy   ? "true" : "false");
+    fprintf(f, "    \"lora\": %s,\n",     lora     ? "true" : "false");
+    fprintf(f, "    \"audio\": %s,\n",    audio    ? "true" : "false");
+    fprintf(f, "    \"wifi\": %s\n",      wifi     ? "true" : "false");
+    fprintf(f, "  },\n");
+    fprintf(f, "  \"backtrace\": [\n");
+    // Write symbol strings using backtrace_symbols_fd would go to a separate fd;
+    // here we use backtrace_symbols for the JSON (malloc is safe in child).
+    char** syms = backtrace_symbols(bt, bt_depth);
+    for (int i = 0; i < bt_depth; ++i) {
+        const char* s = (syms && syms[i]) ? syms[i] : "??";
+        fprintf(f, "    \"%s\"%s\n", s, (i < bt_depth - 1) ? "," : "");
+    }
+    fprintf(f, "  ]\n}\n");
+    fclose(f);
+
+    // Also dump raw addresses to stderr for addr2line
+    if (bt_depth > 0) {
+        int err_fd = open("/dev/stderr", O_WRONLY);
+        if (err_fd >= 0) {
+            const char hdr[] = "\n[CrashReporter] raw backtrace:\n";
+            write(err_fd, hdr, sizeof(hdr) - 1);
+            backtrace_symbols_fd(bt, bt_depth, err_fd);
+            close(err_fd);
+        }
+    }
+}
+
+static void crash_handler(int sig) {
+    // Restore default so re-raise terminates normally.
+    struct sigaction sa {};
+    sa.sa_handler = SIG_DFL;
+    sigaction(sig, &sa, nullptr);
+
+    pid_t pid = fork();
+    if (pid == 0) {
+        // Child: write report then exit.
+        write_report_child(sig);
+        _exit(0);
+    } else if (pid > 0) {
+        // Parent: wait for child to finish writing, then re-raise.
+        waitpid(pid, nullptr, 0);
+    }
+    raise(sig); // re-raise to get proper exit status / core dump
+}
+
+namespace CrashReporter {
+
+void install(const AppState* state,
+             const std::string& crash_dir,
+             const std::string& git_hash) {
+    g_state = state;
+    strncpy(g_crash_dir, crash_dir.c_str(), sizeof(g_crash_dir) - 1);
+    strncpy(g_git_hash,  git_hash.c_str(),  sizeof(g_git_hash)  - 1);
+
+    struct sigaction sa {};
+    sa.sa_handler = crash_handler;
+    sigemptyset(&sa.sa_mask);
+    sa.sa_flags = SA_RESETHAND; // restore default after first signal
+
+    sigaction(SIGSEGV, &sa, nullptr);
+    sigaction(SIGABRT, &sa, nullptr);
+    sigaction(SIGFPE,  &sa, nullptr);
+    sigaction(SIGILL,  &sa, nullptr);
+    sigaction(SIGBUS,  &sa, nullptr);
+}
+
+} // namespace CrashReporter

--- a/src/crash_reporter.h
+++ b/src/crash_reporter.h
@@ -1,0 +1,16 @@
+#pragma once
+#include "app_state.h"
+#include <string>
+
+// Installs SIGSEGV / SIGABRT / SIGFPE / SIGILL / SIGBUS handlers.
+// On crash: forks a child that writes a structured crash report to crash_dir,
+// then the parent calls _exit(1).
+//
+// Call install() once from main() before any other threads are started.
+// The state pointer is stored in a global so the handler can snapshot health flags.
+
+namespace CrashReporter {
+    void install(const AppState* state,
+                 const std::string& crash_dir = "/tmp",
+                 const std::string& git_hash  = "unknown");
+}

--- a/src/hud/hud_renderer.cpp
+++ b/src/hud/hud_renderer.cpp
@@ -589,13 +589,14 @@ void HudRenderer::draw_health_side(ImDrawList* dl, const SystemHealth& h,
     const Ind left_items[]  = {{"Proot",     h.teensy_ok},
                                 {"LoRa",      h.lora_ok},
                                 {"Interface", h.knob_ok},
-                                {"Audio",     h.audio_ok}};
+                                {"Audio",     h.audio_ok},
+                                {"WiFi",      h.wifi_ok}};
     const Ind right_items[] = {{lcam_lbl,    h.cam_owl_left,  false},
                                 {rcam_lbl,    h.cam_owl_right, false},
                                 {"Cam 1",     h.cam_usb1,      h.cam_usb1 && !h.cam_usb1_overlay},
                                 {"Cam 2",     h.cam_usb2,      h.cam_usb2 && !h.cam_usb2_overlay}};
     const Ind* items   = right_side ? right_items : left_items;
-    const int  n_items = 4;
+    const int  n_items = right_side ? 4 : 5;
 
     constexpr float ROW_H   = 18.f;
     constexpr float DOT_R   = 4.f;
@@ -1864,4 +1865,212 @@ void HudRenderer::fx_update(ImDrawList* dl, const AppState& s,
 
     fx_draw(dl);
     fx_draw_lines(dl);
+}
+
+// ── System status panel ───────────────────────────────────────────────────────
+
+void HudRenderer::draw_sys_panel(const AppState& snap, int w, int h, bool active) {
+    if (!active) return;
+
+    ImGui::SetCurrentContext(ctx_);
+
+    const float sw = static_cast<float>(w);
+    const float sh = static_cast<float>(h);
+
+    ImGui::SetNextWindowPos ({0.f, 0.f});
+    ImGui::SetNextWindowSize({sw,  sh });
+    ImGui::SetNextWindowBgAlpha(0.f);
+    ImGui::Begin("##sys_panel", nullptr,
+        ImGuiWindowFlags_NoDecoration          |
+        ImGuiWindowFlags_NoInputs              |
+        ImGuiWindowFlags_NoMove                |
+        ImGuiWindowFlags_NoNav                 |
+        ImGuiWindowFlags_NoBringToFrontOnFocus |
+        ImGuiWindowFlags_NoSavedSettings);
+    ImDrawList* dl = ImGui::GetWindowDrawList();
+
+    // Panel geometry — top-left, fixed size
+    constexpr float PW    = 340.f;
+    constexpr float PH    = 440.f;
+    constexpr float PAD   = 10.f;
+    constexpr float MRG   = 14.f;   // left margin from screen edge
+    const float px = MRG;
+    const float py = MRG;
+
+    // Background + border
+    dl->AddRectFilled({px, py}, {px + PW, py + PH}, col_.panel_bg, 6.f);
+    dl->AddRect      ({px, py}, {px + PW, py + PH}, col_.primary,  6.f, 0, 1.5f);
+
+    if (font_mono_) ImGui::PushFont(font_mono_);
+    const float lh = ImGui::GetTextLineHeight();
+
+    float cy = py + PAD;   // current y cursor
+
+    // Helper: draw a section header + separator
+    auto section = [&](const char* title) {
+        hud_glow_text(dl, {px + PAD, cy}, title, true, col_.primary, col_.primary);
+        cy += lh + 2.f;
+        dl->AddLine({px + PAD, cy}, {px + PW - PAD, cy}, with_alpha(col_.primary, 80), 1.f);
+        cy += 5.f;
+    };
+
+    // Sparkline helper: draws oldest→newest from circular ring buffer
+    auto sparkline = [&](const float* buf, int n, int head,
+                         ImVec2 origin, float spw, float sph,
+                         float scale_max, ImU32 col) {
+        if (scale_max <= 0.f) return;
+        const float step = spw / float(n - 1);
+        for (int i = 0; i < n - 1; ++i) {
+            const int   idx0 = (head + 1 + i)     % n;
+            const int   idx1 = (head + 1 + i + 1) % n;
+            const float v0   = std::min(buf[idx0], scale_max) / scale_max;
+            const float v1   = std::min(buf[idx1], scale_max) / scale_max;
+            dl->AddLine({origin.x + i * step,       origin.y + sph * (1.f - v0)},
+                        {origin.x + (i+1) * step,   origin.y + sph * (1.f - v1)},
+                        col, 1.5f);
+        }
+        // Frame
+        dl->AddRect({origin.x, origin.y}, {origin.x + spw, origin.y + sph},
+                    with_alpha(col, 60), 0.f, 0, 1.f);
+    };
+
+    // ── SYSTEM ────────────────────────────────────────────────────────────────
+    section("SYSTEM");
+
+    // Uptime
+    {
+        const uint64_t s = snap.sys_metrics.uptime_s;
+        const uint32_t d = static_cast<uint32_t>(s / 86400);
+        const uint32_t hh = static_cast<uint32_t>((s % 86400) / 3600);
+        const uint32_t mm = static_cast<uint32_t>((s % 3600) / 60);
+        char buf[48];
+        snprintf(buf, sizeof(buf), "Up: %ud %02uh %02um", d, hh, mm);
+        hud_glow_text(dl, {px + PAD, cy}, buf, false, col_.glow_base, col_.text_fill);
+        cy += lh + 4.f;
+    }
+
+    // CPU sparkline row
+    {
+        char buf[32];
+        snprintf(buf, sizeof(buf), "CPU  %3.0f%%", static_cast<double>(snap.sys_metrics.cpu_pct));
+        hud_glow_text(dl, {px + PAD, cy}, buf, false, col_.glow_base, col_.text_fill);
+        const float spw = PW - PAD * 2.f - 80.f;
+        sparkline(snap.sys_metrics.cpu_history, kSysHistLen, snap.sys_metrics.history_head,
+                  {px + PAD + 78.f, cy}, spw, lh,
+                  100.f, col_.accent);
+        cy += lh + 6.f;
+    }
+
+    // RAM sparkline row
+    {
+        const float used  = snap.sys_metrics.ram_used_mb;
+        const float total = snap.sys_metrics.ram_total_mb;
+        char buf[40];
+        snprintf(buf, sizeof(buf), "RAM  %.0f/%.0f", static_cast<double>(used),
+                                                      static_cast<double>(total));
+        hud_glow_text(dl, {px + PAD, cy}, buf, false, col_.glow_base, col_.text_fill);
+        const float spw = PW - PAD * 2.f - 80.f;
+        sparkline(snap.sys_metrics.ram_history, kSysHistLen, snap.sys_metrics.history_head,
+                  {px + PAD + 78.f, cy}, spw, lh,
+                  total > 0.f ? total : 4096.f, col_.warn);
+        cy += lh + 8.f;
+    }
+
+    // ── NETWORK ───────────────────────────────────────────────────────────────
+    section("NETWORK");
+
+    // Wi-Fi
+    {
+        char buf[80];
+        if (snap.wifi.connected) {
+            snprintf(buf, sizeof(buf), "WiFi: %s", snap.wifi.ssid.c_str());
+        } else {
+            snprintf(buf, sizeof(buf), "WiFi: --");
+        }
+        hud_glow_text(dl, {px + PAD, cy}, buf, snap.wifi.connected,
+                      col_.glow_base, col_.text_fill);
+        cy += lh + 2.f;
+
+        if (snap.wifi.connected) {
+            // IP + signal bars
+            const int dbm   = snap.wifi.signal_dbm;
+            const int bars  = (dbm >= -50) ? 4 : (dbm >= -65) ? 3 : (dbm >= -75) ? 2 : 1;
+            snprintf(buf, sizeof(buf), "  %s  %d dBm", snap.wifi.ip.c_str(), dbm);
+            hud_glow_text(dl, {px + PAD, cy}, buf, false, col_.glow_base, col_.text_fill);
+            // Draw signal bars (4 rectangles of increasing height)
+            const float bx = px + PW - PAD - 28.f;
+            const float by = cy + lh;
+            for (int i = 0; i < 4; ++i) {
+                const float bh2  = (i + 1) * 4.f;
+                const ImU32 bcol = (i < bars) ? col_.ind_good : with_alpha(col_.ind_inactive, 100);
+                dl->AddRectFilled({bx + i * 7.f, by - bh2}, {bx + i * 7.f + 5.f, by}, bcol);
+            }
+            cy += lh + 4.f;
+        } else {
+            cy += 4.f;
+        }
+    }
+
+    // Ping
+    {
+        char buf[80];
+        if (snap.ping.reachable) {
+            snprintf(buf, sizeof(buf), "Ping  %.0fms  %s",
+                     static_cast<double>(snap.ping.latency_ms),
+                     snap.ping.host.c_str());
+        } else {
+            snprintf(buf, sizeof(buf), "Ping  --  %s", snap.ping.host.c_str());
+        }
+        hud_glow_text(dl, {px + PAD, cy}, buf, snap.ping.reachable,
+                      col_.glow_base, col_.text_fill);
+        const float spw = PW - PAD * 2.f - 80.f;
+        // Scale: 500 ms max
+        sparkline(snap.ping.history, kPingHistLen, snap.ping.history_head,
+                  {px + PAD + 78.f, cy}, spw, lh,
+                  500.f, snap.ping.reachable ? col_.primary : with_alpha(col_.primary, 80));
+        cy += lh + 8.f;
+    }
+
+    // ── BLUETOOTH ─────────────────────────────────────────────────────────────
+    section("BLUETOOTH");
+
+    if (snap.bt_devices.empty()) {
+        hud_glow_text(dl, {px + PAD, cy}, "No devices", false, col_.glow_base, col_.text_dim);
+        cy += lh + 4.f;
+    } else {
+        constexpr int MAX_BT = 4;
+        int shown = 0;
+        for (const auto& dev : snap.bt_devices) {
+            if (shown >= MAX_BT) break;
+            const ImU32 dot_col = dev.connected ? col_.ind_good : col_.ind_inactive;
+            dl->AddCircleFilled({px + PAD + 5.f, cy + lh * 0.5f}, 4.f, dot_col);
+            char buf[64];
+            snprintf(buf, sizeof(buf), "  %s", dev.name.c_str());
+            hud_glow_text(dl, {px + PAD + 4.f, cy}, buf, dev.connected,
+                          col_.glow_base, col_.text_fill);
+            cy += lh + 2.f;
+            ++shown;
+        }
+        cy += 4.f;
+    }
+
+    // ── SSH ───────────────────────────────────────────────────────────────────
+    {
+        dl->AddLine({px + PAD, cy}, {px + PW - PAD, cy}, with_alpha(col_.primary, 80), 1.f);
+        cy += 5.f;
+        char buf[32];
+        if (snap.ssh.active) {
+            snprintf(buf, sizeof(buf), "SSH  Active :%d", snap.ssh.port);
+            dl->AddCircleFilled({px + PAD + 5.f, cy + lh * 0.5f}, 4.f, col_.ind_good);
+        } else {
+            snprintf(buf, sizeof(buf), "SSH  Inactive");
+            dl->AddCircleFilled({px + PAD + 5.f, cy + lh * 0.5f}, 4.f, col_.ind_fail);
+        }
+        hud_glow_text(dl, {px + PAD + 4.f, cy}, buf, snap.ssh.active,
+                      col_.glow_base, col_.text_fill);
+    }
+
+    if (font_mono_) ImGui::PopFont();
+
+    ImGui::End();
 }

--- a/src/hud/hud_renderer.h
+++ b/src/hud/hud_renderer.h
@@ -113,6 +113,10 @@ public:
     void draw_panel_preview(unsigned int tex, int screen_w, int screen_h,
                             float scale = 3.f);
 
+    // Draw the system status panel (CPU/RAM sparklines, Wi-Fi, ping, BT, SSH).
+    // active=false skips rendering entirely.
+    void draw_sys_panel(const AppState& snap, int w, int h, bool active);
+
     // Execute ImGui::Render → flush to current GL framebuffer.
     void render_overlay();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -178,8 +178,8 @@ static std::vector<MenuItem> build_menu(
         IFaceController* teensy, XRDisplay* xr, CameraManager* cameras,
         LoRaRadio* lora, SmartKnob* knob, AudioEngine* audio, AppState& state,
         AndroidMirror* android_mirror, bool* android_overlay,
-        OverlayConfig* pip_cfg1, OverlayConfig* pip_cfg2,
-        bool* pip_cam1_overlay, bool* pip_cam2_overlay,
+        OverlayConfig* pip_cfg1, OverlayConfig* pip_cfg2, OverlayConfig* pip_cfg3,
+        bool* pip_cam1_overlay, bool* pip_cam2_overlay, bool* pip_cam3_overlay,
         OverlayConfig* android_cfg,
         HudColors* hud_col, HudConfig* hud_cfg, MenuSystem** menu_sys_pp,
         Mpu9250* mpu9250,
@@ -768,18 +768,147 @@ static std::vector<MenuItem> build_menu(
         }),
     };
 
+    std::vector<MenuItem> cam3_overlay_menu = {
+        toggle("Show Overlay",
+            [pip_cam3_overlay]{ return *pip_cam3_overlay; },
+            [pip_cam3_overlay](bool v){ *pip_cam3_overlay = v; }),
+        submenu("Position", make_position_items(pip_cfg3)),
+        make_size_slider("Size", pip_cfg3),
+    };
+    std::vector<MenuItem> usb3_brightness_menu = {
+        leaf_sel("50%",  [cameras]{ if (cameras) cameras->set_usb3_brightness(0.5f); }, [cameras]{ return cameras && cameras->usb3_brightness() == 0.5f; }),
+        leaf_sel("100%", [cameras]{ if (cameras) cameras->set_usb3_brightness(1.0f); }, [cameras]{ return cameras && cameras->usb3_brightness() == 1.0f; }),
+        leaf_sel("150%", [cameras]{ if (cameras) cameras->set_usb3_brightness(1.5f); }, [cameras]{ return cameras && cameras->usb3_brightness() == 1.5f; }),
+        leaf_sel("200%", [cameras]{ if (cameras) cameras->set_usb3_brightness(2.0f); }, [cameras]{ return cameras && cameras->usb3_brightness() == 2.0f; }),
+        leaf_sel("300%", [cameras]{ if (cameras) cameras->set_usb3_brightness(3.0f); }, [cameras]{ return cameras && cameras->usb3_brightness() == 3.0f; }),
+    };
+    std::vector<MenuItem> usb3_exposure_menu = {
+        toggle("Auto Exposure",
+            [cameras]{ return !cameras || cameras->usb3_cfg().auto_exposure; },
+            [cameras](bool v){
+                if (!cameras) return;
+                UsbCamConfig c = cameras->usb3_cfg(); c.auto_exposure = v;
+                cameras->update_usb3_cfg(c);
+                cameras->set_usb3_ctrl(V4L2_CID_EXPOSURE_AUTO, v ? 3 : 1);
+            }),
+        slider("Exposure Time", 1.f, 5000.f, 10.f, "",
+            [cameras]{ return cameras ? (float)cameras->usb3_cfg().exposure_time : 157.f; },
+            [cameras](float v){
+                if (!cameras) return;
+                UsbCamConfig c = cameras->usb3_cfg(); c.exposure_time = (int)v;
+                cameras->update_usb3_cfg(c);
+                cameras->set_usb3_ctrl(V4L2_CID_EXPOSURE_ABSOLUTE, (int)v);
+            }),
+        toggle("Auto White Balance",
+            [cameras]{ return !cameras || cameras->usb3_cfg().auto_wb; },
+            [cameras](bool v){
+                if (!cameras) return;
+                UsbCamConfig c = cameras->usb3_cfg(); c.auto_wb = v;
+                cameras->update_usb3_cfg(c);
+                cameras->set_usb3_ctrl(V4L2_CID_AUTO_WHITE_BALANCE, v ? 1 : 0);
+            }),
+        slider("WB Temperature", 2800.f, 6500.f, 100.f, "K",
+            [cameras]{ return cameras ? (float)cameras->usb3_cfg().wb_temp : 4600.f; },
+            [cameras](float v){
+                if (!cameras) return;
+                UsbCamConfig c = cameras->usb3_cfg(); c.wb_temp = (int)v;
+                cameras->update_usb3_cfg(c);
+                cameras->set_usb3_ctrl(V4L2_CID_WHITE_BALANCE_TEMPERATURE, (int)v);
+            }),
+        toggle("Dynamic Framerate",
+            [cameras]{ return cameras && cameras->usb3_cfg().dynamic_framerate; },
+            [cameras](bool v){
+                if (!cameras) return;
+                UsbCamConfig c = cameras->usb3_cfg(); c.dynamic_framerate = v;
+                cameras->update_usb3_cfg(c);
+                cameras->set_usb3_ctrl(V4L2_CID_EXPOSURE_AUTO_PRIORITY, v ? 1 : 0);
+            }),
+    };
+    std::vector<MenuItem> usb_cam3_menu = {
+        toggle("Open Stream",
+            [cameras]{ return cameras && cameras->usb3_ok(); },
+            [cameras, pip_cam3_overlay](bool v){
+                if (!cameras) return;
+                if (v) {
+                    std::thread([cameras, pip_cam3_overlay]{
+                        cameras->open_usb3();
+                        *pip_cam3_overlay = true;
+                    }).detach();
+                } else {
+                    cameras->close_usb3();
+                    *pip_cam3_overlay = false;
+                }
+            }),
+        toggle("Flip Upside Down",
+            [cameras]{ return cameras && cameras->usb3_cfg().flip; },
+            [cameras](bool v){
+                if (!cameras) return;
+                UsbCamConfig c = cameras->usb3_cfg(); c.flip = v;
+                cameras->update_usb3_cfg(c);
+            }),
+        toggle("Auto Brightness",
+            [cameras]{ return cameras && cameras->usb3_cfg().auto_brightness; },
+            [cameras](bool v){
+                if (!cameras) return;
+                UsbCamConfig c = cameras->usb3_cfg(); c.auto_brightness = v;
+                cameras->update_usb3_cfg(c);
+            }),
+        slider("Brightness Target", 40.f, 220.f, 5.f, "",
+            [cameras]{ return cameras ? cameras->usb3_cfg().auto_brightness_target : 100.f; },
+            [cameras](float v){
+                if (!cameras) return;
+                UsbCamConfig c = cameras->usb3_cfg(); c.auto_brightness_target = v;
+                cameras->update_usb3_cfg(c);
+            }),
+        submenu("Overlay",     std::move(cam3_overlay_menu)),
+        submenu("Brightness",  std::move(usb3_brightness_menu)),
+        submenu("Exposure",    std::move(usb3_exposure_menu)),
+        leaf("Scan for Camera", [cameras, &state]{
+            if (cameras) {
+                bool ok = cameras->scan_usb3();
+                std::lock_guard<std::mutex> lk(state.mtx);
+                state.health.cam_usb3 = ok;
+            }
+        }),
+    };
+
+    // Build USB cam submenu items with visibility predicates so slots without a
+    // connected or configured camera are hidden from the menu.
+    auto make_usb_cam_item = [&](const char* label, std::vector<MenuItem> menu,
+                                  std::function<bool()> vis) -> MenuItem {
+        auto item = submenu(label, std::move(menu));
+        item.visible_fn = std::move(vis);
+        return item;
+    };
+
     std::vector<MenuItem> usb_cameras_menu = {
-        submenu("USB Cam 1",  std::move(usb_cam1_menu)),
-        submenu("USB Cam 2",  std::move(usb_cam2_menu)),
+        make_usb_cam_item("USB Cam 1", std::move(usb_cam1_menu),
+            [cameras]{ return cameras && (cameras->usb1_ok() || !cameras->usb1_cfg().device.empty()); }),
+        make_usb_cam_item("USB Cam 2", std::move(usb_cam2_menu),
+            [cameras]{ return cameras && (cameras->usb2_ok() || !cameras->usb2_cfg().device.empty()); }),
+        make_usb_cam_item("USB Cam 3", std::move(usb_cam3_menu),
+            [cameras]{ return cameras && (cameras->usb3_ok() || !cameras->usb3_cfg().device.empty()); }),
         toggle("Auto-Reconnect",
             [cameras]{ return cameras &&
                               cameras->usb1_reconnect_enabled() &&
-                              cameras->usb2_reconnect_enabled(); },
+                              cameras->usb2_reconnect_enabled() &&
+                              cameras->usb3_reconnect_enabled(); },
             [cameras](bool v){
                 if (!cameras) return;
                 cameras->set_usb1_reconnect(v);
                 cameras->set_usb2_reconnect(v);
+                cameras->set_usb3_reconnect(v);
             }),
+        leaf("Scan for Cameras", [cameras, &state]{
+            if (!cameras) return;
+            bool ok1 = cameras->scan_usb1();
+            bool ok2 = cameras->scan_usb2();
+            bool ok3 = cameras->scan_usb3();
+            std::lock_guard<std::mutex> lk(state.mtx);
+            state.health.cam_usb1 = ok1;
+            state.health.cam_usb2 = ok2;
+            state.health.cam_usb3 = ok3;
+        }),
     };
 
     std::vector<MenuItem> cameras_menu = {
@@ -1676,7 +1805,7 @@ int main(int argc, char* argv[]) {
         owl_right.fps          = jr.value("fps",      60);
     }
 
-    UsbCamConfig usb1_cfg, usb2_cfg;
+    UsbCamConfig usb1_cfg, usb2_cfg, usb3_cfg;
     if (jcam.contains("usb_cam_1")) {
         auto& j1 = jcam["usb_cam_1"];
         usb1_cfg.device             = j1.value("device",             "/dev/video2");
@@ -1708,6 +1837,22 @@ int main(int argc, char* argv[]) {
         usb2_cfg.flip                    = j2.value("flip",                    false);
         usb2_cfg.auto_brightness         = j2.value("auto_brightness",         false);
         usb2_cfg.auto_brightness_target  = j2.value("auto_brightness_target",  100.f);
+    }
+    if (jcam.contains("usb_cam_3")) {
+        auto& j3 = jcam["usb_cam_3"];
+        usb3_cfg.device             = j3.value("device",             "");
+        usb3_cfg.width              = j3.value("width",               1280);
+        usb3_cfg.height             = j3.value("height",               720);
+        usb3_cfg.fps                = j3.value("fps",                   30);
+        usb3_cfg.brightness         = j3.value("brightness",           1.0f);
+        usb3_cfg.dynamic_framerate  = j3.value("dynamic_framerate",    false);
+        usb3_cfg.auto_exposure      = j3.value("auto_exposure",        true);
+        usb3_cfg.exposure_time      = j3.value("exposure_time",        157);
+        usb3_cfg.auto_wb            = j3.value("auto_wb",              true);
+        usb3_cfg.wb_temp            = j3.value("wb_temp",              4600);
+        usb3_cfg.flip                    = j3.value("flip",                    false);
+        usb3_cfg.auto_brightness         = j3.value("auto_brightness",         false);
+        usb3_cfg.auto_brightness_target  = j3.value("auto_brightness_target",  100.f);
     }
 
     HudConfig hud_cfg;
@@ -1741,7 +1886,7 @@ int main(int argc, char* argv[]) {
     }
 
     AndroidMirrorConfig and_cfg;
-    OverlayConfig       pip_overlay_cfg1, pip_overlay_cfg2;
+    OverlayConfig       pip_overlay_cfg1, pip_overlay_cfg2, pip_overlay_cfg3;
     OverlayConfig       android_overlay_cfg;
 
     if (cfg.contains("pip")) {
@@ -1951,7 +2096,7 @@ int main(int argc, char* argv[]) {
     // ── Camera manager ────────────────────────────────────────────────────────
 
     CameraManager cameras;
-    cameras.init(owl_left, owl_right, usb1_cfg, usb2_cfg,
+    cameras.init(owl_left, owl_right, usb1_cfg, usb2_cfg, usb3_cfg,
                  res("assets/shaders/nv12.vs").c_str(),
                  res("assets/shaders/nv12.fs").c_str());
     {
@@ -1960,6 +2105,7 @@ int main(int argc, char* argv[]) {
         state.health.cam_owl_right = cameras.owl_right_ok();
         state.health.cam_usb1      = cameras.usb1_ok();
         state.health.cam_usb2      = cameras.usb2_ok();
+        state.health.cam_usb3      = cameras.usb3_ok();
     }
 
     // Startup autofocus
@@ -2036,6 +2182,7 @@ int main(int argc, char* argv[]) {
 
     bool pip_cam1_overlay_active = false;
     bool pip_cam2_overlay_active = false;
+    bool pip_cam3_overlay_active = false;
 
     std::vector<std::string> gif_names;
     if (jser.contains("teensy")) {
@@ -2053,8 +2200,8 @@ int main(int argc, char* argv[]) {
     MenuSystem* menu_ptr = nullptr;
     MenuSystem menu(build_menu(&face_proxy, &xr, &cameras, &lora, &knob, &audio, state,
                                &android_mirror, &android_overlay_active,
-                               &pip_overlay_cfg1, &pip_overlay_cfg2,
-                               &pip_cam1_overlay_active, &pip_cam2_overlay_active,
+                               &pip_overlay_cfg1, &pip_overlay_cfg2, &pip_overlay_cfg3,
+                               &pip_cam1_overlay_active, &pip_cam2_overlay_active, &pip_cam3_overlay_active,
                                &android_overlay_cfg,
                                &hud.colors(), &hud.config(), &menu_ptr,
                                &mpu9250, gif_names,
@@ -2152,6 +2299,7 @@ int main(int argc, char* argv[]) {
 
     GLuint tex_usb1  = 0;
     GLuint tex_usb2  = 0;
+    GLuint tex_usb3  = 0;
     GLuint tex_beast = 0;
 
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
@@ -2203,6 +2351,7 @@ int main(int argc, char* argv[]) {
         if (use_beast_cam) beast_cam.get_frame(tex_beast);
         cameras.get_usb1(tex_usb1);
         cameras.get_usb2(tex_usb2);
+        cameras.get_usb3(tex_usb3);
         android_mirror.get_frame(tex_android);
 
         // ── GPIO PiP button state ─────────────────────────────────────────────
@@ -2274,6 +2423,7 @@ int main(int argc, char* argv[]) {
             std::lock_guard<std::mutex> lk(state.mtx);
             state.health.cam_usb1       = cameras.usb1_ok();
             state.health.cam_usb2       = cameras.usb2_ok();
+            state.health.cam_usb3       = cameras.usb3_ok();
             state.health.android_mirror = android_mirror.is_connected();
         }
 
@@ -2327,6 +2477,7 @@ int main(int argc, char* argv[]) {
         // Overlay-active flags mirror the exact condition used in draw_pip calls.
         snap.health.cam_usb1_overlay = pip_cam1_overlay_active || pip_left_active  || kb_pip_left;
         snap.health.cam_usb2_overlay = pip_cam2_overlay_active || pip_right_active || kb_pip_right;
+        snap.health.cam_usb3_overlay = pip_cam3_overlay_active;
 
         // Inject live AF lens position into the snapshot (atomic read, no lock needed)
         if (cameras.owl_left())
@@ -2478,6 +2629,11 @@ int main(int argc, char* argv[]) {
                      pip_cam2_overlay_active || pip_right_active || kb_pip_right,
                      pip_overlay_cfg2,
                      snap.focus_right, snap.night_vision.nv_enabled);
+        hud.draw_pip(tex_usb3, "Cam 3",
+                     xr.eye_width(), xr.eye_height(),
+                     pip_cam3_overlay_active,
+                     pip_overlay_cfg3,
+                     snap.focus_left, snap.night_vision.nv_enabled);
 
         hud.draw_android_overlay(tex_android,
                                   xr.eye_width(), xr.eye_height(),
@@ -2560,6 +2716,7 @@ int main(int argc, char* argv[]) {
         jpp["motion_update_rate"] = state.pp_cfg.motion_update_rate;
         jpp["motion_color"]       = color_to_json(state.pp_cfg.motion_color);
 
+        cfg["cameras"]["usb_cam_1"]["device"]            = cameras.usb1_cfg().device;
         cfg["cameras"]["usb_cam_1"]["brightness"]        = cameras.usb1_brightness();
         cfg["cameras"]["usb_cam_1"]["dynamic_framerate"] = cameras.usb1_cfg().dynamic_framerate;
         cfg["cameras"]["usb_cam_1"]["auto_exposure"]     = cameras.usb1_cfg().auto_exposure;
@@ -2569,6 +2726,7 @@ int main(int argc, char* argv[]) {
         cfg["cameras"]["usb_cam_1"]["flip"]                   = cameras.usb1_cfg().flip;
         cfg["cameras"]["usb_cam_1"]["auto_brightness"]        = cameras.usb1_cfg().auto_brightness;
         cfg["cameras"]["usb_cam_1"]["auto_brightness_target"] = cameras.usb1_cfg().auto_brightness_target;
+        cfg["cameras"]["usb_cam_2"]["device"]            = cameras.usb2_cfg().device;
         cfg["cameras"]["usb_cam_2"]["brightness"]        = cameras.usb2_brightness();
         cfg["cameras"]["usb_cam_2"]["dynamic_framerate"] = cameras.usb2_cfg().dynamic_framerate;
         cfg["cameras"]["usb_cam_2"]["auto_exposure"]     = cameras.usb2_cfg().auto_exposure;
@@ -2578,6 +2736,16 @@ int main(int argc, char* argv[]) {
         cfg["cameras"]["usb_cam_2"]["flip"]                   = cameras.usb2_cfg().flip;
         cfg["cameras"]["usb_cam_2"]["auto_brightness"]        = cameras.usb2_cfg().auto_brightness;
         cfg["cameras"]["usb_cam_2"]["auto_brightness_target"] = cameras.usb2_cfg().auto_brightness_target;
+        cfg["cameras"]["usb_cam_3"]["device"]            = cameras.usb3_cfg().device;
+        cfg["cameras"]["usb_cam_3"]["brightness"]        = cameras.usb3_brightness();
+        cfg["cameras"]["usb_cam_3"]["dynamic_framerate"] = cameras.usb3_cfg().dynamic_framerate;
+        cfg["cameras"]["usb_cam_3"]["auto_exposure"]     = cameras.usb3_cfg().auto_exposure;
+        cfg["cameras"]["usb_cam_3"]["exposure_time"]     = cameras.usb3_cfg().exposure_time;
+        cfg["cameras"]["usb_cam_3"]["auto_wb"]           = cameras.usb3_cfg().auto_wb;
+        cfg["cameras"]["usb_cam_3"]["wb_temp"]           = cameras.usb3_cfg().wb_temp;
+        cfg["cameras"]["usb_cam_3"]["flip"]                   = cameras.usb3_cfg().flip;
+        cfg["cameras"]["usb_cam_3"]["auto_brightness"]        = cameras.usb3_cfg().auto_brightness;
+        cfg["cameras"]["usb_cam_3"]["auto_brightness_target"] = cameras.usb3_cfg().auto_brightness_target;
 
         auto& jm = cfg["menu_style"];
         jm["accent_color"]     = color_to_json(menu.accent_color());
@@ -2634,6 +2802,7 @@ int main(int argc, char* argv[]) {
 
     if (tex_usb1)    glDeleteTextures(1, &tex_usb1);
     if (tex_usb2)    glDeleteTextures(1, &tex_usb2);
+    if (tex_usb3)    glDeleteTextures(1, &tex_usb3);
     if (tex_beast)   glDeleteTextures(1, &tex_beast);
     if (tex_android) glDeleteTextures(1, &tex_android);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,6 +30,15 @@
 #include "audio/audio_engine.h"
 #include "post_process.h"
 #include "sensor/mpu9250.h"
+#include "sys/system_monitor.h"
+#include "net/wifi_monitor.h"
+#include "net/ping_monitor.h"
+#include "net/bt_monitor.h"
+#include "crash_reporter.h"
+
+#ifndef GIT_HASH
+#define GIT_HASH "unknown"
+#endif
 
 #include <fstream>
 #include <unistd.h>
@@ -184,6 +193,9 @@ static std::vector<MenuItem> build_menu(
         HudColors* hud_col, HudConfig* hud_cfg, MenuSystem** menu_sys_pp,
         Mpu9250* mpu9250,
         const std::vector<std::string>& gif_names,
+        BtMonitor* bt_mon,
+        bool* sys_panel_active,
+        AppState* state_ptr,
         // Face Source switching — pass null fp_option to hide Protoface entry
         IFaceController** active_face_pp  = nullptr,
         IFaceController*  teensy_option   = nullptr,
@@ -1676,11 +1688,40 @@ static std::vector<MenuItem> build_menu(
 
     cameras_menu.push_back(submenu("Vision Assist", std::move(vision_menu)));
 
+    // ── System / dev menu ─────────────────────────────────────────────────────
+    std::vector<MenuItem> software_menu = {
+        leaf("Check for Updates", []{
+            system("git -C /home/user/ProtoHUD fetch origin main 2>&1 | logger -t protohud &");
+        }),
+        leaf("Pull && Rebuild", []{
+            system("cd /home/user/ProtoHUD && git pull origin main && ./scripts/build.sh 2>&1 | logger -t protohud &");
+        }),
+    };
+
+    std::vector<MenuItem> system_menu = {
+        toggle("System Panel",
+            [sys_panel_active]{ return sys_panel_active && *sys_panel_active; },
+            [sys_panel_active](bool v){ if (sys_panel_active) *sys_panel_active = v; }),
+        toggle("SSH Access",
+            [state_ptr]{ return state_ptr && state_ptr->ssh.active; },
+            [state_ptr](bool v){
+                system(v ? "systemctl start ssh 2>&1 | logger -t protohud &"
+                         : "systemctl stop ssh 2>&1 | logger -t protohud &");
+                if (state_ptr) {
+                    std::lock_guard<std::mutex> lk(state_ptr->mtx);
+                    state_ptr->ssh.active = v;
+                }
+            }),
+        leaf("Refresh Bluetooth", [bt_mon]{ if (bt_mon) bt_mon->refresh(); }),
+        submenu("Software", std::move(software_menu)),
+    };
+
     return {
         submenu("Cameras",          std::move(cameras_menu)),
         submenu("Prototracer",      std::move(prototracer_menu)),
         submenu("Settings",         std::move(settings_menu)),
         submenu("Timers and Alarm", std::move(timers_alarm_menu)),
+        submenu("System",           std::move(system_menu)),
         leaf("Request Status",      [teensy]{ teensy->request_status(); }),
         leaf("Close Program",       [&state]{ state.quit = true; }),
     };
@@ -1981,6 +2022,20 @@ int main(int argc, char* argv[]) {
         }
     }
 
+    // System monitor / network config
+    std::string cfg_ping_host  = "8.8.8.8";
+    std::string cfg_wifi_iface = "wlan0";
+    std::string cfg_crash_dir  = "/tmp";
+    int         cfg_ssh_port   = 22;
+    if (cfg.contains("system")) {
+        auto& js         = cfg["system"];
+        cfg_ping_host    = js.value("ping_host",  cfg_ping_host);
+        cfg_wifi_iface   = js.value("wifi_iface", cfg_wifi_iface);
+        cfg_crash_dir    = js.value("crash_dir",  cfg_crash_dir);
+        cfg_ssh_port     = js.value("ssh_port",   cfg_ssh_port);
+    }
+    state.ssh.port = cfg_ssh_port;
+
     // Seed resolution state from whatever the OWLsight config says
     state.camera_resolution.width  = owl_left.width;
     state.camera_resolution.height = owl_left.height;
@@ -2035,6 +2090,19 @@ int main(int argc, char* argv[]) {
 
     if (!mpu9250.start() && mpu_cfg.enabled)
         std::cerr << "[main] MPU-9250 backup compass unavailable\n";
+
+    // ── Dev/debug monitors ────────────────────────────────────────────────────
+
+    SystemMonitor sys_mon;
+    WifiMonitor   wifi_mon;
+    PingMonitor   ping_mon;
+    BtMonitor     bt_mon;
+
+    sys_mon.start(&state);
+    wifi_mon.start(&state, cfg_wifi_iface);
+    ping_mon.start(&state, cfg_ping_host);
+    bt_mon.start(&state);
+    CrashReporter::install(&state, cfg_crash_dir, GIT_HASH);
 
     // ── Async Timewarp ────────────────────────────────────────────────────────
 
@@ -2183,6 +2251,7 @@ int main(int argc, char* argv[]) {
     bool pip_cam1_overlay_active = false;
     bool pip_cam2_overlay_active = false;
     bool pip_cam3_overlay_active = false;
+    bool sys_panel_active        = false;
 
     std::vector<std::string> gif_names;
     if (jser.contains("teensy")) {
@@ -2205,6 +2274,7 @@ int main(int argc, char* argv[]) {
                                &android_overlay_cfg,
                                &hud.colors(), &hud.config(), &menu_ptr,
                                &mpu9250, gif_names,
+                               &bt_mon, &sys_panel_active, &state,
                                &active_face,
                                static_cast<IFaceController*>(&teensy),
                                static_cast<IFaceController*>(&protoface_ctrl),
@@ -2649,6 +2719,9 @@ int main(int argc, char* argv[]) {
             hud.draw_panel_preview(panel_tex, xr.eye_width(), xr.eye_height());
         }
 
+        // System status panel (CPU/RAM/WiFi/ping/BT/SSH).
+        hud.draw_sys_panel(snap, xr.eye_width(), xr.eye_height(), sys_panel_active);
+
         // Alarm / timer-expired popups render on top of everything.
         hud.draw_popups(state, xr.eye_width(), xr.eye_height());
 
@@ -2789,6 +2862,10 @@ int main(int argc, char* argv[]) {
 
     // ── Cleanup ───────────────────────────────────────────────────────────────
 
+    bt_mon.stop();
+    ping_mon.stop();
+    wifi_mon.stop();
+    sys_mon.stop();
     mpu9250.stop();
     audio.stop();
     android_mirror.stop();

--- a/src/menu/menu_system.cpp
+++ b/src/menu/menu_system.cpp
@@ -102,8 +102,12 @@ void MenuSystem::pop_level() {
 }
 
 void MenuSystem::emit_detents() {
-    if (detent_cb_ && !stack_.empty())
-        detent_cb_(static_cast<int>(stack_.back().items.size()));
+    if (detent_cb_ && !stack_.empty()) {
+        int count = 0;
+        for (const auto& it : stack_.back().items)
+            if (!it.visible_fn || it.visible_fn()) ++count;
+        detent_cb_(count);
+    }
 }
 
 void MenuSystem::emit_detents_override(int count) {
@@ -147,8 +151,18 @@ void MenuSystem::navigate(int direction) {
         return;
     }
 
-    int n = static_cast<int>(stack_.back().items.size());
-    cursor_ = ((cursor_ + direction) % n + n) % n;
+    const auto& items = stack_.back().items;
+    int n = static_cast<int>(items.size());
+    if (n == 0) return;
+
+    // Advance cursor, skipping invisible items (up to n steps to avoid infinite loop).
+    int next = ((cursor_ + direction) % n + n) % n;
+    for (int tries = 0; tries < n; ++tries) {
+        const auto& it = items[next];
+        if (!it.visible_fn || it.visible_fn()) break;
+        next = ((next + direction) % n + n) % n;
+    }
+    cursor_ = next;
 }
 
 // ── select ────────────────────────────────────────────────────────────────────
@@ -304,6 +318,26 @@ void MenuSystem::draw(int screen_w, int screen_h) {
     const float pad_y  = 14.f;
     const float width  = 380.f;
 
+    // Snap cursor off any newly-hidden item before doing any rendering.
+    {
+        int n = static_cast<int>(items.size());
+        if (n > 0) {
+            const auto& cur_item = items[cursor_];
+            if (cur_item.visible_fn && !cur_item.visible_fn()) {
+                for (int tries = 0; tries < n; ++tries) {
+                    cursor_ = (cursor_ + 1) % n;
+                    const auto& t = items[cursor_];
+                    if (!t.visible_fn || t.visible_fn()) break;
+                }
+            }
+        }
+    }
+
+    // Count only visible items for layout.
+    int visible_count = 0;
+    for (const auto& it : items)
+        if (!it.visible_fn || it.visible_fn()) ++visible_count;
+
     // Extra height for expanded editing rows
     float extra = 0.f;
     if (in_edit_mode_ && cursor_ < static_cast<int>(items.size())) {
@@ -314,7 +348,7 @@ void MenuSystem::draw(int screen_w, int screen_h) {
     }
 
     const float total_h = pad_y * 2.f
-                        + item_h * static_cast<float>(items.size())
+                        + item_h * static_cast<float>(visible_count)
                         + extra;
     const float margin = 48.f;
     float x, y;
@@ -411,8 +445,10 @@ void MenuSystem::draw(int screen_w, int screen_h) {
     };
 
     for (int i = 0; i < static_cast<int>(items.size()); i++) {
-        bool selected = (i == cursor_);
         const auto& item = items[i];
+        if (item.visible_fn && !item.visible_fn()) continue;
+
+        bool selected = (i == cursor_);
 
         // Row height: expanded for the selected item in edit mode
         float row_h = item_h - 1.f;

--- a/src/menu/menu_system.h
+++ b/src/menu/menu_system.h
@@ -74,6 +74,10 @@ struct MenuItem {
 
     // COLOR_PICKER
     ColorPickerConfig color;
+
+    // Optional visibility predicate — item is hidden when this returns false.
+    // When unset, the item is always visible.
+    std::function<bool()> visible_fn;
 };
 
 // ── Menu anchor ───────────────────────────────────────────────────────────────

--- a/src/net/bt_monitor.cpp
+++ b/src/net/bt_monitor.cpp
@@ -1,0 +1,90 @@
+#include "bt_monitor.h"
+
+#include <chrono>
+#include <cstdio>
+#include <cstring>
+#include <sstream>
+#include <thread>
+
+void BtMonitor::start(AppState* state) {
+    state_   = state;
+    running_ = true;
+    thread_  = std::thread(&BtMonitor::thread_fn, this);
+}
+
+void BtMonitor::stop() {
+    running_ = false;
+    if (thread_.joinable()) thread_.join();
+}
+
+// Parse "Device XX:XX:XX:XX:XX:XX Name" lines from bluetoothctl output.
+static std::vector<BtDevice> parse_devices(FILE* fp, bool connected) {
+    std::vector<BtDevice> out;
+    char line[256];
+    while (fgets(line, sizeof(line), fp)) {
+        // Format: "Device AA:BB:CC:DD:EE:FF Some Name\n"
+        char mac[32] = {};
+        if (sscanf(line, " Device %31s", mac) != 1) continue;
+        // Name follows the MAC — find it after the MAC token
+        const char* mac_end = strstr(line, mac);
+        if (!mac_end) continue;
+        const char* name_start = mac_end + strlen(mac);
+        while (*name_start == ' ') ++name_start;
+        // Strip trailing newline
+        std::string name(name_start);
+        if (!name.empty() && name.back() == '\n') name.pop_back();
+        BtDevice d;
+        d.mac       = mac;
+        d.name      = name.empty() ? mac : name;
+        d.connected = connected;
+        out.push_back(std::move(d));
+    }
+    return out;
+}
+
+std::vector<BtDevice> BtMonitor::scan_devices() {
+    std::vector<BtDevice> all;
+
+    // Connected devices
+    FILE* fp = popen("bluetoothctl devices Connected 2>/dev/null", "r");
+    if (fp) {
+        auto connected = parse_devices(fp, true);
+        pclose(fp);
+        all.insert(all.end(), connected.begin(), connected.end());
+    }
+
+    // Paired-but-not-connected devices (de-duplicate against already-connected MACs)
+    fp = popen("bluetoothctl devices Paired 2>/dev/null", "r");
+    if (fp) {
+        auto paired = parse_devices(fp, false);
+        pclose(fp);
+        for (auto& p : paired) {
+            bool dup = false;
+            for (const auto& a : all) if (a.mac == p.mac) { dup = true; break; }
+            if (!dup) all.push_back(std::move(p));
+        }
+    }
+
+    return all;
+}
+
+void BtMonitor::thread_fn() {
+    // Poll immediately on startup, then every 10 s.
+    want_refresh_ = true;
+    int ticks = 0;
+
+    while (running_) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+        ticks++;
+
+        bool do_scan = want_refresh_.exchange(false) || (ticks >= 50); // 50×200ms = 10s
+        if (!do_scan) continue;
+        ticks = 0;
+
+        auto devices = scan_devices();
+        {
+            std::lock_guard<std::mutex> lk(state_->mtx);
+            state_->bt_devices = std::move(devices);
+        }
+    }
+}

--- a/src/net/bt_monitor.h
+++ b/src/net/bt_monitor.h
@@ -1,0 +1,28 @@
+#pragma once
+#include "../app_state.h"
+#include <atomic>
+#include <thread>
+
+// Polls paired/connected Bluetooth devices via bluetoothctl every 10 s.
+// Results are written to AppState::bt_devices under the state mutex.
+// Call refresh() to trigger an immediate rescan (e.g. from a menu action).
+
+class BtMonitor {
+public:
+    BtMonitor()  = default;
+    ~BtMonitor() { stop(); }
+
+    void start(AppState* state);
+    void stop();
+    void refresh() { want_refresh_ = true; }
+    bool is_running() const { return running_.load(); }
+
+private:
+    void thread_fn();
+    static std::vector<BtDevice> scan_devices();
+
+    AppState*          state_       = nullptr;
+    std::thread        thread_;
+    std::atomic<bool>  running_     { false };
+    std::atomic<bool>  want_refresh_{ false };
+};

--- a/src/net/ping_monitor.cpp
+++ b/src/net/ping_monitor.cpp
@@ -1,0 +1,63 @@
+#include "ping_monitor.h"
+
+#include <chrono>
+#include <cstdio>
+#include <cstring>
+#include <thread>
+
+void PingMonitor::start(AppState* state, const std::string& host) {
+    state_   = state;
+    host_    = host;
+    running_ = true;
+    // Store the configured host in state so the panel can display it.
+    {
+        std::lock_guard<std::mutex> lk(state_->mtx);
+        state_->ping.host = host;
+    }
+    thread_ = std::thread(&PingMonitor::thread_fn, this);
+}
+
+void PingMonitor::stop() {
+    running_ = false;
+    if (thread_.joinable()) thread_.join();
+}
+
+// Run one ping and return latency in ms, or -1 if unreachable/error.
+static float ping_once(const std::string& host) {
+    char cmd[256];
+    snprintf(cmd, sizeof(cmd),
+             "ping -c1 -W1 %s 2>/dev/null | grep 'time='", host.c_str());
+    FILE* fp = popen(cmd, "r");
+    if (!fp) return -1.f;
+    char buf[256] = {};
+    char* line = fgets(buf, sizeof(buf), fp);
+    pclose(fp);
+    if (!line) return -1.f;
+    // Parse "time=X.X ms" (also handles "time=X ms")
+    const char* p = strstr(buf, "time=");
+    if (!p) return -1.f;
+    float ms = 0.f;
+    if (sscanf(p, "time=%f", &ms) == 1) return ms;
+    return -1.f;
+}
+
+void PingMonitor::thread_fn() {
+    while (running_) {
+        float ms = host_.empty() ? -1.f : ping_once(host_);
+        bool  ok = ms >= 0.f;
+
+        {
+            std::lock_guard<std::mutex> lk(state_->mtx);
+            auto& p = state_->ping;
+            p.reachable  = ok;
+            p.latency_ms = ok ? ms : 0.f;
+            int h = (p.history_head + 1) % kPingHistLen;
+            p.history[h]  = ok ? ms : 0.f;
+            p.history_head = h;
+        }
+
+        // Sleep 2 s in 100 ms chunks so stop() is responsive.
+        for (int i = 0; i < 20 && running_; ++i)
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+}

--- a/src/net/ping_monitor.h
+++ b/src/net/ping_monitor.h
@@ -1,0 +1,27 @@
+#pragma once
+#include "../app_state.h"
+#include <atomic>
+#include <string>
+#include <thread>
+
+// Pings a configured host every 2 s using popen("ping -c1 -W1 ...").
+// Results are written to AppState::ping (latency_ms, reachable, history).
+
+class PingMonitor {
+public:
+    PingMonitor()  = default;
+    ~PingMonitor() { stop(); }
+
+    // host: IPv4 address or hostname to ping (e.g. "192.168.1.1")
+    void start(AppState* state, const std::string& host);
+    void stop();
+    bool is_running() const { return running_.load(); }
+
+private:
+    void thread_fn();
+
+    AppState*         state_  = nullptr;
+    std::string       host_;
+    std::thread       thread_;
+    std::atomic<bool> running_ { false };
+};

--- a/src/net/wifi_monitor.cpp
+++ b/src/net/wifi_monitor.cpp
@@ -1,0 +1,96 @@
+#include "wifi_monitor.h"
+
+#include <arpa/inet.h>
+#include <chrono>
+#include <cstdio>
+#include <cstring>
+#include <ifaddrs.h>
+#include <linux/wireless.h>
+#include <net/if.h>
+#include <netinet/in.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <thread>
+#include <unistd.h>
+
+void WifiMonitor::start(AppState* state, const std::string& iface) {
+    state_   = state;
+    iface_   = iface;
+    running_ = true;
+    thread_  = std::thread(&WifiMonitor::thread_fn, this);
+}
+
+void WifiMonitor::stop() {
+    running_ = false;
+    if (thread_.joinable()) thread_.join();
+}
+
+// Fetch SSID via ioctl SIOCGIWESSID. Returns empty string if not associated.
+static std::string get_ssid(const char* iface) {
+    int fd = socket(AF_INET, SOCK_DGRAM, 0);
+    if (fd < 0) return {};
+    char essid[IW_ESSID_MAX_SIZE + 1] = {};
+    struct iwreq req {};
+    strncpy(req.ifr_name, iface, IFNAMSIZ - 1);
+    req.u.essid.pointer = essid;
+    req.u.essid.length  = IW_ESSID_MAX_SIZE;
+    bool ok = ioctl(fd, SIOCGIWESSID, &req) >= 0 && req.u.essid.length > 0;
+    close(fd);
+    return ok ? std::string(essid, req.u.essid.length) : std::string{};
+}
+
+// Read signal level (dBm) from /proc/net/wireless for the given interface.
+static int get_signal_dbm(const char* iface) {
+    FILE* f = fopen("/proc/net/wireless", "r");
+    if (!f) return -100;
+    char line[256];
+    while (fgets(line, sizeof(line), f)) {
+        char name[32];
+        int status;
+        float link, level, noise;
+        if (sscanf(line, " %31[^:]: %d %f %f %f", name, &status, &link, &level, &noise) == 5) {
+            if (strcmp(name, iface) == 0) { fclose(f); return static_cast<int>(level); }
+        }
+    }
+    fclose(f);
+    return -100;
+}
+
+// Get IPv4 address for the interface as a dotted-decimal string.
+static std::string get_ip(const char* iface) {
+    struct ifaddrs* ifa_list = nullptr;
+    if (getifaddrs(&ifa_list) != 0) return {};
+    std::string result;
+    for (struct ifaddrs* ifa = ifa_list; ifa; ifa = ifa->ifa_next) {
+        if (!ifa->ifa_addr || ifa->ifa_addr->sa_family != AF_INET) continue;
+        if (strcmp(ifa->ifa_name, iface) != 0) continue;
+        char buf[INET_ADDRSTRLEN];
+        auto* sin = reinterpret_cast<struct sockaddr_in*>(ifa->ifa_addr);
+        if (inet_ntop(AF_INET, &sin->sin_addr, buf, sizeof(buf)))
+            result = buf;
+        break;
+    }
+    freeifaddrs(ifa_list);
+    return result;
+}
+
+void WifiMonitor::thread_fn() {
+    while (running_) {
+        std::string ssid = get_ssid(iface_.c_str());
+        bool connected   = !ssid.empty();
+        int  sig         = connected ? get_signal_dbm(iface_.c_str()) : -100;
+        std::string ip   = connected ? get_ip(iface_.c_str()) : std::string{};
+
+        {
+            std::lock_guard<std::mutex> lk(state_->mtx);
+            state_->wifi.connected  = connected;
+            state_->wifi.ssid       = ssid;
+            state_->wifi.ip         = ip;
+            state_->wifi.signal_dbm = sig;
+            state_->health.wifi_ok  = connected;
+        }
+
+        for (int i = 0; i < 50 && running_; ++i)
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+}

--- a/src/net/wifi_monitor.h
+++ b/src/net/wifi_monitor.h
@@ -1,0 +1,27 @@
+#pragma once
+#include "../app_state.h"
+#include <atomic>
+#include <string>
+#include <thread>
+
+// Polls SSID (ioctl SIOCGIWESSID), signal strength (/proc/net/wireless),
+// and IP address (getifaddrs) for a given wireless interface every 5 s.
+// Results are written to AppState::wifi and AppState::health.wifi_ok.
+
+class WifiMonitor {
+public:
+    WifiMonitor()  = default;
+    ~WifiMonitor() { stop(); }
+
+    void start(AppState* state, const std::string& iface = "wlan0");
+    void stop();
+    bool is_running() const { return running_.load(); }
+
+private:
+    void thread_fn();
+
+    AppState*         state_  = nullptr;
+    std::string       iface_;
+    std::thread       thread_;
+    std::atomic<bool> running_ { false };
+};

--- a/src/sys/system_monitor.cpp
+++ b/src/sys/system_monitor.cpp
@@ -1,0 +1,101 @@
+#include "system_monitor.h"
+
+#include <algorithm>
+#include <cerrno>
+#include <chrono>
+#include <cstdio>
+#include <cstring>
+#include <sys/sysinfo.h>
+#include <thread>
+
+void SystemMonitor::start(AppState* state) {
+    state_   = state;
+    running_ = true;
+    thread_  = std::thread(&SystemMonitor::thread_fn, this);
+}
+
+void SystemMonitor::stop() {
+    running_ = false;
+    if (thread_.joinable()) thread_.join();
+}
+
+// Read first "cpu" line of /proc/stat → (total_jiffies, idle_jiffies)
+static bool read_cpu_jiffies(uint64_t& total, uint64_t& idle) {
+    FILE* f = fopen("/proc/stat", "r");
+    if (!f) return false;
+    char label[8];
+    uint64_t user, nice, system, id, iowait, irq, softirq, steal;
+    int n = fscanf(f, "%7s %llu %llu %llu %llu %llu %llu %llu %llu",
+                   label, &user, &nice, &system, &id, &iowait, &irq, &softirq, &steal);
+    fclose(f);
+    if (n < 9) return false;
+    idle  = id + iowait;
+    total = user + nice + system + id + iowait + irq + softirq + steal;
+    return true;
+}
+
+// Parse /proc/meminfo for MemTotal and MemAvailable (kB).
+static bool read_meminfo(float& total_mb, float& used_mb) {
+    FILE* f = fopen("/proc/meminfo", "r");
+    if (!f) return false;
+    uint64_t total_kb = 0, avail_kb = 0;
+    char line[128];
+    while (fgets(line, sizeof(line), f)) {
+        uint64_t val;
+        if (sscanf(line, "MemTotal: %llu kB", &val) == 1)     total_kb = val;
+        if (sscanf(line, "MemAvailable: %llu kB", &val) == 1) avail_kb = val;
+        if (total_kb && avail_kb) break;
+    }
+    fclose(f);
+    if (!total_kb) return false;
+    total_mb = static_cast<float>(total_kb) / 1024.f;
+    used_mb  = static_cast<float>(total_kb - avail_kb) / 1024.f;
+    return true;
+}
+
+void SystemMonitor::thread_fn() {
+    // Prime the CPU delta baseline before the first report.
+    read_cpu_jiffies(prev_total_, prev_idle_);
+
+    while (running_) {
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+        if (!running_) break;
+
+        // ── Uptime ────────────────────────────────────────────────────────────
+        struct sysinfo si {};
+        uint64_t uptime_s = (sysinfo(&si) == 0) ? static_cast<uint64_t>(si.uptime) : 0;
+
+        // ── CPU % ─────────────────────────────────────────────────────────────
+        uint64_t cur_total = 0, cur_idle = 0;
+        float cpu_pct = 0.f;
+        if (read_cpu_jiffies(cur_total, cur_idle)) {
+            uint64_t dtotal = cur_total - prev_total_;
+            uint64_t didle  = cur_idle  - prev_idle_;
+            if (dtotal > 0)
+                cpu_pct = 100.f * (1.f - static_cast<float>(didle) /
+                                         static_cast<float>(dtotal));
+            cpu_pct    = std::clamp(cpu_pct, 0.f, 100.f);
+            prev_total_ = cur_total;
+            prev_idle_  = cur_idle;
+        }
+
+        // ── RAM ───────────────────────────────────────────────────────────────
+        float total_mb = 0.f, used_mb = 0.f;
+        read_meminfo(total_mb, used_mb);
+
+        // ── Write to AppState ─────────────────────────────────────────────────
+        {
+            std::lock_guard<std::mutex> lk(state_->mtx);
+            auto& m = state_->sys_metrics;
+            m.uptime_s     = uptime_s;
+            m.cpu_pct      = cpu_pct;
+            m.ram_used_mb  = used_mb;
+            m.ram_total_mb = total_mb;
+
+            int h = (m.history_head + 1) % kSysHistLen;
+            m.cpu_history[h] = cpu_pct;
+            m.ram_history[h] = (total_mb > 0.f) ? (used_mb / total_mb * 100.f) : 0.f;
+            m.history_head   = h;
+        }
+    }
+}

--- a/src/sys/system_monitor.h
+++ b/src/sys/system_monitor.h
@@ -1,0 +1,26 @@
+#pragma once
+#include "../app_state.h"
+#include <atomic>
+#include <thread>
+
+// Polls /proc/stat (CPU), /proc/meminfo (RAM), and /proc/uptime every second.
+// Results are written to AppState::sys_metrics under the state mutex.
+
+class SystemMonitor {
+public:
+    SystemMonitor()  = default;
+    ~SystemMonitor() { stop(); }
+
+    void start(AppState* state);
+    void stop();
+    bool is_running() const { return running_.load(); }
+
+private:
+    void thread_fn();
+
+    AppState*          state_    = nullptr;
+    std::thread        thread_;
+    std::atomic<bool>  running_  { false };
+    uint64_t           prev_total_ = 0;
+    uint64_t           prev_idle_  = 0;
+};


### PR DESCRIPTION
## Summary

### USB Camera Management
- **USB Cam 3**: Full third USB camera slot added throughout the stack — `CameraManager`, `AppState`, config, menu, PiP overlay, and config persistence
- **Dynamic menu visibility**: USB Cam 1/2/3 submenus hide automatically when no camera is configured; appear once a device path is assigned
- **"Scan for Cameras"** in the main USB Cameras menu — scans all three slots in one action
- **Auto-Reconnect** and device path persistence extended to all three slots

### Dev/Debug Monitoring
- **SystemMonitor** (`src/sys/`): polls `/proc/stat`, `/proc/meminfo`, `sysinfo()` every 1s → CPU%, RAM usage, uptime with 60-sample ring buffers
- **WifiMonitor** (`src/net/`): polls SSID via `ioctl SIOCGIWESSID`, signal dBm from `/proc/net/wireless`, IP via `getifaddrs` every 5s
- **PingMonitor** (`src/net/`): `ping -c1` every 2s, parses latency into a 30-sample ring buffer
- **BtMonitor** (`src/net/`): `bluetoothctl devices Connected/Paired` every 10s + `refresh()` trigger
- **CrashReporter** (`src/`): `fork()`+`sigaction` on SIGSEGV/SIGABRT/SIGFPE/SIGILL/SIGBUS; child writes structured JSON crash report with `backtrace_symbols` to `/tmp/protohud_crash_<epoch>.json`
- **System Panel** (`HudRenderer::draw_sys_panel()`): semi-transparent overlay with CPU/RAM sparklines, uptime, WiFi SSID/IP/signal bars, ping sparkline, BT device list, SSH status
- **WiFi dot** added to left health indicator arm
- **System menu**: System Panel toggle, SSH on/off toggle, Refresh Bluetooth leaf, Software submenu (Check for Updates, Pull & Rebuild)

## Test plan
- [ ] Build succeeds on target hardware
- [ ] USB Cam 3: scan assigns a third camera; Cam 3 submenu appears; overlay, brightness, flip controls work
- [ ] Dynamic visibility: empty device path → slot hidden; scan → slot appears
- [ ] System Panel: toggle from System menu → panel shows live CPU%, RAM, uptime, WiFi, ping, BT devices
- [ ] WiFi dot appears on left health arm, green when associated
- [ ] Crash reporter: `kill -SIGSEGV $(pgrep protohud)` → JSON file in `/tmp`
- [ ] SSH toggle: `systemctl start/stop ssh` fires via menu action
- [ ] BT Refresh: triggers re-scan within 1s
- [ ] `config/config.json` `"system"` section loaded on startup (ping_host, wifi_iface, crash_dir)

https://claude.ai/code/session_01Tn5VtJ7qewa7Px4uoPBQHg