### PR TITLE
Add digital zoom for OWLsight cameras

### DIFF
--- a/CAPABILITIES.md
+++ b/CAPABILITIES.md
@@ -1,0 +1,467 @@
+# ProtoHUD — Options & Capabilities Reference
+
+---
+
+## Overview
+
+ProtoHUD is a heads-up display system for VITURE XR glasses running on a Raspberry Pi CM5. It composites camera feeds, a HUD overlay, post-processing vision-assist effects, and hardware integrations (LoRa radio, haptic knob, LED face panels, IMU) into a real-time stereo side-by-side display at up to 90 fps.
+
+---
+
+## 1. Camera System
+
+### Supported Cameras
+- **Two OWLsight CSI cameras** (left + right eye) — libcamera, EGL dmabuf zero-copy NV12 path
+- **Three USB cameras** — OpenCV capture, used as picture-in-picture overlays
+- **VITURE Beast passthrough camera** — enabled via config when glasses are detected
+- **Android mirror** — scrcpy → V4L2 loopback → overlay
+
+### OWLsight Resolutions
+| Label | Resolution | Max FPS |
+|---|---|---|
+| 640×400 | 640×400 | 120 fps |
+| 1280×800 | 1280×800 | 60 fps (default) |
+| 1920×1080 | 1920×1080 | 30 fps |
+| 2560×1440 | 2560×1440 | 15 fps |
+
+### Digital Zoom (per-eye)
+- Zoom levels: 1.0×, 1.25×, 1.5×, 2.0×, 3.0×
+- Crop center: Center, Top, Bottom, Left, Right
+- Reset Zoom action
+
+### Focus
+- **Modes**: Manual, Auto, Slave (right eye mirrors left eye 500 ms after AF completes)
+- **Focus Position slider**: 0–1000, step 50
+- **One-shot AF**: Left only, Right only, Both
+
+### Night Vision
+- Manual toggle (sets exposure EV +3.0, shutter 1/25 s)
+- **Auto Night Vision** — enables automatically when scene gain crosses a threshold
+- Auto NV Gain Threshold: 1.5–16×, step 0.5
+- Exposure (EV) slider: −3.0 to +3.0, step 0.5
+- Shutter Speed presets: 1/4000 through 1/25 s (nine steps)
+
+### White Balance
+- Auto WB toggle
+- Colour temp presets: Tungsten (2800K), Warm (3500K), Neutral (4500K), Daylight (5600K), Cool Blue (7000K)
+
+### Theater Mode
+Renders OWLsight feeds at their native aspect ratio (letterbox or pillarbox) with black bars, preserving correct proportions. Black bar region is reserved for future USB camera placement.
+
+### Photo Capture
+Captures the raw camera FBO (no HUD overlay) as a PNG. Write is asynchronous; a toast shows the saved path.
+
+| Mode | Output |
+|---|---|
+| Capture Left | Single eye PNG at camera resolution |
+| Capture Right | Single eye PNG at camera resolution |
+| Capture Stereo | Side-by-side both eyes in one wide PNG |
+
+- Default save path: `/home/user/Pictures/protohud/`
+- Override with `system.photo_dir` in config.json (e.g. an NVMe mount)
+- Filename: `protohud_YYYYMMDD_HHMMSS_{left|right|stereo}.png`
+
+### USB Camera Overlays (PiP)
+Each of the three USB cameras has:
+- Open/close stream toggle
+- Show overlay toggle
+- Position: Top-Left, Top-Center, Top-Right, Bottom-Left, Bottom-Center, Bottom-Right
+- Size: 15%–60%, step 5%
+- Flip Upside Down toggle
+- Auto Brightness toggle + Brightness Target slider (40–220)
+- Software brightness multiplier: 50%, 100%, 150%, 200%, 300%
+- Manual exposure controls: Exposure Time, Auto WB, WB Temperature (2800–6500K), Dynamic Framerate toggle
+- Scan for Camera action (probes /dev/video0..N)
+
+---
+
+## 2. HUD Display
+
+### Always-On Elements
+- **Compass tape** (bottom-center) — shows ~120° arc with cardinal/intercardinal labels, major/mid/minor ticks, LoRa bearing markers
+- **Health indicators** (left side) — Proot (Teensy), LoRa, Interface (knob), WiFi
+- **Camera indicators** (right side) — L.Cam, R.Cam with AF status (MAN / SLV / LOCK / SCAN / AUTO), USB Cam 1/2
+- **Indicator arms** — diagonal lines with label nodes for: Face, Clock, Timer/Alarm
+- **Toast notifications** — slide-in from right, up to 4 stacked, auto-dismiss configurable per message
+
+### System Status Panel (toggleable)
+Full system information panel in the top-left corner:
+- CPU % with 60-sample sparkline
+- RAM used/total with 60-sample sparkline
+- Uptime
+- WiFi: SSID, IP, signal dBm, 4-bar indicator
+- Ping latency with 30-sample sparkline and host
+- Bluetooth: up to 4 paired devices with connection state
+- Performance: FPS + frame-time sparkline
+- Serial Latency: Teensy RTT, SmartKnob event age, LoRa RSSI/SNR
+- SSH: active state and port
+
+### FPS Overlay (toggleable)
+Small per-eye "NN FPS  N.N ms" readout in the top-right of each eye.
+
+### LED Panel Preview (toggleable)
+Live 128×64 HUB75 panel canvas from Protoface shared memory, displayed as a floating HUD window (scaled 3×).
+
+### Clock
+- 12/24-hour toggle
+- Show seconds toggle
+- Show date toggle
+- Font scale
+- Manual time offset (seconds)
+
+### Compass Options
+- Background enabled/disabled
+- Background opacity (0–1)
+- Background side fade (px)
+- Tick length (8–48 px, step 2)
+- Tick glow toggle
+- Height (px)
+- Bottom margin (px)
+- LoRa node bearing markers (colored per-node)
+
+### HUD Styling
+- **Text Scale**: 0.7×–2.0×, step 0.1
+- **Glow Intensity**: 0–2, step 0.05
+- **Text Glow toggle**
+- **Indicator Background toggle**
+- **Flip to Top** — mirrors HUD chrome to top edge instead of bottom
+- **Health Panel Opacity**
+- **PiP Corner Clip** — chamfer radius for USB camera overlay borders
+
+---
+
+## 3. Themes & Color Customization
+
+### Themes (coordinated presets)
+Each theme sets glow base, text color, compass tick colors, menu selection style, border, and bold text simultaneously:
+
+| Theme | Accent | Selection Style |
+|---|---|---|
+| Halo | White | Filled Row |
+| Solar | Orange | Accent Bar |
+| Fallout | Green | Accent Bar |
+| Space | Blue | Accent Bar |
+
+### Individual Color Controls
+- **Borders & Lines**: Orange, Teal, Cyan, Green, Yellow, Purple, White, Red
+- **Text Color**: White, Cyan, Orange, Amber, Green, Yellow, Red, Purple, Blue, Pink
+- **Compass Tick Color**: Orange, Teal, Cyan, Green, Purple, White
+- **Compass Glow Color**: Orange, Teal, Cyan, Green, Purple, White
+- **Menu Accent**: Orange, Teal, Cyan, Green, Purple
+- **Menu Border**: toggle, thickness 0.5–8 px, 8 color options
+- **Backgrounds**: HUD background (Dark/Navy/Black/Teal/Green/Space), menu background, compass background (with tint options)
+- **Indicator Colors**: active, inactive, fail states — each independently configurable
+- **LoRa Node Colors**: per-node (1–8) from: Orange, Teal, Cyan, Green, Yellow, Purple, Red, White
+
+---
+
+## 4. Vision Assist (Post-Processing)
+
+All three effects are independent and stackable. Applied as a GLSL shader pass over the camera FBOs.
+
+### Edge Highlight
+Sobel edge detection; draws colored outlines on object boundaries.
+
+| Parameter | Options |
+|---|---|
+| Enabled | Toggle (keyboard: E) |
+| Strength | 10%, 30%, 50%, 70%, 100% |
+| Color | Orange, Teal, Cyan, Green, White, Black |
+| Detail (kernel step) | Ultra Fine, Fine, Standard, Coarse, Silhouette |
+| Threshold | None, Low, Medium, High |
+| Size Filter | Off, Tiny, Small, Medium, Large (removes noise/small objects) |
+
+### Background Desaturate
+Desaturates low-contrast background regions, leaving foreground objects in color.
+
+| Parameter | Options |
+|---|---|
+| Enabled | Toggle (keyboard: D) |
+| Strength | 25%, 50%, 75%, 100% |
+| BG Threshold | Subtle, Medium, Aggressive |
+| Focus Blend | Off, Low, Medium, Full (uses AF lens position) |
+| Color Protect | 0–100%, step 10% |
+| Edge Expand | 0–3, step 0.5 |
+
+### Motion Highlight
+Temporal frame-difference; highlights moving objects against a blended reference frame.
+
+| Parameter | Options |
+|---|---|
+| Enabled | Toggle (keyboard: W) |
+| Mode | Fine Line, Fill |
+| Sensitivity | Low, Medium, High, Very High |
+| Spread | Tight (2px), Close (4px), Medium (8px), Wide (16px) |
+| Trail Length | Instant (1 frame) → Extended (~30 frames) |
+| Color | Green, Cyan, Yellow, White, Orange |
+
+---
+
+## 5. Effects & Border System
+
+### Effect Types
+| Effect | Description | Draw Cost |
+|---|---|---|
+| None | No border effect | 0 |
+| Arm Glints | Sparks along the five indicator arm angles | ~3/s per arm |
+| Corner Drift | Slow drifting dots from compass tape corners | ~2.5/s per corner |
+| Popup Burst | One-shot 24-particle ring from screen center on alarm/timer popup | One-shot |
+| Compass Turbulence | Random sparks inside the compass tape area | ~12/s |
+| Nebula Edge | Layered dark-blue/violet gradient cloud on all edges + dot and comet particles; covers corners cleanly via box gradient | 3 fills + ~1–4 particles/frame |
+| Dark Vignette | Two-pass dark border (soft 200px outer band + hard 55px edge ring); no particles | 2 fills, static |
+
+### Effect Palettes (applies to particle color)
+Theme (match HUD), Halo (white), Solar (amber), Fallout (radioactive green), Space (electric blue)
+
+---
+
+## 6. Audio
+
+- ALSA passthrough from RP2350 USB Audio (beamforming, noise suppression handled on-device)
+- **Enable/disable toggle**
+- **Volume**: 25%–150%, step 5%
+- **Output selection**: VITURE glasses / Headphones / HDMI
+
+---
+
+## 7. LoRa Radio
+
+Communicates with RAK4631 nodes running custom firmware.
+
+### Per-Node Data Tracked
+- Name (up to 12 chars)
+- Bearing (degrees)
+- Distance (meters)
+- RSSI (dBm) and SNR (dB)
+- Last-seen timestamp
+
+### HUD Integration
+- Bearing markers on compass tape (colored per node, 8-color palette)
+- Right-side indicator arm: up to 4 nodes showing `NAME ___° X.Xk`
+- Message panel (left side): scrolling message history
+- Toast notification on incoming message
+
+### Menu Actions
+- Clear Messages
+- Clear Notifications
+- Lookup Node (1–8): fires a 6-second toast with distance, heading, RSSI, SNR, time-since
+
+### Message Queue
+Ring buffer capped at 50 messages (configurable via `hud.lora_message_history`).
+
+---
+
+## 8. SmartKnob
+
+ESP32-S3 haptic detent rotary encoder over UART.
+
+- Rotary input navigates menus and toast action buttons
+- Detent count and haptic strength adapt to menu depth:
+  - Root level: strong haptics
+  - Submenus: medium
+  - Deep menus: lighter
+- Sleep timeout configurable (default 30 s)
+- Wake threshold configurable (default 5°)
+- Last event age shown in System Panel
+
+---
+
+## 9. Face / LED Panels
+
+Two interchangeable backends — Teensy (ProtoTracer) and Protoface Python daemon. Runtime-selectable.
+
+### Effects (10 face animations)
+Idle, Blink, Angry, Happy, Sad, Shocked, Rainbow, Pulse, Wave, Custom
+
+### Material Colors (12)
+Default, Yellow, Orange, White, Green, Purple, Red, Blue, Rainbow, Flow Noise, H Rainbow, Black
+
+### GIF Playback
+8 GIF slots (labels configurable via `serial.teensy.gif_names[]` in config)
+
+### Controls
+| Control | Range |
+|---|---|
+| Color (preset) | Teal, Cyan, Red, Green, Purple, White |
+| Color (custom) | Full RGB picker |
+| Brightness | 0–255, step 5 |
+| Accent Brightness | 0–10 |
+| Face Size | 0–10 |
+| Fan Speed | 0–10 |
+| Microphone | Toggle |
+| Mic Level | 0–10 |
+| Boop Sensor | Toggle |
+| Spectrum Mirror | Toggle |
+
+- **Release Control** — relinquishes HUD control; Teensy resumes autonomous animation
+- **Panel Preview** — live 128×64 LED canvas as floating HUD window
+
+---
+
+## 10. XR Display Controls
+
+| Control | Range |
+|---|---|
+| Lens Brightness | 1–7 |
+| Dimming | 0–9 |
+| HUD Brightness | 1–9 |
+| Recenter Tracking | Action |
+| Gaze Lock | Action |
+| 3D SBS Mode | Action |
+
+---
+
+## 11. Input Methods
+
+### GPIO Buttons (3 physical buttons)
+| Button | Short press | ≥1.5 s hold | ≥5 s hold |
+|---|---|---|---|
+| Button 1 (GPIO 17) | Toggle left USB PiP | Autofocus left camera | Capture left photo |
+| Button 2 (GPIO 27) | Toggle right USB PiP | Autofocus right camera | Capture right photo |
+| Button 3 (GPIO 22) | Menu select / toast select | — | — |
+
+All thresholds configurable via config.json (`af_trigger_time_ms`, `pip_trigger_time_ms`, `capture_trigger_time_ms`).
+
+### Keyboard Shortcuts
+| Key | Action |
+|---|---|
+| M | Open/close menu |
+| Up / Down | Navigate menu or toast |
+| Enter / Right | Select menu item |
+| Backspace / Left | Menu back |
+| E | Toggle Edge Highlight |
+| D | Toggle Background Desaturate |
+| W | Toggle Motion Highlight |
+| 1 | Toggle USB Cam 1 PiP |
+| 2 | Toggle USB Cam 2 PiP |
+| 3 | Toggle focus Manual/Auto |
+| 4 | Autofocus both cameras |
+| , | Focus step near (−20) |
+| . | Focus step far (+20) |
+| Escape / P | Quit |
+| Ctrl+Q / Ctrl+K | Force quit |
+
+### SmartKnob
+Rotate to navigate menus and toasts; detent count matches current menu level.
+
+---
+
+## 12. System Monitoring & Connectivity
+
+| Metric | Update Rate | Where Shown |
+|---|---|---|
+| CPU % | 1 s | System Panel + sparkline |
+| RAM used/total | 1 s | System Panel + sparkline |
+| Uptime | 1 s | System Panel |
+| FPS + frame time | Every frame | System Panel + FPS overlay |
+| WiFi SSID, IP, dBm | 5 s | System Panel + health indicator |
+| Ping latency | 2 s | System Panel + sparkline |
+| Bluetooth devices | 10 s | System Panel |
+| Teensy RTT | Per request | System Panel |
+| SmartKnob event age | Every frame | System Panel |
+| LoRa RSSI/SNR | Per packet | System Panel + LoRa indicator |
+| SSH status | On toggle | System Panel |
+
+- **SSH Access** toggle (starts/stops sshd via systemctl)
+- **Refresh Bluetooth** action (immediate rescan)
+- **Onboard Compass** (MPU-9250): Active toggle, Calibrate action (hard-iron, writes mag_bias to config)
+
+---
+
+## 13. Configuration File (config.json)
+
+| Section | Key Fields |
+|---|---|
+| `display` | width, height, fullscreen, target_fps, eye_separation |
+| `cameras.owlsight_left/right` | libcamera_id, width, height, fps, flip_h/v |
+| `cameras.usb_cam_1/2/3` | device, resolution, fps, exposure, wb settings |
+| `serial.teensy` | port, baud, gif_names[8] |
+| `serial.lora` | port, baud, ping_on_start, node_info_refresh_s |
+| `serial.smartknob` | port, baud, sleep_timeout_s, wake_degrees |
+| `vitrue` | product_id, use_beast_camera, enable_imu |
+| `hud` | compass dimensions, opacity, panel widths, pip settings, effects |
+| `gpio` | enabled, pin assignments, hold thresholds |
+| `audio` | enabled, output device, sample_rate, master_gain |
+| `post_process` | per-effect enable + all parameter values |
+| `night_vision` | exposure_ev, shutter_us |
+| `clock` | use_24h, show_seconds, show_date, manual_offset_s |
+| `system` | ping_host, wifi_iface, ssh_port, crash_dir, photo_dir |
+| `mpu9250` | enabled, i2c_bus, declination_deg, mag_bias[3] |
+| `android` | enabled, v4l2_sink, adb_serial, overlay settings |
+| `colors` | hud_primary, hud_accent, hud_warn, hud_danger, hud_background |
+| `splash` | enabled, animated, image, title, subtitle |
+
+Settings modified via the menu are persisted to config.json on exit.
+
+---
+
+## 14. Other Features
+
+### Timers & Alarms
+- Countdown timer: preset durations (5/10/30/60 min) or custom (0–99 min + 0–59 s)
+- Alarm: set by hour/minute, fires as a pulsing red edge gradient + toast with DISMISS action
+- Timer expiry fires orange edge pulse + toast with DISMISS / +2 MIN / +5 MIN actions
+
+### Software Updates (System → Software)
+- **Check for Updates** — runs `git fetch origin main`
+- **Pull & Rebuild** — runs `git pull` + `./scripts/build.sh`
+
+### Demo Mode (System → Demo Mode)
+Test all notification types without hardware: Trigger Alarm, Trigger Timer Done, LoRa Message, App Toast, Toast Stack (×4), Clear All.
+
+### Crash Reporter
+Signal handler writes a JSON crash dump with git hash to `system.crash_dir` (default `/tmp`).
+
+### Splash Screen
+Animated hexagon mark or custom PNG logo with title/subtitle, shown at startup for a configurable minimum duration.
+
+### Rotational Timewarp
+IMU-driven reprojection reduces rotational display latency from ~16 ms to ~4 ms by warping the last rendered frame using the latest IMU pose before display.
+
+---
+
+## 15. Possible Additions
+
+### Camera & Capture
+- **HUB75 panel flash for photo capture** — `ProtoFaceController::set_color(255,255,255)` before capture with 1–2 frame delay, then restore. Infrastructure already wired.
+- **USB camera fill in theater mode black bars** — shift the main feed flush to one edge and fill the single contiguous black region with a USB camera feed. Layout coordinates already planned in the theater-mode code.
+- **Burst capture mode** — take N frames in rapid succession and save as a numbered sequence.
+- **Timelapse / interval capture** — capture at a fixed interval (e.g. every 30 s) and assemble into a video.
+- **JPEG option for captures** — stb_image_write supports JPEG; add a format toggle alongside the existing PNG path.
+- **Video recording** — pipe the FBO to a V4L2 loopback or encode with FFmpeg. The async write infrastructure from photo capture provides a starting point.
+- **Per-eye independent zoom/exposure** — currently zoom and exposure are mirrored; allow full decoupling.
+
+### HUD & Display
+- **Minimap overlay** — GPS or LoRa-derived relative position plotted on a small top-down map.
+- **Heads-up altimeter / barometer** — BME280 or similar I2C sensor feeding an altitude indicator arm.
+- **Battery indicator** — read `/sys/class/power_supply` or INA219 over I2C; show percentage + sparkline in System Panel.
+- **Configurable indicator arm layout** — let the user drag/reorder which indicators appear on left vs. right side.
+- **Notification action on GPIO** — wire button 3 long-press to dismiss / action the currently focused toast.
+- **Custom clock faces** — analog dial, large digital, or minimal dot-matrix styles selectable in the clock submenu.
+- **Scrolling LoRa message ticker** — thin single-line ticker along the top edge for incoming messages without occupying the full side panel.
+
+### Vision Assist
+- **Depth estimation overlay** — monocular depth model (MiDaS-small) running on the Pi NPU; colorize by depth or use depth as a desaturation mask instead of contrast-based detection.
+- **Face/person detection bounding boxes** — lightweight MobileNet or YOLOv8-nano inference; draw labeled outlines on the camera feed.
+- **Color blindness correction modes** — shift hues in the GLSL post-process pass to assist deuteranopia / protanopia.
+- **Zoom-to-cursor** — magnify a selectable region of the camera feed (e.g. whatever the SmartKnob points at) without scaling the full frame.
+
+### LoRa & Networking
+- **Send message UI** — on-screen keyboard (SmartKnob-driven character picker) to compose and send LoRa messages.
+- **Node proximity alerts** — toast when a node enters/exits a configurable distance threshold.
+- **Track history / breadcrumb trail** — store node position history and draw a faint path on a minimap.
+- **MQTT bridge** — publish LoRa node data to an MQTT broker over WiFi for logging or dashboard display.
+
+### Hardware Integrations
+- **HUB75 ambient sync** — extend the active HUD color palette to the LED panels in real time (e.g. edge highlight color drives panel color).
+- **Haptic feedback for alerts** — use SmartKnob motor for a short pulse on alarm/timer fire or incoming LoRa message.
+- **Speaker/buzzer support** — play a short tone on alarm events via the ALSA audio path.
+- **Additional GPIO inputs** — extra buttons for dedicated functions (e.g. dedicated capture button, one-touch effect cycle).
+- **Rotary encoder for zoom** — second SmartKnob or simple encoder wired to digital zoom without entering the menu.
+
+### System & Infrastructure
+- **OTA update via LoRa or WiFi** — download and apply firmware updates without a keyboard, triggered from the System menu.
+- **Config profiles** — save/load named config presets (day, night, indoor, outdoor) from the System menu.
+- **Remote HUD control** — WebSocket server exposing state so a phone/tablet can act as a second display or control surface.
+- **Log viewer** — System Panel tab showing recent log lines from a ring buffer, scrollable with the SmartKnob.
+- **NVMe storage management** — once NVMe is connected, add a Storage section to System: free space, eject, auto-move captures older than N days.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,14 @@ pkg_check_modules(LIBGPIOD REQUIRED libgpiod)
 # ALSA (audio capture from RP2350 USB Audio + playback to output device)
 pkg_check_modules(ALSA REQUIRED alsa)
 
+# ZBar (QR / barcode scanning) — optional; install with: sudo apt install libzbar-dev
+pkg_check_modules(ZBAR zbar)
+if(ZBAR_FOUND)
+    message(STATUS "ZBar found — QR scanning enabled")
+else()
+    message(STATUS "ZBar not found — QR scanning disabled (sudo apt install libzbar-dev)")
+endif()
+
 # ── Dear ImGui (vendored source, no external install required) ───────────────
 # Fetched once by CMake; cached in build/_deps after first configure.
 include(FetchContent)
@@ -171,6 +179,7 @@ set(SOURCES
     src/net/bt_monitor.cpp
     src/crash_reporter.cpp
     src/capture.cpp
+    src/qr_scanner.cpp
     src/splash.cpp
     src/nanovg_gl_impl.cpp
     src/hud/toast_renderer.cpp
@@ -192,6 +201,7 @@ target_include_directories(protohud PRIVATE
     ${GLFW3_INCLUDE_DIRS}
     ${LIBGPIOD_INCLUDE_DIRS}
     ${ALSA_INCLUDE_DIRS}
+    $<$<BOOL:${ZBAR_FOUND}>:${ZBAR_INCLUDE_DIRS}>
 )
 
 target_link_libraries(protohud PRIVATE
@@ -207,7 +217,12 @@ target_link_libraries(protohud PRIVATE
     ${ALSA_LIBRARIES}
     nlohmann_json::nlohmann_json
     Threads::Threads
+    $<$<BOOL:${ZBAR_FOUND}>:${ZBAR_LIBRARIES}>
 )
+
+if(ZBAR_FOUND)
+    target_compile_definitions(protohud PRIVATE HAVE_ZBAR)
+endif()
 
 target_compile_options(protohud PRIVATE
     ${LIBCAMERA_CFLAGS_OTHER}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,6 +170,7 @@ set(SOURCES
     src/net/ping_monitor.cpp
     src/net/bt_monitor.cpp
     src/crash_reporter.cpp
+    src/capture.cpp
     src/splash.cpp
     src/nanovg_gl_impl.cpp
     src/hud/toast_renderer.cpp

--- a/assets/shaders/nv12.vs
+++ b/assets/shaders/nv12.vs
@@ -3,10 +3,17 @@
 attribute vec2 a_pos;
 attribute vec2 a_uv;
 
+// Digital zoom: zoom=1.0 → identity; zoom>1.0 → crops to center 1/zoom of frame.
+// center is normalized screen-space (0.5,0.5 = frame center).
+uniform float u_zoom;
+uniform vec2  u_center;
+
 varying vec2 v_uv;
 
 void main() {
     gl_Position = vec4(a_pos, 0.0, 1.0);
     // Camera DMA buffers have origin at top-left; flip V for GL bottom-left convention.
-    v_uv = vec2(a_uv.x, 1.0 - a_uv.y);
+    vec2 uv = vec2(a_uv.x, 1.0 - a_uv.y);
+    // Apply zoom crop: scale UV around the crop center.
+    v_uv = (uv - u_center) / u_zoom + u_center;
 }

--- a/src/app_state.h
+++ b/src/app_state.h
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <ctime>
 #include <imgui.h>
+#include "capture.h"
 
 // ── Post-processing config ────────────────────────────────────────────────────
 // Modified from menu (any thread); read by the render thread via snap.
@@ -331,6 +332,9 @@ struct AppState {
     // black bars filling the remaining FBO area. Letterbox or pillarbox depending
     // on camera AR vs. display AR. Future: USB cameras fill the black bar regions.
     bool  theater_mode = false;
+
+    // Photo capture: set by menu or GPIO long-press; consumed by the render thread.
+    CaptureRequest capture_request = CaptureRequest::None;
 
     // Latest IMU pose (NWU coordinates). Updated by XRDisplay IMU callback.
     ImuPose imu_pose;

--- a/src/app_state.h
+++ b/src/app_state.h
@@ -336,6 +336,12 @@ struct AppState {
     // Photo capture: set by menu or GPIO long-press; consumed by the render thread.
     CaptureRequest capture_request = CaptureRequest::None;
 
+    // QR / barcode scanning (requires libzbar-dev).
+    // qr_scan_main: periodic glReadPixels from OWLsight FBO → ZBar.
+    // qr_scan_usb:  scanned in the USB capture thread from the raw BGR frame.
+    bool qr_scan_main = false;
+    bool qr_scan_usb  = false;
+
     // Latest IMU pose (NWU coordinates). Updated by XRDisplay IMU callback.
     ImuPose imu_pose;
 

--- a/src/app_state.h
+++ b/src/app_state.h
@@ -181,7 +181,7 @@ struct ImuPose {
 // ── Particle effects ──────────────────────────────────────────────────────────
 
 enum class EffectType : uint8_t {
-    None = 0, ArmGlints, CornerDrift, PopupBurst, CompassTurbulence, NebulaEdge
+    None = 0, ArmGlints, CornerDrift, PopupBurst, CompassTurbulence, NebulaEdge, DarkVignette
 };
 enum class EffectPalette : uint8_t {
     Theme = 0, Halo, Solar, Fallout, Space

--- a/src/app_state.h
+++ b/src/app_state.h
@@ -327,6 +327,11 @@ struct AppState {
     float compass_heading    = 0.0f;
     bool  compass_bg_enabled = true;
 
+    // Theater mode: render OWLsight cameras at their native aspect ratio with
+    // black bars filling the remaining FBO area. Letterbox or pillarbox depending
+    // on camera AR vs. display AR. Future: USB cameras fill the black bar regions.
+    bool  theater_mode = false;
+
     // Latest IMU pose (NWU coordinates). Updated by XRDisplay IMU callback.
     ImuPose imu_pose;
 

--- a/src/app_state.h
+++ b/src/app_state.h
@@ -160,6 +160,17 @@ struct CameraResolutionState {
     int fps    = 60;
 };
 
+// Digital zoom / crop for OWLsight cameras.
+// zoom=1.0 → full frame (identity). zoom>1.0 → crops to 1/zoom of the frame.
+// center_x / center_y are normalized (0.0–1.0) screen-space coordinates.
+// Option B hook: the same values are forwarded to libcamera ScalerCrop when
+// apply_pending_controls() implements it.
+struct ZoomCropState {
+    float zoom     = 1.0f;
+    float center_x = 0.5f;
+    float center_y = 0.5f;
+};
+
 struct ImuPose {
     float roll  = 0.0f;
     float pitch = 0.0f;
@@ -319,11 +330,12 @@ struct AppState {
     // Latest IMU pose (NWU coordinates). Updated by XRDisplay IMU callback.
     ImuPose imu_pose;
 
-    // Camera focus, night vision, and resolution control
+    // Camera focus, night vision, resolution, and digital zoom
     CameraFocusState     focus_left, focus_right;
     NightVisionState     night_vision;
     ClockConfig          clock_cfg;
     CameraResolutionState camera_resolution;
+    ZoomCropState        zoom_left, zoom_right;
 
     // Post-processing (edge highlight + background desaturation)
     PostProcessConfig    pp_cfg;

--- a/src/camera/camera_manager.cpp
+++ b/src/camera/camera_manager.cpp
@@ -1,4 +1,5 @@
 #include "camera_manager.h"
+#include "qr_scanner.h"
 
 #include <libcamera/libcamera.h>
 #include <opencv2/imgproc.hpp>
@@ -288,6 +289,16 @@ void CameraManager::usb_capture_thread() {
                 if (flip_ref.load())
                     cv::flip(frame, frame, -1);  // -1 = 180° rotation (both axes)
                 cv::cvtColor(frame, rgba, cv::COLOR_BGR2RGBA);
+                // QR scan: convert BGR frame to grayscale and submit to scanner.
+                // submit_gray() is rate-limited internally; safe to call every frame.
+                if (qr_scanner_ && qr_scan_usb_.load()) {
+                    cv::Mat gray;
+                    cv::cvtColor(frame, gray, cv::COLOR_BGR2GRAY);
+                    qr_scanner_->submit_gray(
+                        std::vector<uint8_t>(gray.data,
+                                             gray.data + gray.total()),
+                        gray.cols, gray.rows);
+                }
                 got_frame = true;
                 consec = 0;
                 ++good;

--- a/src/camera/camera_manager.cpp
+++ b/src/camera/camera_manager.cpp
@@ -221,8 +221,8 @@ void CameraManager::shutdown() {
 
 // ── OWLsight draw (zero-copy, render thread) ──────────────────────────────────
 
-bool CameraManager::draw_owl_left()  { return owl_left_  && owl_left_->draw();  }
-bool CameraManager::draw_owl_right() { return owl_right_ && owl_right_->draw(); }
+bool CameraManager::draw_owl_left( float zoom, float cx, float cy) { return owl_left_  && owl_left_->draw(zoom, cx, cy);  }
+bool CameraManager::draw_owl_right(float zoom, float cx, float cy) { return owl_right_ && owl_right_->draw(zoom, cx, cy); }
 
 // ── Resolution hot-swap ────────────────────────────────────────────────────────
 

--- a/src/camera/camera_manager.h
+++ b/src/camera/camera_manager.h
@@ -14,6 +14,7 @@
 #include <opencv2/videoio.hpp>
 
 namespace libcamera { class CameraManager; }
+class QrScanner;
 
 struct CamConfig {
     int         libcamera_id = 0;
@@ -125,6 +126,12 @@ public:
     bool usb2_reconnect_enabled() const { return usb2_reconnect_; }
     bool usb3_reconnect_enabled() const { return usb3_reconnect_; }
 
+    // ── QR / barcode scanning ─────────────────────────────────────────────────
+    // set_qr_scanner: register the shared scanner instance (call before init).
+    // enable_qr_usb:  hot-toggle USB scanning from any thread (atomic).
+    void set_qr_scanner(QrScanner* s)  { qr_scanner_  = s; }
+    void enable_qr_usb(bool v)         { qr_scan_usb_ = v; }
+
     // ── USB brightness (software multiplier, safe to call from any thread) ────
     void  set_usb1_brightness(float v) { usb1_brightness_ = v; }
     void  set_usb2_brightness(float v) { usb2_brightness_ = v; }
@@ -217,6 +224,9 @@ private:
     std::atomic<float> usb2_auto_brightness_target_ { 100.f };
     std::atomic<float> usb3_auto_brightness_target_ { 100.f };
 
-    std::atomic<bool> running_ { false };
+    std::atomic<bool> running_     { false };
     std::thread       usb_thread_;
+
+    QrScanner*        qr_scanner_  { nullptr };
+    std::atomic<bool> qr_scan_usb_ { false };
 };

--- a/src/camera/camera_manager.h
+++ b/src/camera/camera_manager.h
@@ -64,9 +64,10 @@ public:
 
     // ── OWLsight (zero-copy DMA) ──────────────────────────────────────────────
     // Draw directly into the current render target (fills viewport).
+    // zoom=1.0 → full frame; zoom>1.0 → digital crop around (cx,cy).
     // Returns false if no frame is ready yet.
-    bool draw_owl_left();
-    bool draw_owl_right();
+    bool draw_owl_left( float zoom = 1.0f, float cx = 0.5f, float cy = 0.5f);
+    bool draw_owl_right(float zoom = 1.0f, float cx = 0.5f, float cy = 0.5f);
 
     // ── USB cameras (CPU→GPU upload) ──────────────────────────────────────────
     // Upload latest frame; out receives the GL texture id (0 if unavailable).

--- a/src/camera/dma_camera.cpp
+++ b/src/camera/dma_camera.cpp
@@ -276,11 +276,15 @@ bool DmaCamera::create_gl_resources(const char* vs_path, const char* fs_path) {
         return false;
     }
 
-    // Cache the sampler uniform location (uniform name "tex" in nv12.fs)
-    loc_tex_y_ = glGetUniformLocation(nv12_prog_, "tex");
+    // Cache uniform locations
+    loc_tex_y_  = glGetUniformLocation(nv12_prog_, "tex");
+    loc_zoom_   = glGetUniformLocation(nv12_prog_, "u_zoom");
+    loc_center_ = glGetUniformLocation(nv12_prog_, "u_center");
 
     glUseProgram(nv12_prog_);
     if (loc_tex_y_ >= 0) glUniform1i(loc_tex_y_, 0);   // GL_TEXTURE0
+    if (loc_zoom_   >= 0) glUniform1f(loc_zoom_,  1.0f);
+    if (loc_center_ >= 0) glUniform2f(loc_center_, 0.5f, 0.5f);
     glUseProgram(0);
 
     // Fullscreen quad VBO (NDC, shared across draws)
@@ -376,7 +380,7 @@ void DmaCamera::on_request_complete(Request* req) {
 // Draws the latest frame filling the current GL viewport.
 // Returns false if no frame has ever arrived.
 
-bool DmaCamera::draw() {
+bool DmaCamera::draw(float zoom, float cx, float cy) {
     int slot = -1;
 
     {
@@ -411,6 +415,11 @@ bool DmaCamera::draw() {
     // ── Draw fullscreen NV12 → RGB quad ──────────────────────────────────────
 
     glUseProgram(nv12_prog_);
+
+    // Apply digital zoom; clamp zoom to [1.0, 8.0] to avoid degenerate UVs.
+    float safe_zoom = (zoom < 1.0f) ? 1.0f : (zoom > 8.0f ? 8.0f : zoom);
+    if (loc_zoom_   >= 0) glUniform1f(loc_zoom_,  safe_zoom);
+    if (loc_center_ >= 0) glUniform2f(loc_center_, cx, cy);
 
     gl::bind_quad(quad_vbo_);
     gl::draw_quad();

--- a/src/camera/dma_camera.h
+++ b/src/camera/dma_camera.h
@@ -61,8 +61,9 @@ public:
     void shutdown();
 
     // Draw the latest frame filling the current GL viewport.
+    // zoom=1.0 → full frame; zoom>1.0 → digital crop around (cx,cy).
     // Returns false if no frame is available yet.
-    bool draw();
+    bool draw(float zoom = 1.0f, float cx = 0.5f, float cy = 0.5f);
 
     // Hot-swap the capture resolution / frame-rate without destroying GL resources.
     // Stops capture, reconfigures libcamera, reallocates DMA buffers, restarts.
@@ -149,6 +150,8 @@ private:
     GLuint nv12_prog_  = 0;
     GLuint quad_vbo_   = 0;
     GLint  loc_tex_y_  = -1;   // uniform location of "tex" (samplerExternalOES)
+    GLint  loc_zoom_   = -1;   // uniform location of "u_zoom"
+    GLint  loc_center_ = -1;   // uniform location of "u_center"
 
     // Capture thread
     std::atomic<bool> running_ { false };

--- a/src/capture.cpp
+++ b/src/capture.cpp
@@ -1,0 +1,105 @@
+// stb_image_write: single-header PNG/JPEG encoder.
+// stb_image.h is already defined in nanovg_gl_impl.cpp (via STB_IMAGE_IMPLEMENTATION),
+// but stb_image_write is independent — define its implementation here only.
+#define STB_IMAGE_WRITE_IMPLEMENTATION
+#include <stb_image_write.h>
+
+#include "capture.h"
+#include "app_state.h"
+#include "gl_utils.h"
+#include "vitrue/xr_display.h"
+
+#include <GLES2/gl2.h>
+#include <algorithm>
+#include <chrono>
+#include <ctime>
+#include <filesystem>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+// Read the entire contents of an FBO into a top-down RGBA pixel buffer.
+// Must be called on the render (GL) thread.
+static std::vector<uint8_t> read_fbo_pixels(gl::Fbo& fbo) {
+    const int w = fbo.w, h = fbo.h;
+    std::vector<uint8_t> px(static_cast<size_t>(w * h * 4));
+    fbo.bind();
+    glReadPixels(0, 0, w, h, GL_RGBA, GL_UNSIGNED_BYTE, px.data());
+    fbo.unbind();
+    // OpenGL memory is bottom-up; flip rows to get top-down for PNG
+    for (int row = 0; row < h / 2; ++row)
+        std::swap_ranges(px.begin() + row * w * 4,
+                         px.begin() + (row + 1) * w * 4,
+                         px.begin() + (h - 1 - row) * w * 4);
+    return px;
+}
+
+static std::string build_path(const std::string& dir, const char* tag) {
+    auto tt = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+    struct tm tm_buf {};
+    localtime_r(&tt, &tm_buf);
+    char ts[32];
+    std::strftime(ts, sizeof(ts), "%Y%m%d_%H%M%S", &tm_buf);
+    return dir + "/protohud_" + ts + "_" + tag + ".png";
+}
+
+static void async_write_png(std::vector<uint8_t> px, std::string path, int w, int h) {
+    std::thread([px = std::move(px), path = std::move(path), w, h]() {
+        stbi_write_png(path.c_str(), w, h, 4, px.data(), w * 4);
+    }).detach();
+}
+
+static void push_toast(AppState& state, std::string title, std::string body) {
+    Notification n;
+    n.type          = NotifType::App;
+    n.title         = std::move(title);
+    n.body          = std::move(body);
+    n.auto_dismiss_s = 6.f;
+    state.notifs.push(std::move(n));
+}
+
+void do_capture(CaptureRequest req, XRDisplay& xr,
+                const std::string& dir, AppState& state) {
+    fs::create_directories(dir);
+
+    if (req == CaptureRequest::Left) {
+        const int w = xr.eye_left().w, h = xr.eye_left().h;
+        auto px   = read_fbo_pixels(xr.eye_left());
+        auto path = build_path(dir, "left");
+        async_write_png(std::move(px), path, w, h);
+        std::lock_guard lk(state.mtx);
+        push_toast(state, "Photo saved", path);
+        state.capture_request = CaptureRequest::None;
+
+    } else if (req == CaptureRequest::Right) {
+        const int w = xr.eye_right().w, h = xr.eye_right().h;
+        auto px   = read_fbo_pixels(xr.eye_right());
+        auto path = build_path(dir, "right");
+        async_write_png(std::move(px), path, w, h);
+        std::lock_guard lk(state.mtx);
+        push_toast(state, "Photo saved", path);
+        state.capture_request = CaptureRequest::None;
+
+    } else if (req == CaptureRequest::Stereo) {
+        const int w = xr.eye_left().w, h = xr.eye_left().h;
+        auto L = read_fbo_pixels(xr.eye_left());
+        auto R = read_fbo_pixels(xr.eye_right());
+        // Interleave rows: left half then right half per scanline
+        std::vector<uint8_t> sbs(static_cast<size_t>(2 * w * h * 4));
+        for (int row = 0; row < h; ++row) {
+            const uint8_t* l = L.data() + row * w * 4;
+            const uint8_t* r = R.data() + row * w * 4;
+            uint8_t*      dst = sbs.data() + row * 2 * w * 4;
+            std::copy(l, l + w * 4, dst);
+            std::copy(r, r + w * 4, dst + w * 4);
+        }
+        auto path = build_path(dir, "stereo");
+        async_write_png(std::move(sbs), path, 2 * w, h);
+        std::lock_guard lk(state.mtx);
+        push_toast(state, "Stereo photo saved", path);
+        state.capture_request = CaptureRequest::None;
+    }
+}

--- a/src/capture.h
+++ b/src/capture.h
@@ -1,0 +1,13 @@
+#pragma once
+#include <string>
+
+enum class CaptureRequest : uint8_t { None, Left, Right, Stereo };
+
+struct AppState;
+class  XRDisplay;
+
+// Called on the render thread: reads pixel data from the camera eye FBOs,
+// writes a PNG to dir asynchronously, and pushes a toast via state.notifs.
+// Resets state.capture_request = None before returning.
+void do_capture(CaptureRequest req, XRDisplay& xr,
+                const std::string& dir, AppState& state);

--- a/src/hud/hud_renderer.cpp
+++ b/src/hud/hud_renderer.cpp
@@ -453,10 +453,26 @@ void HudRenderer::draw_pip(unsigned int tex, const char* label,
     // 1. Background fill
     dl->AddConvexPolyFilled(pts, n_pts, col_.background);
 
-    // 2. Camera image or "No Signal" placeholder
+    // 2. Camera image or "No Signal" placeholder — rounded corners match chamfer shape
     if (tex) {
-        dl->AddImage(reinterpret_cast<ImTextureID>(static_cast<uintptr_t>(tex)),
-                     {x, y}, {x + bw, y + bh});
+        ImDrawFlags corner_flags;
+        switch (cfg.anchor) {
+            case A::TOP_LEFT:
+            case A::BOTTOM_RIGHT:
+                corner_flags = ImDrawFlags_RoundCornersTopLeft | ImDrawFlags_RoundCornersBottomRight;
+                break;
+            case A::TOP_RIGHT:
+            case A::BOTTOM_LEFT:
+                corner_flags = ImDrawFlags_RoundCornersTopRight | ImDrawFlags_RoundCornersBottomLeft;
+                break;
+            default:
+                corner_flags = ImDrawFlags_RoundCornersAll;
+                break;
+        }
+        dl->AddImageRounded(reinterpret_cast<ImTextureID>(static_cast<uintptr_t>(tex)),
+                            {x, y}, {x + bw, y + bh},
+                            {0.f, 0.f}, {1.f, 1.f},
+                            IM_COL32_WHITE, C, corner_flags);
     } else {
         if (font_mono_) ImGui::PushFont(font_mono_);
         dl->AddText({x + bw * 0.5f - 36.f, y + bh * 0.5f - 7.f},
@@ -464,28 +480,7 @@ void HudRenderer::draw_pip(unsigned int tex, const char* label,
         if (font_mono_) ImGui::PopFont();
     }
 
-    // 3. Mask image overflow at each clipped corner
-    constexpr ImU32 mask = IM_COL32(0, 0, 0, 255);
-    switch (cfg.anchor) {
-        case A::TOP_LEFT:
-        case A::BOTTOM_RIGHT:
-            dl->AddTriangleFilled({x,      y   }, {x+C,    y   }, {x,    y+C   }, mask);
-            dl->AddTriangleFilled({x+bw,   y+bh}, {x+bw-C, y+bh}, {x+bw, y+bh-C}, mask);
-            break;
-        case A::TOP_RIGHT:
-        case A::BOTTOM_LEFT:
-            dl->AddTriangleFilled({x+bw,   y   }, {x+bw-C, y   }, {x+bw, y+C   }, mask);
-            dl->AddTriangleFilled({x,      y+bh}, {x+C,    y+bh}, {x,    y+bh-C}, mask);
-            break;
-        default:
-            dl->AddTriangleFilled({x,      y   }, {x+C,    y   }, {x,    y+C   }, mask);
-            dl->AddTriangleFilled({x+bw,   y   }, {x+bw-C, y   }, {x+bw, y+C   }, mask);
-            dl->AddTriangleFilled({x,      y+bh}, {x+C,    y+bh}, {x,    y+bh-C}, mask);
-            dl->AddTriangleFilled({x+bw,   y+bh}, {x+bw-C, y+bh}, {x+bw, y+bh-C}, mask);
-            break;
-    }
-
-    // 4. Label (top-left)
+    // 3. Label (top-left)
     if (font_mono_) ImGui::PushFont(font_mono_);
     dl->AddText({x + 4.f, y + 4.f}, col_.primary, label);
     if (font_mono_) ImGui::PopFont();

--- a/src/hud/hud_renderer.cpp
+++ b/src/hud/hud_renderer.cpp
@@ -1629,6 +1629,10 @@ void HudRenderer::fx_draw_lines(NVGcontext* vg) const {
 
 // Layered dark-blue/violet gradient vignette along all four edges to evoke a nebula cloud.
 void HudRenderer::fx_draw_nebula_cloud(NVGcontext* vg, float fw, float fh) const {
+    // Each layer uses nvgBoxGradient over a fullscreen rect: one draw call covers
+    // all four edges and corners simultaneously instead of four separate strips.
+    // The inner box sits `depth` pixels from each screen edge; the feather of
+    // `depth` pixels then carries the gradient outward to the screen boundary.
     struct CloudLayer { float depth; uint8_t r, g, b, a; };
     static const CloudLayer layers[] = {
         {  80.f,  3,  2, 18, 215 },
@@ -1636,26 +1640,38 @@ void HudRenderer::fx_draw_nebula_cloud(NVGcontext* vg, float fw, float fh) const
         { 195.f, 20,  8, 65,  55 },
     };
     for (const auto& l : layers) {
-        const float d = l.depth;
+        const float d    = l.depth;
+        const NVGcolor clear = nvgRGBA(l.r, l.g, l.b,    0);
         const NVGcolor edge  = nvgRGBA(l.r, l.g, l.b, l.a);
-        const NVGcolor clear = nvgRGBA(l.r, l.g, l.b, 0);
-        NVGpaint p;
-        // Top
-        p = nvgLinearGradient(vg, 0, 0, 0, d, edge, clear);
-        nvgBeginPath(vg); nvgRect(vg, 0, 0, fw, d);
-        nvgFillPaint(vg, p); nvgFill(vg);
-        // Bottom
-        p = nvgLinearGradient(vg, 0, fh - d, 0, fh, clear, edge);
-        nvgBeginPath(vg); nvgRect(vg, 0, fh - d, fw, d);
-        nvgFillPaint(vg, p); nvgFill(vg);
-        // Left
-        p = nvgLinearGradient(vg, 0, 0, d, 0, edge, clear);
-        nvgBeginPath(vg); nvgRect(vg, 0, 0, d, fh);
-        nvgFillPaint(vg, p); nvgFill(vg);
-        // Right
-        p = nvgLinearGradient(vg, fw - d, 0, fw, 0, clear, edge);
-        nvgBeginPath(vg); nvgRect(vg, fw - d, 0, d, fh);
-        nvgFillPaint(vg, p); nvgFill(vg);
+        NVGpaint p = nvgBoxGradient(vg, d, d, fw - 2.f*d, fh - 2.f*d,
+                                    0.f, d, clear, edge);
+        nvgBeginPath(vg);
+        nvgRect(vg, 0, 0, fw, fh);
+        nvgFillPaint(vg, p);
+        nvgFill(vg);
+    }
+}
+
+void HudRenderer::fx_draw_vignette(NVGcontext* vg, float fw, float fh) const {
+    // Soft outer band: wide, gentle dark falloff from edges
+    {
+        constexpr float d = 200.f;
+        NVGpaint p = nvgBoxGradient(vg, d, d, fw - 2.f*d, fh - 2.f*d,
+                                    0.f, d, nvgRGBA(0,0,0,0), nvgRGBA(0,0,0,160));
+        nvgBeginPath(vg);
+        nvgRect(vg, 0, 0, fw, fh);
+        nvgFillPaint(vg, p);
+        nvgFill(vg);
+    }
+    // Hard inner ring: thin strip at the very edge for a clean border line
+    {
+        constexpr float d = 55.f;
+        NVGpaint p = nvgBoxGradient(vg, d, d, fw - 2.f*d, fh - 2.f*d,
+                                    0.f, d, nvgRGBA(0,0,0,0), nvgRGBA(0,0,0,220));
+        nvgBeginPath(vg);
+        nvgRect(vg, 0, 0, fw, fh);
+        nvgFillPaint(vg, p);
+        nvgFill(vg);
     }
 }
 
@@ -1939,6 +1955,9 @@ void HudRenderer::fx_update(NVGcontext* vg, const AppState& s,
         fx_draw_nebula_cloud(vg, fw, fh);
         fx_emit_nebula_edge(fw, fh, dt);
     }
+
+    if (effect == EffectType::DarkVignette)
+        fx_draw_vignette(vg, fw, fh);
 
     fx_draw(vg);
     fx_draw_lines(vg);

--- a/src/hud/hud_renderer.h
+++ b/src/hud/hud_renderer.h
@@ -200,6 +200,7 @@ private:
     void  fx_draw      (NVGcontext* vg) const;
     void  fx_draw_lines(NVGcontext* vg) const;
     void  fx_draw_nebula_cloud(NVGcontext* vg, float fw, float fh) const;
+    void  fx_draw_vignette    (NVGcontext* vg, float fw, float fh) const;
     void  fx_draw_alarm_pulse (NVGcontext* vg, const AppState& s, float fw, float fh);
 
     void  fx_emit_arm_glint    (float ax, float ay, float dx, float dy,

--- a/src/input/gpio_buttons.cpp
+++ b/src/input/gpio_buttons.cpp
@@ -14,9 +14,11 @@
 //   GPIOD_LINE_EVENT_*         → GPIOD_EDGE_EVENT_*
 
 GpioButtons::GpioButtons(int pin_left, int pin_right, int pin_aux,
-                         int af_trigger_ms, int pip_trigger_ms)
+                         int af_trigger_ms, int pip_trigger_ms,
+                         int capture_trigger_ms)
     : pin_left_(pin_left), pin_right_(pin_right), pin_aux_(pin_aux),
-      af_trigger_ms_(af_trigger_ms), pip_trigger_ms_(pip_trigger_ms) {}
+      af_trigger_ms_(af_trigger_ms), pip_trigger_ms_(pip_trigger_ms),
+      capture_trigger_ms_(capture_trigger_ms) {}
 
 GpioButtons::~GpioButtons() {
     shutdown();
@@ -153,12 +155,14 @@ void GpioButtons::handle_button_event(int pin, int state) {
             button_left_held_ = true;
             pip_left_threshold_reached_ = false;
         } else {
-            // Released
+            // Released — thresholds (highest first to avoid fall-through)
             auto hold_ms = get_left_hold_ms();
             button_left_held_ = false;
             pip_left_threshold_reached_ = false;
 
-            if (hold_ms >= af_trigger_ms_) {
+            if (hold_ms >= capture_trigger_ms_) {
+                if (capture_left_cb_) capture_left_cb_();
+            } else if (hold_ms >= af_trigger_ms_) {
                 if (af_left_cb_) af_left_cb_();
             } else {
                 pip_left_active_ = !pip_left_active_.load();
@@ -172,11 +176,14 @@ void GpioButtons::handle_button_event(int pin, int state) {
             button_right_held_ = true;
             pip_right_threshold_reached_ = false;
         } else {
+            // Released — thresholds (highest first)
             auto hold_ms = get_right_hold_ms();
             button_right_held_ = false;
             pip_right_threshold_reached_ = false;
 
-            if (hold_ms >= af_trigger_ms_) {
+            if (hold_ms >= capture_trigger_ms_) {
+                if (capture_right_cb_) capture_right_cb_();
+            } else if (hold_ms >= af_trigger_ms_) {
                 if (af_right_cb_) af_right_cb_();
             } else {
                 pip_right_active_ = !pip_right_active_.load();

--- a/src/input/gpio_buttons.h
+++ b/src/input/gpio_buttons.h
@@ -10,17 +10,21 @@ public:
     using ButtonCallback = std::function<void()>;
 
     GpioButtons(int pin_left, int pin_right, int pin_aux,
-                int af_trigger_ms = 1500, int pip_trigger_ms = 2000);
+                int af_trigger_ms      = 1500,
+                int pip_trigger_ms     = 2000,
+                int capture_trigger_ms = 5000);
     ~GpioButtons();
 
     bool init();
     void shutdown();
 
-    void on_af_left(ButtonCallback cb)   { af_left_cb_   = std::move(cb); }
-    void on_af_right(ButtonCallback cb)  { af_right_cb_  = std::move(cb); }
-    void on_pip_left(ButtonCallback cb)  { pip_left_cb_  = std::move(cb); }
-    void on_pip_right(ButtonCallback cb) { pip_right_cb_ = std::move(cb); }
-    void on_select(ButtonCallback cb)    { select_cb_    = std::move(cb); }
+    void on_af_left(ButtonCallback cb)       { af_left_cb_      = std::move(cb); }
+    void on_af_right(ButtonCallback cb)      { af_right_cb_     = std::move(cb); }
+    void on_pip_left(ButtonCallback cb)      { pip_left_cb_     = std::move(cb); }
+    void on_pip_right(ButtonCallback cb)     { pip_right_cb_    = std::move(cb); }
+    void on_select(ButtonCallback cb)        { select_cb_       = std::move(cb); }
+    void on_capture_left(ButtonCallback cb)  { capture_left_cb_ = std::move(cb); }
+    void on_capture_right(ButtonCallback cb) { capture_right_cb_= std::move(cb); }
 
     bool button_left_held()  const { return button_left_held_.load(); }
     bool button_right_held() const { return button_right_held_.load(); }
@@ -38,7 +42,7 @@ private:
     void handle_button_event(int pin, int state);
 
     int pin_left_, pin_right_, pin_aux_;
-    int af_trigger_ms_, pip_trigger_ms_;
+    int af_trigger_ms_, pip_trigger_ms_, capture_trigger_ms_;
 
     std::atomic<bool> running_ { false };
     std::thread poll_thread_;
@@ -58,4 +62,6 @@ private:
     ButtonCallback pip_left_cb_;
     ButtonCallback pip_right_cb_;
     ButtonCallback select_cb_;
+    ButtonCallback capture_left_cb_;
+    ButtonCallback capture_right_cb_;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1738,14 +1738,8 @@ static std::vector<MenuItem> build_menu(
         submenu("Bg Desaturate",  std::move(desat_menu)),
     };
 
-    std::vector<MenuItem> settings_menu = {
-        submenu("Headset",        std::move(headset_menu)),
-        submenu("Audio",          std::move(audio_menu)),
-        submenu("HUD",            std::move(hud_menu)),
-        submenu("Android Mirror", std::move(android_menu)),
-    };
-
-    cameras_menu.push_back(submenu("Vision Assist", std::move(vision_menu)));
+    cameras_menu.push_back(submenu("Android Mirror", std::move(android_menu)));
+    cameras_menu.push_back(submenu("Vision Assist",  std::move(vision_menu)));
 
     // ── LoRa menu ─────────────────────────────────────────────────────────────
 
@@ -1882,6 +1876,9 @@ static std::vector<MenuItem> build_menu(
     };
 
     std::vector<MenuItem> system_menu = {
+        submenu("Headset",          std::move(headset_menu)),
+        submenu("Audio",            std::move(audio_menu)),
+        submenu("Timers and Alarm", std::move(timers_alarm_menu)),
         toggle("System Panel",
             [sys_panel_active]{ return sys_panel_active && *sys_panel_active; },
             [sys_panel_active](bool v){ if (sys_panel_active) *sys_panel_active = v; }),
@@ -1901,17 +1898,16 @@ static std::vector<MenuItem> build_menu(
         leaf("Refresh Bluetooth", [bt_mon]{ if (bt_mon) bt_mon->refresh(); }),
         submenu("Software",   std::move(software_menu)),
         submenu("Demo Mode",  std::move(demo_menu)),
+        leaf("Request Status", [teensy]{ teensy->request_status(); }),
+        leaf("Close Program",  [&state]{ state.quit = true; }),
     };
 
     return {
-        submenu("Cameras",          std::move(cameras_menu)),
-        submenu("Prototracer",      std::move(prototracer_menu)),
-        submenu("Settings",         std::move(settings_menu)),
-        submenu("Timers and Alarm", std::move(timers_alarm_menu)),
-        submenu("LoRa",             std::move(lora_menu)),
-        submenu("System",           std::move(system_menu)),
-        leaf("Request Status",      [teensy]{ teensy->request_status(); }),
-        leaf("Close Program",       [&state]{ state.quit = true; }),
+        submenu("Vision",       std::move(cameras_menu)),
+        submenu("HUD",          std::move(hud_menu)),
+        submenu("Face Display", std::move(prototracer_menu)),
+        submenu("LoRa",         std::move(lora_menu)),
+        submenu("System",       std::move(system_menu)),
     };
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -497,8 +497,65 @@ static std::vector<MenuItem> build_menu(
         submenu("Colour Temp", std::move(wb_temp_menu)),
     };
 
+    // ── Digital zoom presets (both eyes together) ─────────────────────────────
+    struct ZoomPreset { const char* label; float zoom; };
+    static const ZoomPreset ZOOM_PRESETS[] = {
+        { "1.0× (Full)", 1.00f },
+        { "1.25×",       1.25f },
+        { "1.5×",        1.50f },
+        { "2.0×",        2.00f },
+        { "3.0×",        3.00f },
+    };
+
+    std::vector<MenuItem> zoom_level_menu;
+    for (const auto& z : ZOOM_PRESETS) {
+        zoom_level_menu.push_back(leaf_sel(
+            z.label,
+            [&state, zoom = z.zoom]{
+                state.zoom_left.zoom  = zoom;
+                state.zoom_right.zoom = zoom;
+            },
+            [&state, zoom = z.zoom]{ return state.zoom_left.zoom == zoom; }
+        ));
+    }
+
+    struct CropPreset { const char* label; float cx, cy; };
+    static const CropPreset CROP_PRESETS[] = {
+        { "Center",       0.5f, 0.5f },
+        { "Top",          0.5f, 0.25f },
+        { "Bottom",       0.5f, 0.75f },
+        { "Left",         0.25f, 0.5f },
+        { "Right",        0.75f, 0.5f },
+    };
+
+    std::vector<MenuItem> crop_center_menu;
+    for (const auto& c : CROP_PRESETS) {
+        crop_center_menu.push_back(leaf_sel(
+            c.label,
+            [&state, cx = c.cx, cy = c.cy]{
+                state.zoom_left.center_x  = cx;
+                state.zoom_left.center_y  = cy;
+                state.zoom_right.center_x = cx;
+                state.zoom_right.center_y = cy;
+            },
+            [&state, cx = c.cx, cy = c.cy]{
+                return state.zoom_left.center_x == cx && state.zoom_left.center_y == cy;
+            }
+        ));
+    }
+
+    std::vector<MenuItem> zoom_menu = {
+        submenu("Zoom Level",  std::move(zoom_level_menu)),
+        submenu("Crop Center", std::move(crop_center_menu)),
+        leaf("Reset Zoom", [&state]{
+            state.zoom_left  = ZoomCropState{};
+            state.zoom_right = ZoomCropState{};
+        }),
+    };
+
     std::vector<MenuItem> main_cameras_menu = {
         submenu("Resolution",  std::move(resolution_presets)),
+        submenu("Digital Zoom", std::move(zoom_menu)),
         submenu("Focus Mode",  std::move(focus_modes)),
         slider("Focus Position", 0.f, 1000.f, 50.f, "",
             [&state]{ return static_cast<float>(state.focus_left.focus_position); },
@@ -2791,6 +2848,8 @@ int main(int argc, char* argv[]) {
             snap.bt_devices         = state.bt_devices;
             snap.serial_metrics     = state.serial_metrics;
             snap.camera_resolution  = state.camera_resolution;
+            snap.zoom_left          = state.zoom_left;
+            snap.zoom_right         = state.zoom_right;
             snap.notifs             = state.notifs;
             memcpy(snap.lora_node_colors, state.lora_node_colors,
                    sizeof(state.lora_node_colors));
@@ -2869,7 +2928,8 @@ int main(int argc, char* argv[]) {
                 // For now: TODO: render tex_beast as fullscreen quad
                 drew = false;  // fallback to OWLsight below
             }
-            if (!drew) drew = cameras.draw_owl_left();
+            if (!drew) drew = cameras.draw_owl_left(
+                snap.zoom_left.zoom, snap.zoom_left.center_x, snap.zoom_left.center_y);
 
             xr.eye_left().unbind();
         }
@@ -2884,7 +2944,8 @@ int main(int argc, char* argv[]) {
             if (use_beast_cam && tex_beast != 0) {
                 drew = false;  // fallback to OWLsight below
             }
-            if (!drew) drew = cameras.draw_owl_right();
+            if (!drew) drew = cameras.draw_owl_right(
+                snap.zoom_right.zoom, snap.zoom_right.center_x, snap.zoom_right.center_y);
 
             xr.eye_right().unbind();
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -554,6 +554,9 @@ static std::vector<MenuItem> build_menu(
     };
 
     std::vector<MenuItem> main_cameras_menu = {
+        toggle("Theater Mode",
+            [&state]{ return state.theater_mode; },
+            [&state](bool v){ state.theater_mode = v; }),
         submenu("Resolution",  std::move(resolution_presets)),
         submenu("Digital Zoom", std::move(zoom_menu)),
         submenu("Focus Mode",  std::move(focus_modes)),
@@ -2846,6 +2849,7 @@ int main(int argc, char* argv[]) {
             snap.camera_resolution  = state.camera_resolution;
             snap.zoom_left          = state.zoom_left;
             snap.zoom_right         = state.zoom_right;
+            snap.theater_mode       = state.theater_mode;
             snap.notifs             = state.notifs;
             memcpy(snap.lora_node_colors, state.lora_node_colors,
                    sizeof(state.lora_node_colors));
@@ -2912,11 +2916,34 @@ int main(int argc, char* argv[]) {
         }
 
         // ── Render cameras into per-eye FBOs ──────────────────────────────────
+        // Theater mode: compute a letterbox/pillarbox sub-viewport that preserves
+        // the camera's native aspect ratio. Black bars are filled by glClear().
+        // When theater_mode is false the camera fills the entire FBO (legacy).
+        auto make_theater_vp = [&snap](int fw, int fh) -> std::array<int,4> {
+            float cam_ar  = (float)snap.camera_resolution.width
+                          / snap.camera_resolution.height;
+            float disp_ar = (float)fw / fh;
+            int vp_w, vp_h, vp_x, vp_y;
+            if (cam_ar < disp_ar) {        // pillarbox (bars left/right)
+                vp_h = fh; vp_w = (int)(fh * cam_ar);
+                vp_x = (fw - vp_w) / 2; vp_y = 0;
+            } else {                       // letterbox (bars top/bottom)
+                vp_w = fw; vp_h = (int)(fw / cam_ar);
+                vp_x = 0; vp_y = (fh - vp_h) / 2;
+            }
+            return { vp_x, vp_y, vp_w, vp_h };
+        };
+
         // Left eye
         {
             xr.eye_left().bind();
             glClearColor(0.f, 0.f, 0.f, 1.f);
             glClear(GL_COLOR_BUFFER_BIT);
+
+            if (snap.theater_mode) {
+                auto vp = make_theater_vp(xr.eye_left().w, xr.eye_left().h);
+                glViewport(vp[0], vp[1], vp[2], vp[3]);
+            }
 
             bool drew = false;
             if (use_beast_cam && tex_beast != 0) {
@@ -2927,6 +2954,9 @@ int main(int argc, char* argv[]) {
             if (!drew) drew = cameras.draw_owl_left(
                 snap.zoom_left.zoom, snap.zoom_left.center_x, snap.zoom_left.center_y);
 
+            if (snap.theater_mode)
+                glViewport(0, 0, xr.eye_left().w, xr.eye_left().h);
+
             xr.eye_left().unbind();
         }
 
@@ -2936,12 +2966,20 @@ int main(int argc, char* argv[]) {
             glClearColor(0.f, 0.f, 0.f, 1.f);
             glClear(GL_COLOR_BUFFER_BIT);
 
+            if (snap.theater_mode) {
+                auto vp = make_theater_vp(xr.eye_right().w, xr.eye_right().h);
+                glViewport(vp[0], vp[1], vp[2], vp[3]);
+            }
+
             bool drew = false;
             if (use_beast_cam && tex_beast != 0) {
                 drew = false;  // fallback to OWLsight below
             }
             if (!drew) drew = cameras.draw_owl_right(
                 snap.zoom_right.zoom, snap.zoom_right.center_x, snap.zoom_right.center_y);
+
+            if (snap.theater_mode)
+                glViewport(0, 0, xr.eye_right().w, xr.eye_right().h);
 
             xr.eye_right().unbind();
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1420,6 +1420,8 @@ static std::vector<MenuItem> build_menu(
                                        [&state]{ return state.effects_cfg.effect == EffectType::CompassTurbulence;  }),
         leaf_sel("Nebula Edge",        [&state]{ state.effects_cfg.effect = EffectType::NebulaEdge;         },
                                        [&state]{ return state.effects_cfg.effect == EffectType::NebulaEdge;         }),
+        leaf_sel("Dark Vignette",      [&state]{ state.effects_cfg.effect = EffectType::DarkVignette;       },
+                                       [&state]{ return state.effects_cfg.effect == EffectType::DarkVignette;       }),
         submenu("Color Palette", std::move(fx_palette_menu)),
     };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -35,6 +35,7 @@
 #include "net/ping_monitor.h"
 #include "net/bt_monitor.h"
 #include "crash_reporter.h"
+#include "capture.h"
 #include "splash.h"
 
 #ifndef GIT_HASH
@@ -558,6 +559,9 @@ static std::vector<MenuItem> build_menu(
             [&state]{ return state.theater_mode; },
             [&state](bool v){ state.theater_mode = v; }),
         submenu("Resolution",  std::move(resolution_presets)),
+        leaf("Capture Left",   [&state]{ std::lock_guard lk(state.mtx); state.capture_request = CaptureRequest::Left;   }),
+        leaf("Capture Right",  [&state]{ std::lock_guard lk(state.mtx); state.capture_request = CaptureRequest::Right;  }),
+        leaf("Capture Stereo", [&state]{ std::lock_guard lk(state.mtx); state.capture_request = CaptureRequest::Stereo; }),
         submenu("Digital Zoom", std::move(zoom_menu)),
         submenu("Focus Mode",  std::move(focus_modes)),
         slider("Focus Position", 0.f, 1000.f, 50.f, "",
@@ -2213,12 +2217,14 @@ int main(int argc, char* argv[]) {
     std::string cfg_ping_host  = "8.8.8.8";
     std::string cfg_wifi_iface = "wlan0";
     std::string cfg_crash_dir  = "/tmp";
+    std::string cfg_photo_dir  = "/home/user/Pictures/protohud";
     int         cfg_ssh_port   = 22;
     if (cfg.contains("system")) {
         auto& js         = cfg["system"];
         cfg_ping_host    = js.value("ping_host",  cfg_ping_host);
         cfg_wifi_iface   = js.value("wifi_iface", cfg_wifi_iface);
         cfg_crash_dir    = js.value("crash_dir",  cfg_crash_dir);
+        cfg_photo_dir    = js.value("photo_dir",  cfg_photo_dir);
         cfg_ssh_port     = js.value("ssh_port",   cfg_ssh_port);
     }
     state.ssh.port = cfg_ssh_port;
@@ -2580,10 +2586,12 @@ int main(int argc, char* argv[]) {
     int button_1_gpio   = jval(cfg.contains("gpio") ? cfg["gpio"] : empty, "button_1_gpio",     17);
     int button_2_gpio   = jval(cfg.contains("gpio") ? cfg["gpio"] : empty, "button_2_gpio",     27);
     int button_3_gpio   = jval(cfg.contains("gpio") ? cfg["gpio"] : empty, "button_3_gpio",     22);
-    int af_trigger_ms   = jval(cfg.contains("gpio") ? cfg["gpio"] : empty, "af_trigger_time_ms", 1500);
-    int pip_trigger_ms  = jval(cfg.contains("gpio") ? cfg["gpio"] : empty, "pip_trigger_time_ms",2000);
+    int af_trigger_ms      = jval(cfg.contains("gpio") ? cfg["gpio"] : empty, "af_trigger_time_ms",      1500);
+    int pip_trigger_ms     = jval(cfg.contains("gpio") ? cfg["gpio"] : empty, "pip_trigger_time_ms",     2000);
+    int capture_trigger_ms = jval(cfg.contains("gpio") ? cfg["gpio"] : empty, "capture_trigger_time_ms", 5000);
 
-    GpioButtons buttons(button_1_gpio, button_2_gpio, button_3_gpio, af_trigger_ms, pip_trigger_ms);
+    GpioButtons buttons(button_1_gpio, button_2_gpio, button_3_gpio,
+                        af_trigger_ms, pip_trigger_ms, capture_trigger_ms);
     bool pip_left_active  = false, pip_right_active  = false;  // GPIO-driven
     bool kb_pip_left      = false, kb_pip_right      = false;  // keyboard-driven
 
@@ -2599,6 +2607,16 @@ int main(int argc, char* argv[]) {
             buttons.on_af_right([&cameras]() {
                 std::cout << "[gpio] AF right\n";
                 if (cameras.owl_right()) cameras.owl_right()->start_autofocus();
+            });
+            buttons.on_capture_left([&state]() {
+                std::cout << "[gpio] capture left\n";
+                std::lock_guard lk(state.mtx);
+                state.capture_request = CaptureRequest::Left;
+            });
+            buttons.on_capture_right([&state]() {
+                std::cout << "[gpio] capture right\n";
+                std::lock_guard lk(state.mtx);
+                state.capture_request = CaptureRequest::Right;
             });
             buttons.on_pip_left ([&pip_left_active] () { pip_left_active  = true; });
             buttons.on_pip_right([&pip_right_active]() { pip_right_active = true; });
@@ -2850,6 +2868,7 @@ int main(int argc, char* argv[]) {
             snap.zoom_left          = state.zoom_left;
             snap.zoom_right         = state.zoom_right;
             snap.theater_mode       = state.theater_mode;
+            snap.capture_request    = state.capture_request;
             snap.notifs             = state.notifs;
             memcpy(snap.lora_node_colors, state.lora_node_colors,
                    sizeof(state.lora_node_colors));
@@ -3009,6 +3028,11 @@ int main(int argc, char* argv[]) {
             left_src  = pp_fbo_left.tex;
             right_src = pp_fbo_right.tex;
         }
+
+        // ── Photo capture ─────────────────────────────────────────────────────
+        // Reads directly from the camera eye FBOs (no HUD). Async PNG write.
+        if (snap.capture_request != CaptureRequest::None)
+            do_capture(snap.capture_request, xr, cfg_photo_dir, state);
 
         // ── Composite or timewarp ─────────────────────────────────────────────
         ImuPose current_pose = xr.get_latest_imu_pose();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -36,6 +36,7 @@
 #include "net/bt_monitor.h"
 #include "crash_reporter.h"
 #include "capture.h"
+#include "qr_scanner.h"
 #include "splash.h"
 
 #ifndef GIT_HASH
@@ -562,6 +563,10 @@ static std::vector<MenuItem> build_menu(
         leaf("Capture Left",   [&state]{ std::lock_guard lk(state.mtx); state.capture_request = CaptureRequest::Left;   }),
         leaf("Capture Right",  [&state]{ std::lock_guard lk(state.mtx); state.capture_request = CaptureRequest::Right;  }),
         leaf("Capture Stereo", [&state]{ std::lock_guard lk(state.mtx); state.capture_request = CaptureRequest::Stereo; }),
+        toggle("QR Scan Main Cams", [&state]{ return state.qr_scan_main; },
+                                    [&state](bool v){ state.qr_scan_main = v; }),
+        toggle("QR Scan USB Cams",  [&state]{ return state.qr_scan_usb; },
+                                    [&state](bool v){ state.qr_scan_usb = v; }),
         submenu("Digital Zoom", std::move(zoom_menu)),
         submenu("Focus Mode",  std::move(focus_modes)),
         slider("Focus Position", 0.f, 1000.f, 50.f, "",
@@ -2471,6 +2476,19 @@ int main(int argc, char* argv[]) {
 
     if (!teensy.start()) std::cerr << "[main] Teensy not available on " << teensy_port << "\n";
     protoface_ctrl.start();   // connects async; no-op if socket absent
+
+    // QR / barcode scanner — active when either scan toggle is enabled.
+    QrScanner qr_scanner;
+    qr_scanner.set_callback([&state](const std::string& text, const std::string& type) {
+        Notification n;
+        n.type          = NotifType::App;
+        n.title         = type + " Detected";
+        n.body          = text;
+        n.auto_dismiss_s = 12.f;
+        std::lock_guard lk(state.mtx);
+        state.notifs.push(std::move(n));
+    });
+    cameras.set_qr_scanner(&qr_scanner);
     if (!lora.start())   std::cerr << "[main] LoRa not available on "   << lora_port   << "\n";
     if (!knob.start())   std::cerr << "[main] SmartKnob not available on " << knob_port << "\n";
 
@@ -2871,6 +2889,8 @@ int main(int argc, char* argv[]) {
             snap.zoom_right         = state.zoom_right;
             snap.theater_mode       = state.theater_mode;
             snap.capture_request    = state.capture_request;
+            snap.qr_scan_main       = state.qr_scan_main;
+            snap.qr_scan_usb        = state.qr_scan_usb;
             snap.notifs             = state.notifs;
             memcpy(snap.lora_node_colors, state.lora_node_colors,
                    sizeof(state.lora_node_colors));
@@ -3035,6 +3055,25 @@ int main(int argc, char* argv[]) {
         // Reads directly from the camera eye FBOs (no HUD). Async PNG write.
         if (snap.capture_request != CaptureRequest::None)
             do_capture(snap.capture_request, xr, cfg_photo_dir, state);
+
+        // ── QR scan — main cameras ────────────────────────────────────────────
+        // Periodic glReadPixels from the left eye FBO (rate-limited to 2 Hz by
+        // the timer below; ZBar's own interval also guards the worker thread).
+        cameras.enable_qr_usb(snap.qr_scan_usb);
+        if (snap.qr_scan_main) {
+            static auto s_last_qr = std::chrono::steady_clock::now();
+            auto now_qr = std::chrono::steady_clock::now();
+            if (std::chrono::duration_cast<std::chrono::milliseconds>(
+                    now_qr - s_last_qr).count() >= 500) {
+                s_last_qr = now_qr;
+                const int qw = xr.eye_left().w, qh = xr.eye_left().h;
+                std::vector<uint8_t> px(static_cast<size_t>(qw * qh * 4));
+                xr.eye_left().bind();
+                glReadPixels(0, 0, qw, qh, GL_RGBA, GL_UNSIGNED_BYTE, px.data());
+                xr.eye_left().unbind();
+                qr_scanner.submit_rgba(px.data(), qw, qh);
+            }
+        }
 
         // ── Composite or timewarp ─────────────────────────────────────────────
         ImuPose current_pose = xr.get_latest_imu_pose();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2919,6 +2919,15 @@ int main(int argc, char* argv[]) {
         // Theater mode: compute a letterbox/pillarbox sub-viewport that preserves
         // the camera's native aspect ratio. Black bars are filled by glClear().
         // When theater_mode is false the camera fills the entire FBO (legacy).
+        //
+        // TODO (USB layout): when placing USB camera feeds in the black region,
+        // shift the main feed flush to the opposite edge so all empty space
+        // is a single contiguous rectangle (e.g. pillarbox → main feed flush
+        // left, one wide black column on the right; letterbox → main feed flush
+        // top, one tall black strip at the bottom). That gives a clean
+        // rectangular region to fill with the USB feed rather than two thin
+        // split bars. vp_x / vp_y below should be set to 0 (or 0, fh-vp_h
+        // respectively) instead of the centered offset.
         auto make_theater_vp = [&snap](int fw, int fh) -> std::array<int,4> {
             float cam_ar  = (float)snap.camera_resolution.width
                           / snap.camera_resolution.height;

--- a/src/qr_scanner.cpp
+++ b/src/qr_scanner.cpp
@@ -1,0 +1,106 @@
+#ifdef HAVE_ZBAR
+
+#include "qr_scanner.h"
+#include <zbar.h>
+#include <algorithm>
+#include <chrono>
+
+using clock_t2 = std::chrono::steady_clock;
+
+QrScanner::QrScanner() {
+    running_ = true;
+    thread_  = std::thread(&QrScanner::worker, this);
+}
+
+QrScanner::~QrScanner() {
+    {
+        std::lock_guard lk(mtx_);
+        running_ = false;
+    }
+    cv_.notify_one();
+    if (thread_.joinable()) thread_.join();
+}
+
+void QrScanner::set_callback(Callback cb)       { callback_         = std::move(cb); }
+void QrScanner::set_scan_interval_ms(int ms)    { scan_interval_ms_ = ms; }
+void QrScanner::set_cooldown_ms(int ms)         { cooldown_ms_      = ms; }
+
+void QrScanner::submit_rgba(const uint8_t* rgba, int w, int h) {
+    // Luma (BT.601): Y = 0.299R + 0.587G + 0.114B  (integer: *77 *150 *29 >> 8)
+    std::vector<uint8_t> gray(static_cast<size_t>(w * h));
+    for (int i = 0; i < w * h; ++i) {
+        const uint8_t* p = rgba + i * 4;
+        gray[i] = static_cast<uint8_t>((p[0] * 77 + p[1] * 150 + p[2] * 29) >> 8);
+    }
+    submit_gray(std::move(gray), w, h);
+}
+
+void QrScanner::submit_gray(std::vector<uint8_t> gray, int w, int h) {
+    // Rate limit on the calling thread — cheap check before acquiring any lock.
+    auto now     = clock_t2::now();
+    auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+                       now - last_submit_).count();
+    if (elapsed < scan_interval_ms_) return;
+    last_submit_ = now;
+
+    {
+        std::lock_guard lk(mtx_);
+        pending_     = { std::move(gray), w, h };
+        has_pending_ = true;
+    }
+    cv_.notify_one();
+}
+
+void QrScanner::worker() {
+    zbar_image_scanner_t* scanner = zbar_image_scanner_create();
+    // Enable all symbologies; restrict to QR + Code128 for a common use-case.
+    zbar_image_scanner_set_config(scanner, ZBAR_NONE,    ZBAR_CFG_ENABLE, 0);
+    zbar_image_scanner_set_config(scanner, ZBAR_QRCODE,  ZBAR_CFG_ENABLE, 1);
+    zbar_image_scanner_set_config(scanner, ZBAR_CODE128, ZBAR_CFG_ENABLE, 1);
+    zbar_image_scanner_set_config(scanner, ZBAR_EAN13,   ZBAR_CFG_ENABLE, 1);
+
+    while (true) {
+        Frame frame;
+        {
+            std::unique_lock lk(mtx_);
+            cv_.wait(lk, [this] { return has_pending_ || !running_; });
+            if (!running_) break;
+            frame       = std::move(pending_);
+            has_pending_ = false;
+        }
+
+        zbar_image_t* img = zbar_image_create();
+        // GREY fourcc: little-endian 'G','R','E','Y'
+        zbar_image_set_format(img, 0x59455247UL);
+        zbar_image_set_size(img, static_cast<unsigned>(frame.w),
+                                 static_cast<unsigned>(frame.h));
+        // ZBar does not own the data; we keep frame.gray alive until destroy.
+        zbar_image_set_data(img, frame.gray.data(), frame.gray.size(), nullptr);
+
+        if (zbar_scan_image(scanner, img) > 0) {
+            const zbar_symbol_t* sym = zbar_image_first_symbol(img);
+            while (sym) {
+                std::string text = zbar_symbol_get_data(sym);
+                std::string type = zbar_get_symbol_name(zbar_symbol_get_type(sym));
+
+                auto now2      = clock_t2::now();
+                auto since     = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                     now2 - last_found_).count();
+                bool duplicate = (text == last_result_) && (since < cooldown_ms_);
+
+                if (!duplicate) {
+                    last_result_ = text;
+                    last_found_  = now2;
+                    if (callback_) callback_(text, type);
+                }
+                sym = zbar_symbol_next(sym);
+            }
+        }
+
+        zbar_image_destroy(img);
+    }
+
+    zbar_image_scanner_destroy(scanner);
+}
+
+#endif // HAVE_ZBAR

--- a/src/qr_scanner.h
+++ b/src/qr_scanner.h
@@ -1,0 +1,73 @@
+#pragma once
+#include <functional>
+#include <string>
+#include <vector>
+
+#ifdef HAVE_ZBAR
+#include <atomic>
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+
+// Async QR/barcode scanner backed by a single ZBar worker thread.
+//
+// submit_gray() and submit_rgba() are thread-safe and return immediately.
+// Internally rate-limited: frames submitted faster than scan_interval_ms
+// are silently dropped, so callers can submit every frame without overhead.
+// Duplicate results are suppressed for cooldown_ms after the last decode.
+//
+// Call set_callback() before submit_*() — callback fires on the worker thread.
+class QrScanner {
+public:
+    // (text, symbol_type_name) e.g. ("https://...", "QR-Code")
+    using Callback = std::function<void(const std::string& text,
+                                        const std::string& type)>;
+
+    QrScanner();
+    ~QrScanner();
+
+    void set_callback(Callback cb);
+    void set_scan_interval_ms(int ms);   // min ms between scans, default 500
+    void set_cooldown_ms(int ms);        // suppress same result, default 5000
+
+    // Submit a single-channel grayscale frame. Rate-limited; excess ignored.
+    void submit_gray(std::vector<uint8_t> gray, int w, int h);
+
+    // Convenience: converts RGBA (4 ch) to gray then calls submit_gray.
+    void submit_rgba(const uint8_t* rgba, int w, int h);
+
+private:
+    void worker();
+
+    struct Frame { std::vector<uint8_t> gray; int w = 0, h = 0; };
+
+    Callback   callback_;
+    int        scan_interval_ms_ = 500;
+    int        cooldown_ms_      = 5000;
+
+    std::mutex              mtx_;
+    std::condition_variable cv_;
+    bool                    has_pending_ = false;
+    Frame                   pending_;
+    bool                    running_     = false;
+    std::thread             thread_;
+
+    std::chrono::steady_clock::time_point last_submit_{};
+    std::chrono::steady_clock::time_point last_found_{};
+    std::string                            last_result_;
+};
+
+#else // !HAVE_ZBAR
+
+// No-op stub when ZBar is not installed.
+class QrScanner {
+public:
+    using Callback = std::function<void(const std::string&, const std::string&)>;
+    void set_callback(Callback)         {}
+    void set_scan_interval_ms(int)      {}
+    void set_cooldown_ms(int)           {}
+    void submit_gray(std::vector<uint8_t>, int, int) {}
+    void submit_rgba(const uint8_t*, int, int)       {}
+};
+
+#endif // HAVE_ZBAR


### PR DESCRIPTION
## Summary

- Adds per-eye digital zoom via UV-space crop in the NV12 vertex shader (`u_zoom` + `u_center` uniforms)
- `ZoomCropState` struct in `app_state.h` holds `zoom`, `center_x`, `center_y`; defaults are identity (zoom=1.0, center=0.5/0.5)
- `DmaCamera::draw(zoom, cx, cy)` applies uniforms each frame; zoom clamped to [1.0, 8.0] to prevent degenerate UVs
- Architecture ready for Option B (libcamera `ScalerCrop`) — same `ZoomCropState` values can be forwarded to `apply_pending_controls()` when needed

## Menu path

**Cameras → Main Cameras → Digital Zoom**
- **Zoom Level**: 1.0× / 1.25× / 1.5× / 2.0× / 3.0× (radio-select, both eyes together)
- **Crop Center**: Center / Top / Bottom / Left / Right presets
- **Reset Zoom**: returns both eyes to identity

## Test plan

- [ ] Build clean: `cmake --build build`
- [ ] At zoom=1.0, image is unchanged (identity UV transform)
- [ ] At zoom=2.0, image is cropped to center 50% — objects appear 2× larger
- [ ] Crop Center presets shift the crop window in the expected direction
- [ ] Reset Zoom returns to full-frame view
- [ ] Left and right eyes track the same zoom level simultaneously
- [ ] Menu navigation still works normally after zoom changes

https://claude.ai/code/session_017xAaFHoiBHVqGLxVhohcAh

---
_Generated by [Claude Code](https://claude.ai/code/session_017xAaFHoiBHVqGLxVhohcAh)_