### PR TITLE
Fix NanoVG CMake: pin SOURCE_DIR to eliminate variable scope dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,20 +77,19 @@ pkg_check_modules(ALSA REQUIRED alsa)
 include(FetchContent)
 
 # ── NanoVG (vector graphics renderer for the HUD layer) ──────────────────────
-# nanovg has no CMakeLists.txt — use Populate (not MakeAvailable) so that
-# nanovg_SOURCE_DIR is guaranteed to be set before the add_library call.
+# nanovg has no CMakeLists.txt. Pin SOURCE_DIR explicitly so the path used in
+# add_library is always correct regardless of FetchContent variable scope.
+set(_nanovg_src "${CMAKE_BINARY_DIR}/_deps/nanovg-src")
 FetchContent_Declare(nanovg
     GIT_REPOSITORY https://github.com/memononen/nanovg.git
     GIT_TAG        master
     GIT_SHALLOW    TRUE
+    SOURCE_DIR     "${_nanovg_src}"
 )
-FetchContent_GetProperties(nanovg)
-if(NOT nanovg_POPULATED)
-    FetchContent_Populate(nanovg)
-endif()
+FetchContent_MakeAvailable(nanovg)
 
-add_library(nanovg STATIC ${nanovg_SOURCE_DIR}/src/nanovg.c)
-target_include_directories(nanovg PUBLIC ${nanovg_SOURCE_DIR}/src ${GLES_INCLUDE_DIRS})
+add_library(nanovg STATIC "${_nanovg_src}/src/nanovg.c")
+target_include_directories(nanovg PUBLIC "${_nanovg_src}/src" ${GLES_INCLUDE_DIRS})
 target_link_libraries(nanovg PUBLIC ${GLES_LIBRARIES})
 
 FetchContent_Declare(imgui


### PR DESCRIPTION
## Summary

Persistent `CMake can not determine linker language for target: nanovg` after the previous fix (#91) was caused by FetchContent's `nanovg_SOURCE_DIR` variable being unreliable when CMake regenerates against a stale build directory (one that pre-dates the nanovg addition). The stored FetchContent state could mark nanovg as "populated" with an empty source dir.

Fix: set `_nanovg_src` to the known pinned path (`${CMAKE_BINARY_DIR}/_deps/nanovg-src`) and pass it as `SOURCE_DIR` in `FetchContent_Declare`. Both the fetch and the `add_library` use the same variable — no FetchContent variable propagation involved.

## Recovery for existing stale builds

If you already have a build directory from before nanovg was added, clear it first:
```
rm -rf build
cmake -B build
ninja -C build
```

## Test plan

- [ ] Fresh `cmake -B build && ninja -C build` succeeds
- [ ] Re-running `ninja -C build` (regeneration) also succeeds

https://claude.ai/code/session_017xAaFHoiBHVqGLxVhohcAh

---
_Generated by [Claude Code](https://claude.ai/code/session_017xAaFHoiBHVqGLxVhohcAh)_