### PR TITLE
Fix IFF_* redefinition build error in wifi_monitor.cpp

### DIFF
--- a/src/net/wifi_monitor.cpp
+++ b/src/net/wifi_monitor.cpp
@@ -1,15 +1,15 @@
 #include "wifi_monitor.h"
 
+#include <sys/socket.h>
+#include <sys/ioctl.h>
+#include <net/if.h>
+#include <netinet/in.h>
 #include <arpa/inet.h>
+#include <ifaddrs.h>
+#include <linux/wireless.h>
 #include <chrono>
 #include <cstdio>
 #include <cstring>
-#include <ifaddrs.h>
-#include <linux/wireless.h>
-#include <net/if.h>
-#include <netinet/in.h>
-#include <sys/ioctl.h>
-#include <sys/socket.h>
 #include <thread>
 #include <unistd.h>
 


### PR DESCRIPTION
POSIX headers (<net/if.h>, <sys/socket.h>, etc.) must be included before <linux/wireless.h> so the kernel UAPI guards recognise that net_device_flags is already defined and skip the conflicting redefinition.

https://claude.ai/code/session_01Tn5VtJ7qewa7Px4uoPBQHg