### PR TITLE
Fix wifi_monitor.cpp IFF_* redefinition build error

### DIFF
--- a/src/net/wifi_monitor.cpp
+++ b/src/net/wifi_monitor.cpp
@@ -1,15 +1,15 @@
 #include "wifi_monitor.h"
 
+#include <sys/socket.h>
+#include <sys/ioctl.h>
+#include <net/if.h>
+#include <netinet/in.h>
 #include <arpa/inet.h>
+#include <ifaddrs.h>
+#include <linux/wireless.h>
 #include <chrono>
 #include <cstdio>
 #include <cstring>
-#include <ifaddrs.h>
-#include <linux/wireless.h>
-#include <net/if.h>
-#include <netinet/in.h>
-#include <sys/ioctl.h>
-#include <sys/socket.h>
 #include <thread>
 #include <unistd.h>
 


### PR DESCRIPTION
## Summary

- Reorder system headers in `src/net/wifi_monitor.cpp` so all POSIX headers (`<sys/socket.h>`, `<sys/ioctl.h>`, `<net/if.h>`, `<netinet/in.h>`, `<arpa/inet.h>`, `<ifaddrs.h>`) are included **before** `<linux/wireless.h>`

## Root Cause

`<linux/wireless.h>` transitively pulls in `<linux/if.h>`, which defines `IFF_UP`, `IFF_BROADCAST`, etc. as members of the `net_device_flags` kernel enum. If `<net/if.h>` (POSIX) is included afterwards, it tries to declare the same names as a different enum, producing 17+ `conflicts with a previous declaration` errors. Including POSIX headers first causes `<linux/if.h>`'s `__UAPI_DEF_*` guards to fire, preventing the conflicting redefinitions.

## Test plan

- [ ] `ninja -C build` completes with no errors on Pi (previously failed at `wifi_monitor.cpp.o`)

https://claude.ai/code/session_01Tn5VtJ7qewa7Px4uoPBQHg

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tn5VtJ7qewa7Px4uoPBQHg)_