### PR TITLE
Fix include order in nanovg_gl_impl.cpp: nanovg.h before nanovg_gl.h

### DIFF
--- a/src/nanovg_gl_impl.cpp
+++ b/src/nanovg_gl_impl.cpp
@@ -1,4 +1,7 @@
 // Compile the NanoVG GLES2 backend into the protohud binary.
+// Include order matters: nanovg.h defines NVGcontext (used in nanovg_gl.h's
+// public declarations), GLES2/gl2.h provides GL types for the implementation.
+#include <nanovg.h>
 #include <GLES2/gl2.h>
 #define NANOVG_GLES2_IMPLEMENTATION
 #include <nanovg_gl.h>


### PR DESCRIPTION
## Summary

`nanovg_gl.h` declares `NVGcontext*` in its public API section (lines 79–83, outside the `#ifdef NANOVG_GLES2_IMPLEMENTATION` block), but only `#include "nanovg.h"` inside that block. So when `nanovg_gl_impl.cpp` processes the header, `NVGcontext` is not yet declared at line 79.

Fix: add `#include <nanovg.h>` before `#include <nanovg_gl.h>` in `nanovg_gl_impl.cpp`.

`hud_renderer.cpp` is fine — it includes `hud_renderer.h` first, which already includes `nanovg.h`.

## Test plan

- [ ] `ninja -C build` — `nanovg_gl_impl.cpp` compiles without `NVGcontext` undeclared errors

https://claude.ai/code/session_017xAaFHoiBHVqGLxVhohcAh

---
_Generated by [Claude Code](https://claude.ai/code/session_017xAaFHoiBHVqGLxVhohcAh)_