### PR TITLE
Fix stbi_* duplicate symbol linker error via STB_IMAGE_STATIC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,9 @@ FetchContent_MakeAvailable(nanovg)
 add_library(nanovg STATIC "${_nanovg_src}/src/nanovg.c")
 target_include_directories(nanovg PUBLIC "${_nanovg_src}/src" ${GLES_INCLUDE_DIRS})
 target_compile_definitions(nanovg PUBLIC NANOVG_GLES2)
+# nanovg.c embeds stb_image.h with STB_IMAGE_IMPLEMENTATION; STB_IMAGE_STATIC
+# makes those symbols file-local so they don't collide with splash.cpp's copy.
+target_compile_definitions(nanovg PRIVATE STB_IMAGE_STATIC)
 target_link_libraries(nanovg PUBLIC ${GLES_LIBRARIES})
 
 FetchContent_Declare(imgui


### PR DESCRIPTION
## Summary

Compile errors are resolved — this is the first linker error.

`nanovg.c` embeds `stb_image.h` with `STB_IMAGE_IMPLEMENTATION`, defining `stbi_load`, `stbi_failure_reason`, and ~30 other symbols. `splash.cpp` also defines these via its own stb usage. The linker sees duplicate definitions.

Fix: add `STB_IMAGE_STATIC` as a `PRIVATE` compile definition on the `nanovg` target. This wraps all stb functions in `nanovg.c` with `static`, giving them internal linkage and eliminating the conflict.

## Test plan

- [ ] `cmake -B build -G Ninja && ninja -C build` — links successfully, no duplicate `stbi_*` errors

https://claude.ai/code/session_017xAaFHoiBHVqGLxVhohcAh

---
_Generated by [Claude Code](https://claude.ai/code/session_017xAaFHoiBHVqGLxVhohcAh)_