### PR TITLE
Fix GLES2 headers missing before nanovg_gl.h

### DIFF
--- a/src/hud/hud_renderer.cpp
+++ b/src/hud/hud_renderer.cpp
@@ -5,8 +5,8 @@
 #include <imgui_impl_glfw.h>
 #include <imgui_impl_opengl3.h>
 #include <GLFW/glfw3.h>
-#include <nanovg_gl.h>
 #include <GLES2/gl2.h>
+#include <nanovg_gl.h>
 
 #include <cmath>
 #include <ctime>

--- a/src/nanovg_gl_impl.cpp
+++ b/src/nanovg_gl_impl.cpp
@@ -1,3 +1,4 @@
 // Compile the NanoVG GLES2 backend into the protohud binary.
+#include <GLES2/gl2.h>
 #define NANOVG_GLES2_IMPLEMENTATION
 #include <nanovg_gl.h>


### PR DESCRIPTION
## Summary

`nanovg_gl.h` relies on GL types (`GLuint`, `GLenum`, `GLint`, etc.) and function declarations already being in scope — it does not include any GL headers itself. Two files had the include order wrong:

- **`src/nanovg_gl_impl.cpp`**: no GLES2 include at all before `nanovg_gl.h`
- **`src/hud/hud_renderer.cpp`**: had `<GLES2/gl2.h>` after `<nanovg_gl.h>`

Both files now include `<GLES2/gl2.h>` before `<nanovg_gl.h>`.

## Test plan

- [ ] `ninja -C build` — `nanovg_gl_impl.cpp` and `hud_renderer.cpp` compile without GL undeclared-identifier errors

https://claude.ai/code/session_017xAaFHoiBHVqGLxVhohcAh

---
_Generated by [Claude Code](https://claude.ai/code/session_017xAaFHoiBHVqGLxVhohcAh)_