### PR TITLE
Fix NanoVG CMake linker language error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,12 +77,17 @@ pkg_check_modules(ALSA REQUIRED alsa)
 include(FetchContent)
 
 # ── NanoVG (vector graphics renderer for the HUD layer) ──────────────────────
+# nanovg has no CMakeLists.txt — use Populate (not MakeAvailable) so that
+# nanovg_SOURCE_DIR is guaranteed to be set before the add_library call.
 FetchContent_Declare(nanovg
     GIT_REPOSITORY https://github.com/memononen/nanovg.git
     GIT_TAG        master
     GIT_SHALLOW    TRUE
 )
-FetchContent_MakeAvailable(nanovg)
+FetchContent_GetProperties(nanovg)
+if(NOT nanovg_POPULATED)
+    FetchContent_Populate(nanovg)
+endif()
 
 add_library(nanovg STATIC ${nanovg_SOURCE_DIR}/src/nanovg.c)
 target_include_directories(nanovg PUBLIC ${nanovg_SOURCE_DIR}/src ${GLES_INCLUDE_DIRS})


### PR DESCRIPTION
## Summary

Fixes `CMake can not determine linker language for target: nanovg`.

`FetchContent_MakeAvailable` is designed for repos that have a `CMakeLists.txt` — it calls `add_subdirectory` on them. For repos without one (like nanovg), it can fail to propagate `nanovg_SOURCE_DIR` into the calling scope, so the `add_library` source list comes up empty, triggering the linker-language error.

Fix: replace with the explicit `FetchContent_GetProperties` + `FetchContent_Populate` pattern, which guarantees `nanovg_SOURCE_DIR` is set before the `add_library(nanovg STATIC …)` call.

## Test plan

- [ ] `cmake -B build` completes without the linker language error
- [ ] `cmake --build build` compiles nanovg.c successfully

https://claude.ai/code/session_017xAaFHoiBHVqGLxVhohcAh

---
_Generated by [Claude Code](https://claude.ai/code/session_017xAaFHoiBHVqGLxVhohcAh)_