### PR TITLE
Fix compile errors: missing app_state.h include and NANOVG_GLES2 define

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,7 @@ FetchContent_MakeAvailable(nanovg)
 
 add_library(nanovg STATIC "${_nanovg_src}/src/nanovg.c")
 target_include_directories(nanovg PUBLIC "${_nanovg_src}/src" ${GLES_INCLUDE_DIRS})
+target_compile_definitions(nanovg PUBLIC NANOVG_GLES2)
 target_link_libraries(nanovg PUBLIC ${GLES_LIBRARIES})
 
 FetchContent_Declare(imgui

--- a/src/menu/menu_system.h
+++ b/src/menu/menu_system.h
@@ -6,6 +6,7 @@
 #include <tuple>
 #include <cstdint>
 #include <imgui.h>
+#include "../app_state.h"
 
 // ── Item types ────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Two compile errors from the NanoVG migration:

**1. `menu_system.h` missing `#include "../app_state.h"`**

`NotificationQueue` and `NotifType` were added to `app_state.h` as part of the toast notification system, but `menu_system.h` (which uses `NotificationQueue*` in `NotifLogConfig`) never got the include. Results in `'NotificationQueue' does not name a type` errors throughout `menu_system.cpp`.

**2. `NANOVG_GLES2` not defined for files that include `nanovg_gl.h`**

`nanovg_gl.h` gates the `nvgCreateGLES2`/`nvgDeleteGLES2` declarations behind `#ifdef NANOVG_GLES2`. Only `nanovg_gl_impl.cpp` defined `NANOVG_GLES2_IMPLEMENTATION` (which internally sets `NANOVG_GLES2`), but `hud_renderer.cpp` includes the header without that define. Fix: add `NANOVG_GLES2` as a `PUBLIC` compile definition on the `nanovg` CMake target so it propagates to all consumers.

## Test plan

- [ ] `cmake -B build -G Ninja && ninja -C build` — both `menu_system.cpp` and `hud_renderer.cpp` compile without errors

https://claude.ai/code/session_017xAaFHoiBHVqGLxVhohcAh

---
_Generated by [Claude Code](https://claude.ai/code/session_017xAaFHoiBHVqGLxVhohcAh)_