### PR TITLE
Add Demo Mode menu + wire ToastRenderer into render loop

### DIFF
--- a/src/hud/hud_renderer.cpp
+++ b/src/hud/hud_renderer.cpp
@@ -314,6 +314,18 @@ void HudRenderer::draw_hud_frame(const AppState& s, int w, int h, bool show_fps)
     glStencilMask(0xFF);
 }
 
+void HudRenderer::draw_toasts(NotificationQueue& live_q, int w, int h) {
+    if (!nvg_) return;
+    const float fw = static_cast<float>(w);
+    const float fh = static_cast<float>(h);
+    nvgBeginFrame(nvg_, fw, fh, 1.0f);
+    toast_renderer_.draw(nvg_, live_q, fw, fh, frame_dt_, nvg_font_ui_, nvg_font_mono_);
+    nvgEndFrame(nvg_);
+    glDisable(GL_STENCIL_TEST);
+    glDisable(GL_CULL_FACE);
+    glStencilMask(0xFF);
+}
+
 void HudRenderer::draw_fps_overlay(const AppState& snap, int w, int h, bool active) {
     if (!active || fps_shown_in_hud_ || !nvg_) return;
     const float fw = static_cast<float>(w);

--- a/src/hud/hud_renderer.h
+++ b/src/hud/hud_renderer.h
@@ -15,6 +15,7 @@
 //   hud.render_menu_overlay();                 // ImGui::Render + RenderDrawData
 
 #include "../app_state.h"
+#include "toast_renderer.h"
 #include <imgui.h>
 #include <nanovg.h>
 #include <string>
@@ -94,6 +95,12 @@ public:
     // NanoVG FPS counter pass — small independent NVG frame for the fps text.
     // If draw_hud_frame was called with show_fps=true this is a no-op safe to skip.
     void draw_fps_overlay(const AppState& snap, int w, int h, bool active);
+
+    // NanoVG toast pass — separate NVG frame; takes live queue for dismiss mutations.
+    void draw_toasts(NotificationQueue& live_q, int w, int h);
+    bool toast_has_focused() const { return toast_renderer_.has_focused_toast(); }
+    void toast_navigate(int delta)  { toast_renderer_.navigate(delta); }
+    void toast_select(AppState& s)  { toast_renderer_.select(s); }
 
     // Start an ImGui frame for menu + debug overlays.
     void begin_menu_frame();
@@ -205,6 +212,8 @@ private:
 
     void  fx_update(NVGcontext* vg, const AppState& s,
                     float fw, float fh, float dt);
+
+    ToastRenderer toast_renderer_;
 
     HudConfig     cfg_;
     HudColors     col_;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1691,6 +1691,65 @@ static std::vector<MenuItem> build_menu(
     cameras_menu.push_back(submenu("Vision Assist", std::move(vision_menu)));
 
     // ── System / dev menu ─────────────────────────────────────────────────────
+
+    // Helper: push a notification to the live queue (thread-safe).
+    auto push_notif = [state_ptr](NotifType type, std::string title, std::string body,
+                                   float auto_dismiss_s,
+                                   std::vector<NotifAction> actions = {}) {
+        if (!state_ptr) return;
+        Notification n;
+        n.type           = type;
+        n.title          = std::move(title);
+        n.body           = std::move(body);
+        n.timestamp      = std::chrono::duration_cast<std::chrono::milliseconds>(
+                               std::chrono::system_clock::now().time_since_epoch()).count();
+        n.auto_dismiss_s = auto_dismiss_s;
+        n.actions        = std::move(actions);
+        std::lock_guard<std::mutex> lk(state_ptr->mtx);
+        state_ptr->notifs.push(std::move(n));
+    };
+
+    std::vector<MenuItem> demo_menu = {
+        leaf("Trigger Alarm", [state_ptr, push_notif]{
+            if (!state_ptr) return;
+            { std::lock_guard<std::mutex> lk(state_ptr->mtx);
+              state_ptr->timer_alarm.alarm_triggered = true; }
+            push_notif(NotifType::Alarm, "Test Alarm", "Demo alarm fired", 0.f,
+                {{"DISMISS", [](AppState& s){ s.timer_alarm.alarm_triggered = false; }}});
+        }),
+        leaf("Trigger Timer Done", [state_ptr, push_notif]{
+            if (!state_ptr) return;
+            { std::lock_guard<std::mutex> lk(state_ptr->mtx);
+              state_ptr->timer_alarm.timer_triggered = true; }
+            push_notif(NotifType::Timer, "Timer Done", "Demo 5:00 timer expired", 0.f,
+                {{"DISMISS", [](AppState& s){ s.timer_alarm.timer_triggered = false; }},
+                 {"+2 MIN",  [](AppState& s){ s.timer_alarm.timer_end = time(nullptr)+120; s.timer_alarm.timer_active=true; s.timer_alarm.timer_triggered=false; }},
+                 {"+5 MIN",  [](AppState& s){ s.timer_alarm.timer_end = time(nullptr)+300; s.timer_alarm.timer_active=true; s.timer_alarm.timer_triggered=false; }}});
+        }),
+        leaf("LoRa Message (Node-2)", [state_ptr, push_notif]{
+            if (!state_ptr) return;
+            { std::lock_guard<std::mutex> lk(state_ptr->mtx);
+              state_ptr->push_lora_message({2, time(nullptr), "Demo: en route to objective"}); }
+            push_notif(NotifType::LoRa, "Node-2", "Demo: en route to objective", 8.f);
+        }),
+        leaf("App Toast", [push_notif]{
+            push_notif(NotifType::App, "ProtoHUD", "Demo app notification", 4.f);
+        }),
+        leaf("Toast Stack (x4)", [push_notif]{
+            push_notif(NotifType::Alarm, "Alarm",  "Demo alarm",  0.f);
+            push_notif(NotifType::Timer, "Timer",  "Demo timer",  0.f);
+            push_notif(NotifType::LoRa,  "Node-3", "Demo LoRa",  8.f);
+            push_notif(NotifType::App,   "System", "Demo app",   4.f);
+        }),
+        leaf("Clear All", [state_ptr]{
+            if (!state_ptr) return;
+            std::lock_guard<std::mutex> lk(state_ptr->mtx);
+            state_ptr->notifs.dismiss_all();
+            state_ptr->timer_alarm.alarm_triggered = false;
+            state_ptr->timer_alarm.timer_triggered = false;
+        }),
+    };
+
     std::vector<MenuItem> software_menu = {
         leaf("Check for Updates", []{
             system("git -C /home/user/ProtoHUD fetch origin main 2>&1 | logger -t protohud &");
@@ -1718,7 +1777,8 @@ static std::vector<MenuItem> build_menu(
                 }
             }),
         leaf("Refresh Bluetooth", [bt_mon]{ if (bt_mon) bt_mon->refresh(); }),
-        submenu("Software", std::move(software_menu)),
+        submenu("Software",   std::move(software_menu)),
+        submenu("Demo Mode",  std::move(demo_menu)),
     };
 
     return {
@@ -2367,8 +2427,9 @@ int main(int argc, char* argv[]) {
     });
 
     knob.on_move([&menu, &hud](int8_t dir, int) {
-        if      (hud.popup_active())  hud.popup_navigate(dir);
-        else if (menu.is_open())      menu.navigate(dir);
+        if      (hud.popup_active())    hud.popup_navigate(dir);
+        else if (menu.is_open())        menu.navigate(dir);
+        else if (hud.toast_has_focused()) hud.toast_navigate(dir);
     });
 
     knob.on_status([&state](uint8_t status, uint8_t param) {
@@ -2409,9 +2470,10 @@ int main(int argc, char* argv[]) {
             });
             buttons.on_pip_left ([&pip_left_active] () { pip_left_active  = true; });
             buttons.on_pip_right([&pip_right_active]() { pip_right_active = true; });
-            buttons.on_select   ([&menu, &hud]() {
-                if      (hud.popup_active()) hud.popup_select();
-                else if (menu.is_open())     menu.select();
+            buttons.on_select   ([&menu, &hud, &state]() {
+                if      (hud.popup_active())      hud.popup_select();
+                else if (menu.is_open())           menu.select();
+                else if (hud.toast_has_focused())  hud.toast_select(state);
             });
         } else {
             std::cerr << "[main] GPIO button init failed\n";
@@ -2471,6 +2533,10 @@ int main(int argc, char* argv[]) {
             if (key_pressed(ImGuiKey_LeftArrow))  hud.popup_navigate(-1);
             if (key_pressed(ImGuiKey_RightArrow)) hud.popup_navigate(+1);
             if (key_pressed(ImGuiKey_Enter))      hud.popup_select();
+        } else if (hud.toast_has_focused()) {
+            if (key_pressed(ImGuiKey_LeftArrow))  hud.toast_navigate(-1);
+            if (key_pressed(ImGuiKey_RightArrow)) hud.toast_navigate(+1);
+            if (key_pressed(ImGuiKey_Enter))      hud.toast_select(state);
         } else if (menu.is_open()) {
             if (key_pressed(ImGuiKey_UpArrow))    menu.navigate(-1);
             if (key_pressed(ImGuiKey_DownArrow))  menu.navigate(+1);
@@ -2795,6 +2861,7 @@ int main(int argc, char* argv[]) {
         // Pass full display dimensions so NanoVG covers both eye halves.
         glViewport(0, 0, xr.display_width(), xr.display_height());
         hud.draw_hud_frame(snap, xr.display_width(), xr.display_height(), fps_overlay_active);
+        hud.draw_toasts(state.notifs, xr.display_width(), xr.display_height());
 
         // ── Phase 2: ImGui overlays (pip, menu, popups) ───────────────────
         menu.set_glow_enabled(hud.config().glow_enabled);


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Wire ToastRenderer**: `HudRenderer` now owns a `ToastRenderer` member. A new `draw_toasts(live_q, w, h)` method opens its own NanoVG frame after the HUD chrome pass, so toasts render on top of the camera feed but under the ImGui menu layer.
- **Knob + keyboard routing**: When no popup or menu is active, knob scroll and select (and keyboard arrow/enter) are routed to the focused toast's action buttons.
- **Demo Mode submenu**: Added inside System → Demo Mode with 6 items:
  - **Trigger Alarm** — sets `alarm_triggered` + pushes an Alarm notification with DISMISS action
  - **Trigger Timer Done** — sets `timer_triggered` + pushes a Timer notification with DISMISS / +2 MIN / +5 MIN actions
  - **LoRa Message (Node-2)** — pushes to `lora_messages` deque (HUD side panel) and fires an 8s auto-dismiss toast
  - **App Toast** — fires a 4s auto-dismiss App toast
  - **Toast Stack (×4)** — pushes one of each type simultaneously
  - **Clear All** — dismisses all notifications and clears alarm/timer trigger flags

## Test plan

- [ ] Build on target: `cmake --build build`
- [ ] System → Demo Mode → "App Toast" — toast slides in from right, auto-dismisses in 4s
- [ ] "Toast Stack (×4)" — up to 4 toasts stack in top-right corner
- [ ] "Trigger Alarm" — modal alarm popup appears; knob navigates to DISMISS
- [ ] "Trigger Timer Done" — timer popup appears with +2/+5 MIN options
- [ ] "LoRa Message (Node-2)" — LoRa side panel updates and toast appears
- [ ] Knob scroll on focused toast cycles action buttons; press fires action
- [ ] "Clear All" — all toasts and popups dismissed immediately
- [ ] System → Notifications log shows history of pushed notifications
- [ ] Menu navigation unaffected after any demo interaction

https://claude.ai/code/session_017xAaFHoiBHVqGLxVhohcAh
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_017xAaFHoiBHVqGLxVhohcAh)_