### PR TITLE
Add FPS counter, frame time graph, and serial latency display

### DIFF
--- a/src/app_state.h
+++ b/src/app_state.h
@@ -202,7 +202,19 @@ struct SysMetrics {
     float    ram_total_mb = 0.f;
     float    cpu_history [kSysHistLen]  = {};
     float    ram_history [kSysHistLen]  = {};
-    int      history_head = 0;
+    int      history_head = 0;        // shared head for cpu/ram (updated by SystemMonitor)
+    // Frame-time metrics — updated by render thread each frame
+    float    frame_time_ms  = 0.f;    // last frame duration in ms
+    float    fps_avg        = 0.f;    // 1000 / frame_time_ms (instantaneous)
+    float    ft_history[kSysHistLen]  = {};
+    int      ft_history_head = 0;
+};
+
+struct SerialMetrics {
+    float  teensy_rtt_ms     = -1.f;  // round-trip time for REQ_STATUS→STATUS; -1 = no sample
+    float  knob_event_age_ms = -1.f;  // ms since last SmartKnob event; -1 = no events yet
+    int8_t lora_rssi         = 0;     // last RADIO_STATUS RSSI (dBm)
+    float  lora_snr          = 0.f;   // last RADIO_STATUS SNR (dB)
 };
 
 struct WifiState {
@@ -287,6 +299,7 @@ struct AppState {
     PingState              ping;
     SshState               ssh;
     std::vector<BtDevice>  bt_devices;
+    SerialMetrics          serial_metrics;
 
     // Cached XR display control values (no SDK getter; updated when menu writes).
     int xr_brightness     = 5;   // 1–7; mirrors last xr->set_brightness() call

--- a/src/hud/hud_renderer.cpp
+++ b/src/hud/hud_renderer.cpp
@@ -1891,7 +1891,7 @@ void HudRenderer::draw_sys_panel(const AppState& snap, int w, int h, bool active
 
     // Panel geometry — top-left, fixed size
     constexpr float PW    = 340.f;
-    constexpr float PH    = 440.f;
+    constexpr float PH    = 580.f;
     constexpr float PAD   = 10.f;
     constexpr float MRG   = 14.f;   // left margin from screen edge
     const float px = MRG;
@@ -2054,6 +2054,82 @@ void HudRenderer::draw_sys_panel(const AppState& snap, int w, int h, bool active
         cy += 4.f;
     }
 
+    // ── PERFORMANCE ───────────────────────────────────────────────────────────
+    section("PERFORMANCE");
+
+    // FPS + frame time sparkline
+    {
+        const float fps = snap.sys_metrics.fps_avg;
+        const float ft  = snap.sys_metrics.frame_time_ms;
+        char buf[48];
+        if (fps > 0.f)
+            snprintf(buf, sizeof(buf), "FPS  %4.1f", static_cast<double>(fps));
+        else
+            snprintf(buf, sizeof(buf), "FPS  --");
+        hud_glow_text(dl, {px + PAD, cy}, buf, fps > 0.f, col_.glow_base, col_.text_fill);
+        const float spw = PW - PAD * 2.f - 80.f;
+        // Sparkline: frame time in ms, capped at 50ms (20 FPS floor)
+        sparkline(snap.sys_metrics.ft_history, kSysHistLen, snap.sys_metrics.ft_history_head,
+                  {px + PAD + 78.f, cy}, spw, lh, 50.f, col_.primary);
+        cy += lh + 4.f;
+
+        if (ft > 0.f)
+            snprintf(buf, sizeof(buf), "Frame  %.1fms", static_cast<double>(ft));
+        else
+            snprintf(buf, sizeof(buf), "Frame  --");
+        hud_glow_text(dl, {px + PAD, cy}, buf, false, col_.glow_base, col_.text_dim);
+        cy += lh + 8.f;
+    }
+
+    // ── SERIAL ────────────────────────────────────────────────────────────────
+    section("SERIAL LATENCY");
+
+    // Teensy RTT
+    {
+        const float rtt = snap.serial_metrics.teensy_rtt_ms;
+        const bool ok   = snap.health.teensy_ok;
+        char buf[40];
+        if (rtt >= 0.f)
+            snprintf(buf, sizeof(buf), "  Teensy   %.0fms", static_cast<double>(rtt));
+        else
+            snprintf(buf, sizeof(buf), "  Teensy   --");
+        dl->AddCircleFilled({px + PAD + 5.f, cy + lh * 0.5f}, 4.f,
+                            ok ? col_.ind_good : col_.ind_fail);
+        hud_glow_text(dl, {px + PAD + 4.f, cy}, buf, ok, col_.glow_base, col_.text_fill);
+        cy += lh + 4.f;
+    }
+
+    // SmartKnob event age
+    {
+        const float age = snap.serial_metrics.knob_event_age_ms;
+        const bool  ok  = snap.health.knob_ok;
+        char buf[40];
+        if (age >= 0.f)
+            snprintf(buf, sizeof(buf), "  Knob   <%.0fms ago", static_cast<double>(age));
+        else
+            snprintf(buf, sizeof(buf), "  Knob   --");
+        dl->AddCircleFilled({px + PAD + 5.f, cy + lh * 0.5f}, 4.f,
+                            ok ? col_.ind_good : col_.ind_inactive);
+        hud_glow_text(dl, {px + PAD + 4.f, cy}, buf, ok, col_.glow_base, col_.text_fill);
+        cy += lh + 4.f;
+    }
+
+    // LoRa RSSI / SNR
+    {
+        const bool ok = snap.health.lora_ok;
+        char buf[48];
+        if (ok)
+            snprintf(buf, sizeof(buf), "  LoRa   %ddBm  %.1fdB",
+                     static_cast<int>(snap.serial_metrics.lora_rssi),
+                     static_cast<double>(snap.serial_metrics.lora_snr));
+        else
+            snprintf(buf, sizeof(buf), "  LoRa   --");
+        dl->AddCircleFilled({px + PAD + 5.f, cy + lh * 0.5f}, 4.f,
+                            ok ? col_.ind_good : col_.ind_inactive);
+        hud_glow_text(dl, {px + PAD + 4.f, cy}, buf, ok, col_.glow_base, col_.text_fill);
+        cy += lh + 8.f;
+    }
+
     // ── SSH ───────────────────────────────────────────────────────────────────
     {
         dl->AddLine({px + PAD, cy}, {px + PW - PAD, cy}, with_alpha(col_.primary, 80), 1.f);
@@ -2072,5 +2148,58 @@ void HudRenderer::draw_sys_panel(const AppState& snap, int w, int h, bool active
 
     if (font_mono_) ImGui::PopFont();
 
+    ImGui::End();
+}
+
+// ── FPS overlay ───────────────────────────────────────────────────────────────
+
+void HudRenderer::draw_fps_overlay(const AppState& snap, int w, int h, bool active) {
+    if (!active) return;
+    ImGui::SetCurrentContext(ctx_);
+
+    const float sw = static_cast<float>(w);
+    const float sh = static_cast<float>(h);
+
+    ImGui::SetNextWindowPos ({0.f, 0.f});
+    ImGui::SetNextWindowSize({sw, sh});
+    ImGui::SetNextWindowBgAlpha(0.f);
+    ImGui::Begin("##fps_overlay", nullptr,
+        ImGuiWindowFlags_NoDecoration          |
+        ImGuiWindowFlags_NoInputs              |
+        ImGuiWindowFlags_NoMove                |
+        ImGuiWindowFlags_NoNav                 |
+        ImGuiWindowFlags_NoBringToFrontOnFocus |
+        ImGuiWindowFlags_NoSavedSettings);
+    ImDrawList* dl = ImGui::GetWindowDrawList();
+
+    if (font_mono_) ImGui::PushFont(font_mono_);
+    const float lh  = ImGui::GetTextLineHeight();
+    const float fps = snap.sys_metrics.fps_avg;
+    const float ft  = snap.sys_metrics.frame_time_ms;
+
+    char buf[32];
+    if (fps > 0.f)
+        snprintf(buf, sizeof(buf), "%.0f FPS  %.1fms", static_cast<double>(fps),
+                                                        static_cast<double>(ft));
+    else
+        snprintf(buf, sizeof(buf), "-- FPS");
+
+    const ImU32 col    = with_alpha(col_.text_fill, 160);
+    const ImU32 bg_col = IM_COL32(6, 8, 10, 140);
+    const float margin = 8.f;
+
+    // Draw in top-right corner of each eye half
+    const float eye_w = sw * 0.5f;
+    for (int eye = 0; eye < 2; ++eye) {
+        const float off  = eye * eye_w;
+        ImVec2 ts = ImGui::CalcTextSize(buf);
+        const float bx = off + eye_w - ts.x - margin * 2.f;
+        const float by = margin;
+        dl->AddRectFilled({bx - 4.f, by - 2.f}, {bx + ts.x + 4.f, by + lh + 2.f},
+                          bg_col, 3.f);
+        dl->AddText({bx, by}, col, buf);
+    }
+
+    if (font_mono_) ImGui::PopFont();
     ImGui::End();
 }

--- a/src/hud/hud_renderer.h
+++ b/src/hud/hud_renderer.h
@@ -113,9 +113,13 @@ public:
     void draw_panel_preview(unsigned int tex, int screen_w, int screen_h,
                             float scale = 3.f);
 
-    // Draw the system status panel (CPU/RAM sparklines, Wi-Fi, ping, BT, SSH).
-    // active=false skips rendering entirely.
+    // Draw the system status panel (CPU/RAM sparklines, Wi-Fi, ping, BT, SSH,
+    // performance, and serial latency).  active=false skips rendering entirely.
     void draw_sys_panel(const AppState& snap, int w, int h, bool active);
+
+    // Draw a small FPS/frame-time counter in the top-right corner of each eye.
+    // active=false skips rendering.  Pass the full display width (eye_w * 2).
+    void draw_fps_overlay(const AppState& snap, int w, int h, bool active);
 
     // Execute ImGui::Render → flush to current GL framebuffer.
     void render_overlay();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -196,6 +196,7 @@ static std::vector<MenuItem> build_menu(
         const std::vector<std::string>& gif_names,
         BtMonitor* bt_mon,
         bool* sys_panel_active,
+        bool* fps_overlay_active,
         AppState* state_ptr,
         // Face Source switching — pass null fp_option to hide Protoface entry
         IFaceController** active_face_pp  = nullptr,
@@ -1703,6 +1704,9 @@ static std::vector<MenuItem> build_menu(
         toggle("System Panel",
             [sys_panel_active]{ return sys_panel_active && *sys_panel_active; },
             [sys_panel_active](bool v){ if (sys_panel_active) *sys_panel_active = v; }),
+        toggle("FPS Overlay",
+            [fps_overlay_active]{ return fps_overlay_active && *fps_overlay_active; },
+            [fps_overlay_active](bool v){ if (fps_overlay_active) *fps_overlay_active = v; }),
         toggle("SSH Access",
             [state_ptr]{ return state_ptr && state_ptr->ssh.active; },
             [state_ptr](bool v){
@@ -2299,6 +2303,7 @@ int main(int argc, char* argv[]) {
     bool pip_cam2_overlay_active = false;
     bool pip_cam3_overlay_active = false;
     bool sys_panel_active        = false;
+    bool fps_overlay_active      = false;
 
     std::vector<std::string> gif_names;
     if (jser.contains("teensy")) {
@@ -2321,7 +2326,7 @@ int main(int argc, char* argv[]) {
                                &android_overlay_cfg,
                                &hud.colors(), &hud.config(), &menu_ptr,
                                &mpu9250, gif_names,
-                               &bt_mon, &sys_panel_active, &state,
+                               &bt_mon, &sys_panel_active, &fps_overlay_active, &state,
                                &active_face,
                                static_cast<IFaceController*>(&teensy),
                                static_cast<IFaceController*>(&protoface_ctrl),
@@ -2582,9 +2587,24 @@ int main(int argc, char* argv[]) {
         }
 
         // ── State snapshot ────────────────────────────────────────────────────
+        // Also update render-thread metrics (frame time, knob event age) here
+        // so they're included in the snapshot under a single lock acquisition.
         AppState snap;
         {
             std::lock_guard<std::mutex> lk(state.mtx);
+
+            // Frame time / FPS into SysMetrics
+            {
+                auto& m = state.sys_metrics;
+                m.frame_time_ms = dt * 1000.f;
+                m.fps_avg       = dt > 0.f ? 1.f / dt : 0.f;
+                const int h2    = (m.ft_history_head + 1) % kSysHistLen;
+                m.ft_history[h2]   = m.frame_time_ms;
+                m.ft_history_head  = h2;
+            }
+            // Knob event age (computed on render thread, written here)
+            state.serial_metrics.knob_event_age_ms = knob.event_age_ms();
+
             snap.face            = state.face;
             snap.health          = state.health;
             snap.knob            = state.knob;
@@ -2601,6 +2621,13 @@ int main(int argc, char* argv[]) {
             snap.pp_cfg             = state.pp_cfg;
             snap.timer_alarm        = state.timer_alarm;
             snap.effects_cfg        = state.effects_cfg;
+            snap.sys_metrics        = state.sys_metrics;
+            snap.wifi               = state.wifi;
+            snap.ping               = state.ping;
+            snap.ssh                = state.ssh;
+            snap.bt_devices         = state.bt_devices;
+            snap.serial_metrics     = state.serial_metrics;
+            snap.camera_resolution  = state.camera_resolution;
             memcpy(snap.lora_node_colors, state.lora_node_colors,
                    sizeof(state.lora_node_colors));
         }
@@ -2779,8 +2806,11 @@ int main(int argc, char* argv[]) {
             hud.draw_panel_preview(panel_tex, xr.eye_width(), xr.eye_height());
         }
 
-        // System status panel (CPU/RAM/WiFi/ping/BT/SSH).
+        // System status panel (CPU/RAM/WiFi/ping/BT/SSH/perf/serial).
         hud.draw_sys_panel(snap, xr.eye_width(), xr.eye_height(), sys_panel_active);
+
+        // FPS / frame-time corner overlay (drawn in both eye halves).
+        hud.draw_fps_overlay(snap, xr.eye_width() * 2, xr.eye_height(), fps_overlay_active);
 
         // Alarm / timer-expired popups render on top of everything.
         hud.draw_popups(state, xr.eye_width(), xr.eye_height());

--- a/src/serial/lora_radio.cpp
+++ b/src/serial/lora_radio.cpp
@@ -155,10 +155,12 @@ void LoRaRadio::on_frame(uint8_t cmd, const uint8_t* payload, uint8_t len) {
     // ── RADIO_STATUS ──────────────────────────────────────────────────────────
     case LoRaCmd::RADIO_STATUS: {
         if (len < 2) break;
-        // Currently just marks the radio as alive; could surface RSSI/SNR
-        // to a dedicated AppState field if needed.
+        const int8_t rssi = static_cast<int8_t>(payload[0]);
+        const float  snr  = static_cast<float>(static_cast<int8_t>(payload[1]));
         std::lock_guard<std::mutex> lk(state_.mtx);
-        state_.health.lora_ok = true;
+        state_.health.lora_ok           = true;
+        state_.serial_metrics.lora_rssi = rssi;
+        state_.serial_metrics.lora_snr  = snr;
         break;
     }
 

--- a/src/serial/smartknob.cpp
+++ b/src/serial/smartknob.cpp
@@ -1,5 +1,6 @@
 #include "smartknob.h"
 #include "../protocols.h"
+#include <chrono>
 #include <cstring>
 #include <vector>
 
@@ -65,7 +66,23 @@ void SmartKnob::set_haptic(uint8_t amplitude, uint8_t frequency, uint8_t detent_
     port_.send(KnobCmd::SET_HAPTIC, buf, 3);
 }
 
+float SmartKnob::event_age_ms() const {
+    int64_t t = last_event_us_.load();
+    if (t <= 0) return -1.f;
+    using namespace std::chrono;
+    int64_t now_us = duration_cast<microseconds>(
+        steady_clock::now().time_since_epoch()).count();
+    return static_cast<float>(now_us - t) / 1000.f;
+}
+
 void SmartKnob::on_frame(uint8_t cmd, const uint8_t* payload, uint8_t len) {
+    // Stamp every received frame so event_age_ms() stays current
+    {
+        using namespace std::chrono;
+        last_event_us_.store(duration_cast<microseconds>(
+            steady_clock::now().time_since_epoch()).count());
+    }
+
     if (cmd == KnobCmd::POSITION_UPDATE && len >= sizeof(KnobPositionPayload)) {
         KnobPositionPayload p {};
         std::memcpy(&p, payload, sizeof(p));

--- a/src/serial/smartknob.h
+++ b/src/serial/smartknob.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "serial_port.h"
 #include "../app_state.h"
+#include <atomic>
 #include <functional>
 #include <string>
 #include <vector>
@@ -30,12 +31,16 @@ public:
     void on_wake(KnobWakeCallback cb)   { wake_cb_   = std::move(cb); }
     void on_status(KnobStatusCallback cb) { status_cb_ = std::move(cb); }
 
+    // Returns ms since the last event from the knob, or -1 if no events yet.
+    float event_age_ms() const;
+
 private:
     void on_frame(uint8_t cmd, const uint8_t* payload, uint8_t len);
 
-    SerialPort      port_;
-    AppState&       state_;
-    KnobMoveCallback move_cb_;
-    KnobWakeCallback wake_cb_;
+    SerialPort         port_;
+    AppState&          state_;
+    KnobMoveCallback   move_cb_;
+    KnobWakeCallback   wake_cb_;
     KnobStatusCallback status_cb_;
+    std::atomic<int64_t> last_event_us_ { 0 };  // steady_clock µs of last received frame
 };

--- a/src/serial/teensy_controller.cpp
+++ b/src/serial/teensy_controller.cpp
@@ -79,6 +79,9 @@ void TeensyController::set_menu_item(uint8_t menu_index, uint8_t value) {
 }
 
 void TeensyController::request_status() {
+    using namespace std::chrono;
+    last_req_us_.store(
+        duration_cast<microseconds>(steady_clock::now().time_since_epoch()).count());
     port_.send(TeensyCmd::REQ_STATUS);
 }
 
@@ -93,7 +96,18 @@ void TeensyController::on_frame(uint8_t cmd, const uint8_t* payload, uint8_t len
         TeensyStatusPayload s {};
         std::memcpy(&s, payload, sizeof(s));
 
+        // Compute round-trip time from last REQ_STATUS
+        int64_t req = last_req_us_.exchange(0);
+        float rtt = -1.f;
+        if (req > 0) {
+            using namespace std::chrono;
+            int64_t now_us = duration_cast<microseconds>(
+                steady_clock::now().time_since_epoch()).count();
+            rtt = static_cast<float>(now_us - req) / 1000.f;
+        }
+
         std::lock_guard<std::mutex> lk(state_.mtx);
+        if (rtt >= 0.f) state_.serial_metrics.teensy_rtt_ms = rtt;
         state_.face.effect_id    = s.effect_id;
         state_.face.gif_id       = s.gif_id;
         state_.face.r            = s.r;

--- a/src/serial/teensy_controller.h
+++ b/src/serial/teensy_controller.h
@@ -34,4 +34,5 @@ private:
     AppState&            state_;
     std::thread          poll_thread_;
     std::atomic<bool>    poll_running_ { false };
+    std::atomic<int64_t> last_req_us_  { 0 };  // steady_clock µs when last REQ_STATUS sent
 };


### PR DESCRIPTION
## Summary

- **FPS counter overlay** — compact `"89.7 FPS  11.2ms"` pill in the top-right corner of each eye half, toggleable via **System → FPS Overlay**
- **Frame time graph** — `ft_history[60]` ring buffer updated each render frame; shown as a sparkline in the sys panel's new **PERFORMANCE** section alongside current FPS and frame time in ms
- **Serial latency display** — new **SERIAL LATENCY** section in the sys panel:
  - **Teensy RTT**: `request_status()` now stamps a µs timestamp; `on_frame(STATUS)` computes the round-trip delta
  - **SmartKnob event age**: every received frame stamps `last_event_us_`; `event_age_ms()` computes freshness on demand each render frame
  - **LoRa RSSI/SNR**: `RADIO_STATUS` handler was a stub — now parses the `rssi(int8) snr(int8)` payload and stores it in `serial_metrics`

**Also fixes a pre-existing bug**: `sys_metrics`, `wifi`, `ping`, `ssh`, `bt_devices` were never copied into the per-frame snapshot — the sys panel was drawing all zeros. All fields are now included in the snapshot under the single existing mutex acquisition.

## Test plan

- [ ] System → FPS Overlay toggle: pill appears in top-right of both eye halves showing live FPS and frame ms
- [ ] System Panel → PERFORMANCE section shows sparkline that varies with frame load
- [ ] System Panel → SERIAL LATENCY shows Teensy RTT ~10–50ms once connected
- [ ] System Panel → SERIAL LATENCY shows Knob event age climbing when knob is idle, resetting on turn
- [ ] LoRa RSSI/SNR updates after `request_status()` (or any RADIO_STATUS frame from radio)
- [ ] System Panel CPU/RAM/WiFi/Ping data now shows actual values (not zeros)

https://claude.ai/code/session_01Tn5VtJ7qewa7Px4uoPBQHg

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tn5VtJ7qewa7Px4uoPBQHg)_