### PR TITLE
Fix NanoVG HUD only rendering on right eye

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2791,8 +2791,10 @@ int main(int argc, char* argv[]) {
         }
 
         // ── Phase 1: NanoVG HUD chrome (compass, arms, particles) ───────────
-        // Drawn first so ImGui overlays composite on top.
-        hud.draw_hud_frame(snap, xr.eye_width(), xr.eye_height(), fps_overlay_active);
+        // Reset viewport to full framebuffer — timewarp leaves it at right-eye half.
+        // Pass full display dimensions so NanoVG covers both eye halves.
+        glViewport(0, 0, xr.display_width(), xr.display_height());
+        hud.draw_hud_frame(snap, xr.display_width(), xr.display_height(), fps_overlay_active);
 
         // ── Phase 2: ImGui overlays (pip, menu, popups) ───────────────────
         menu.set_glow_enabled(hud.config().glow_enabled);


### PR DESCRIPTION
## Summary

The NanoVG HUD was only visible in the right eye. The timewarp pass sets `glViewport(half_w, 0, half_w, dh)` for the right eye and doesn't restore it. NanoVG's `nvgBeginFrame` does not call `glViewport` — it just stores the dimensions for shader uniforms — so it inherited the right-eye-only viewport.

Two fixes in `main.cpp`:
1. `glViewport(0, 0, display_width, display_height)` before `draw_hud_frame` to restore the full framebuffer viewport
2. Pass `display_width`/`display_height` (full SBS framebuffer) instead of `eye_width`/`eye_height` so NanoVG's coordinate system covers both eye halves

## Test plan

- [ ] HUD chrome (compass, arms, clock) visible in both left and right eye
- [ ] Menu and PiP overlays (ImGui, unchanged) still correct

https://claude.ai/code/session_017xAaFHoiBHVqGLxVhohcAh

---
_Generated by [Claude Code](https://claude.ai/code/session_017xAaFHoiBHVqGLxVhohcAh)_