### PR TITLE
Add map overlay feature (load floor plan / venue map onto HUD)

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -220,7 +220,9 @@
     "ping_host":  "8.8.8.8",
     "wifi_iface": "wlan0",
     "ssh_port":   22,
-    "crash_dir":  "/tmp"
+    "crash_dir":  "/tmp",
+    "photo_dir":  "/home/user/Pictures/protohud",
+    "map_dir":    "/home/user/Pictures/protohud/maps"
   },
   "splash": {
     "enabled":       true,

--- a/src/app_state.h
+++ b/src/app_state.h
@@ -178,6 +178,23 @@ struct ImuPose {
     float yaw   = 0.0f;
 };
 
+// ── Map overlay ───────────────────────────────────────────────────────────────
+
+struct MapOverlayConfig {
+    bool        enabled             = false;
+    std::string map_path;            // full filesystem path to loaded image
+    float       anchor_x            = 0.5f;   // screen fraction (centre by default)
+    float       anchor_y            = 0.5f;
+    float       size_px             = 300.f;  // half-width of the displayed map in pixels
+    float       opacity             = 0.80f;
+    float       pan_x               = 0.f;    // pixel offset from anchor
+    float       pan_y               = 0.f;
+    float       map_north_deg       = 0.f;    // compass_heading saved at calibration
+    bool        calibrated          = false;
+    bool        rotate_with_heading = true;
+    float       image_rotate_deg    = 0.f;    // manual image rotation offset (degrees)
+};
+
 // ── Particle effects ──────────────────────────────────────────────────────────
 
 enum class EffectType : uint8_t {
@@ -363,6 +380,9 @@ struct AppState {
 
     // Particle effects config (render-thread only)
     EffectsConfig        effects_cfg;
+
+    // Map overlay config (render-thread owned; menu writes while holding mtx)
+    MapOverlayConfig     map_overlay;
 
     // Per-LoRa-node compass marker colors (indexed by node.local_id % 8)
     ImU32 lora_node_colors[8] = {

--- a/src/hud/hud_renderer.cpp
+++ b/src/hud/hud_renderer.cpp
@@ -221,6 +221,7 @@ void HudRenderer::load(void* glfw_window) {
 
 void HudRenderer::unload() {
     if (!ctx_) return;
+    if (nvg_ && map_img_ >= 0) { nvgDeleteImage(nvg_, map_img_); map_img_ = -1; }
     if (nvg_) { nvgDeleteGLES2(nvg_); nvg_ = nullptr; }
     ImGui::SetCurrentContext(ctx_);
     ImGui_ImplOpenGL3_Shutdown();
@@ -281,6 +282,7 @@ void HudRenderer::draw_hud_frame(const AppState& s, int w, int h, bool show_fps)
 
     nvgBeginFrame(nvg_, fw, fh, 1.0f);
 
+    draw_map_overlay(nvg_, s, fw, fh);
     fx_update(nvg_, s, fw, fh, frame_dt_);
 
     if (!s.lora_messages.empty()) {
@@ -335,6 +337,72 @@ void HudRenderer::draw_fps_overlay(const AppState& snap, int w, int h, bool acti
     nvgEndFrame(nvg_);
     glDisable(GL_STENCIL_TEST);
     glStencilMask(0xFF);
+}
+
+void HudRenderer::draw_map_overlay(NVGcontext* vg, const AppState& s, float fw, float fh) {
+    const auto& cfg = s.map_overlay;
+    if (!cfg.enabled) return;
+
+    // Reload image on render thread when path changes
+    if (cfg.map_path != map_img_path_) {
+        if (map_img_ >= 0) { nvgDeleteImage(vg, map_img_); map_img_ = -1; }
+        map_img_path_.clear();
+        if (!cfg.map_path.empty()) {
+            map_img_ = nvgCreateImage(vg, cfg.map_path.c_str(), 0);
+            if (map_img_ >= 0) {
+                nvgImageSize(vg, map_img_, &map_img_w_, &map_img_h_);
+                map_img_path_ = cfg.map_path;
+            }
+        }
+    }
+    if (map_img_ < 0) return;
+
+    const float cx     = fw * cfg.anchor_x + cfg.pan_x;
+    const float cy     = fh * cfg.anchor_y + cfg.pan_y;
+    const float half   = cfg.size_px;
+    const float aspect = (map_img_h_ > 0 && map_img_w_ > 0)
+                         ? (float)map_img_h_ / (float)map_img_w_ : 1.f;
+    const float hw     = half;
+    const float hh     = half * aspect;
+
+    nvgSave(vg);
+    nvgTranslate(vg, cx, cy);
+
+    // Manual image rotation (corrects map orientation) applied first
+    if (cfg.image_rotate_deg != 0.f)
+        nvgRotate(vg, cfg.image_rotate_deg * (float)M_PI / 180.f);
+
+    // Heading-up rotation: map counter-rotates as wearer turns
+    if (cfg.rotate_with_heading && cfg.calibrated)
+        nvgRotate(vg, (s.compass_heading - cfg.map_north_deg) * (float)M_PI / 180.f);
+
+    // Clip to square display window to hide rotated corners
+    nvgScissor(vg, -half, -half, half * 2.f, half * 2.f);
+
+    NVGpaint img = nvgImagePattern(vg, -hw, -hh, hw * 2.f, hh * 2.f, 0.f, map_img_, cfg.opacity);
+    nvgBeginPath(vg);
+    nvgRect(vg, -hw, -hh, hw * 2.f, hh * 2.f);
+    nvgFillPaint(vg, img);
+    nvgFill(vg);
+
+    nvgResetScissor(vg);
+
+    // Subtle border around the overlay
+    nvgBeginPath(vg);
+    nvgRect(vg, -half, -half, half * 2.f, half * 2.f);
+    nvgStrokeColor(vg, nvgRGBA(100, 130, 160, 160));
+    nvgStrokeWidth(vg, 1.5f);
+    nvgStroke(vg);
+
+    // Red crosshair at centre = wearer's position on the map
+    nvgBeginPath(vg);
+    nvgMoveTo(vg, -9.f, 0.f); nvgLineTo(vg, 9.f, 0.f);
+    nvgMoveTo(vg, 0.f, -9.f); nvgLineTo(vg, 0.f, 9.f);
+    nvgStrokeColor(vg, nvgRGBA(255, 70, 70, 220));
+    nvgStrokeWidth(vg, 1.5f);
+    nvgStroke(vg);
+
+    nvgRestore(vg);
 }
 
 void HudRenderer::draw_fps_nvg(NVGcontext* vg, const AppState& snap, float fw, float fh) {

--- a/src/hud/hud_renderer.h
+++ b/src/hud/hud_renderer.h
@@ -156,6 +156,7 @@ private:
     void draw_timer_alarm_indicator(NVGcontext* vg, const AppState& s,
                             float fw, float fh);
     void draw_fps_nvg      (NVGcontext* vg, const AppState& snap, float fw, float fh);
+    void draw_map_overlay  (NVGcontext* vg, const AppState& s, float fw, float fh);
 
     // ── ImGui popup draw methods (stay in ImGui pass) ─────────────────────────
     static const char* cardinal_str(float deg);
@@ -215,6 +216,12 @@ private:
                     float fw, float fh, float dt);
 
     ToastRenderer toast_renderer_;
+
+    // Map overlay image state (render-thread only)
+    int         map_img_      = -1;
+    int         map_img_w_    = 0;
+    int         map_img_h_    = 0;
+    std::string map_img_path_;
 
     HudConfig     cfg_;
     HudColors     col_;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -205,7 +205,8 @@ static std::vector<MenuItem> build_menu(
         IFaceController*  teensy_option   = nullptr,
         IFaceController*  fp_option       = nullptr,
         // Panel preview toggle (Protoface shm → ProtoHUD ImGui window)
-        bool*             panel_preview_pp = nullptr)
+        bool*             panel_preview_pp = nullptr,
+        std::string       map_dir         = "/home/user/Pictures/protohud/maps")
 {
     (void)lora; (void)knob;
 
@@ -1588,6 +1589,86 @@ static std::vector<MenuItem> build_menu(
             [menu_sys_pp]{ return (*menu_sys_pp)->anchor() == MenuAnchor::BottomRight; }),
     };
 
+    // ── Map Overlay ───────────────────────────────────────────────────────────
+    // Scan map directory for PNG/JPG files at menu-build time.
+    auto scan_map_dir = [](const std::string& dir) {
+        std::vector<std::string> paths;
+        std::error_code ec;
+        for (auto& e : std::filesystem::directory_iterator(dir, ec)) {
+            auto ext = e.path().extension().string();
+            if (ext == ".png" || ext == ".jpg" || ext == ".jpeg" ||
+                ext == ".PNG" || ext == ".JPG" || ext == ".JPEG")
+                paths.push_back(e.path().string());
+        }
+        std::sort(paths.begin(), paths.end());
+        return paths;
+    };
+    auto map_files = scan_map_dir(map_dir);
+
+    std::vector<MenuItem> map_select_items;
+    for (auto& path : map_files) {
+        std::string name = std::filesystem::path(path).stem().string();
+        map_select_items.push_back(
+            leaf_sel(name,
+                [&state, path]{ std::lock_guard<std::mutex> lk(state.mtx); state.map_overlay.map_path = path; },
+                [&state, path]{ return state.map_overlay.map_path == path; }));
+    }
+    if (map_select_items.empty())
+        map_select_items.push_back(leaf("(no maps in " + map_dir + ")", []{}));
+
+    std::vector<MenuItem> map_pan_menu = {
+        leaf("Left  -20px",  [&state]{ state.map_overlay.pan_x -= 20.f; }),
+        leaf("Right +20px",  [&state]{ state.map_overlay.pan_x += 20.f; }),
+        leaf("Up    -20px",  [&state]{ state.map_overlay.pan_y -= 20.f; }),
+        leaf("Down  +20px",  [&state]{ state.map_overlay.pan_y += 20.f; }),
+        leaf("Reset Pan",    [&state]{ state.map_overlay.pan_x = 0.f; state.map_overlay.pan_y = 0.f; }),
+    };
+
+    std::vector<MenuItem> map_rotate_menu = {
+        leaf("CCW  -90°",       [&state]{ state.map_overlay.image_rotate_deg -= 90.f; }),
+        leaf("CCW  -45°",       [&state]{ state.map_overlay.image_rotate_deg -= 45.f; }),
+        leaf("CCW  -15°",       [&state]{ state.map_overlay.image_rotate_deg -= 15.f; }),
+        leaf("CCW   -5°",       [&state]{ state.map_overlay.image_rotate_deg -=  5.f; }),
+        leaf("CW    +5°",       [&state]{ state.map_overlay.image_rotate_deg +=  5.f; }),
+        leaf("CW   +15°",       [&state]{ state.map_overlay.image_rotate_deg += 15.f; }),
+        leaf("CW   +45°",       [&state]{ state.map_overlay.image_rotate_deg += 45.f; }),
+        leaf("CW   +90°",       [&state]{ state.map_overlay.image_rotate_deg += 90.f; }),
+        leaf("Reset Rotation",  [&state]{ state.map_overlay.image_rotate_deg =  0.f; }),
+    };
+
+    std::vector<MenuItem> map_opacity_menu = {
+        leaf_sel("25%",  [&state]{ state.map_overlay.opacity = 0.25f; }, [&state]{ return state.map_overlay.opacity == 0.25f; }),
+        leaf_sel("50%",  [&state]{ state.map_overlay.opacity = 0.50f; }, [&state]{ return state.map_overlay.opacity == 0.50f; }),
+        leaf_sel("75%",  [&state]{ state.map_overlay.opacity = 0.75f; }, [&state]{ return state.map_overlay.opacity == 0.75f; }),
+        leaf_sel("100%", [&state]{ state.map_overlay.opacity = 1.00f; }, [&state]{ return state.map_overlay.opacity == 1.00f; }),
+    };
+
+    std::vector<MenuItem> map_size_menu = {
+        leaf_sel("Small  (200px)", [&state]{ state.map_overlay.size_px = 200.f; }, [&state]{ return state.map_overlay.size_px == 200.f; }),
+        leaf_sel("Medium (300px)", [&state]{ state.map_overlay.size_px = 300.f; }, [&state]{ return state.map_overlay.size_px == 300.f; }),
+        leaf_sel("Large  (450px)", [&state]{ state.map_overlay.size_px = 450.f; }, [&state]{ return state.map_overlay.size_px == 450.f; }),
+        leaf_sel("Full   (600px)", [&state]{ state.map_overlay.size_px = 600.f; }, [&state]{ return state.map_overlay.size_px == 600.f; }),
+    };
+
+    std::vector<MenuItem> map_overlay_menu = {
+        toggle("Enabled",
+            [&state]{ return state.map_overlay.enabled; },
+            [&state](bool v){ state.map_overlay.enabled = v; }),
+        submenu("Select Map",           std::move(map_select_items)),
+        submenu("Rotate Image",         std::move(map_rotate_menu)),
+        submenu("Pan",                  std::move(map_pan_menu)),
+        toggle("Rotate with Heading",
+            [&state]{ return state.map_overlay.rotate_with_heading; },
+            [&state](bool v){ state.map_overlay.rotate_with_heading = v; }),
+        leaf("Set My Direction", [&state]{
+            std::lock_guard<std::mutex> lk(state.mtx);
+            state.map_overlay.map_north_deg = state.compass_heading;
+            state.map_overlay.calibrated    = true;
+        }),
+        submenu("Opacity",              std::move(map_opacity_menu)),
+        submenu("Size",                 std::move(map_size_menu)),
+    };
+
     std::vector<MenuItem> hud_menu = {
         toggle("Flip to Top",
             [hud_cfg]{ return hud_cfg->hud_flip_vertical; },
@@ -1599,6 +1680,7 @@ static std::vector<MenuItem> build_menu(
         submenu("Clock",         std::move(clock_menu)),
         submenu("Color",         std::move(color_options_menu)),
         submenu("Menu Position", std::move(menu_position_menu)),
+        submenu("Map Overlay",   std::move(map_overlay_menu)),
     };
 
     // ── Vision Assist (post-processing depth cues) ────────────────────────────
@@ -2225,6 +2307,7 @@ int main(int argc, char* argv[]) {
     std::string cfg_wifi_iface = "wlan0";
     std::string cfg_crash_dir  = "/tmp";
     std::string cfg_photo_dir  = "/home/user/Pictures/protohud";
+    std::string cfg_map_dir    = "/home/user/Pictures/protohud/maps";
     int         cfg_ssh_port   = 22;
     if (cfg.contains("system")) {
         auto& js         = cfg["system"];
@@ -2232,8 +2315,11 @@ int main(int argc, char* argv[]) {
         cfg_wifi_iface   = js.value("wifi_iface", cfg_wifi_iface);
         cfg_crash_dir    = js.value("crash_dir",  cfg_crash_dir);
         cfg_photo_dir    = js.value("photo_dir",  cfg_photo_dir);
+        cfg_map_dir      = js.value("map_dir",    cfg_map_dir);
         cfg_ssh_port     = js.value("ssh_port",   cfg_ssh_port);
     }
+    // Ensure the maps directory exists
+    std::filesystem::create_directories(cfg_map_dir);
     state.ssh.port = cfg_ssh_port;
 
     SplashConfig splash_cfg;
@@ -2549,7 +2635,8 @@ int main(int argc, char* argv[]) {
                                &active_face,
                                static_cast<IFaceController*>(&teensy),
                                static_cast<IFaceController*>(&protoface_ctrl),
-                               &panel_preview_enabled));
+                               &panel_preview_enabled,
+                               cfg_map_dir));
     menu_ptr = &menu;
 
     // Restore menu style from a previous session.
@@ -2878,6 +2965,7 @@ int main(int argc, char* argv[]) {
             snap.pp_cfg             = state.pp_cfg;
             snap.timer_alarm        = state.timer_alarm;
             snap.effects_cfg        = state.effects_cfg;
+            snap.map_overlay        = state.map_overlay;
             snap.sys_metrics        = state.sys_metrics;
             snap.wifi               = state.wifi;
             snap.ping               = state.ping;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1636,12 +1636,6 @@ static std::vector<MenuItem> build_menu(
         leaf("Reset Rotation",  [&state]{ state.map_overlay.image_rotate_deg =  0.f; }),
     };
 
-    std::vector<MenuItem> map_opacity_menu = {
-        leaf_sel("25%",  [&state]{ state.map_overlay.opacity = 0.25f; }, [&state]{ return state.map_overlay.opacity == 0.25f; }),
-        leaf_sel("50%",  [&state]{ state.map_overlay.opacity = 0.50f; }, [&state]{ return state.map_overlay.opacity == 0.50f; }),
-        leaf_sel("75%",  [&state]{ state.map_overlay.opacity = 0.75f; }, [&state]{ return state.map_overlay.opacity == 0.75f; }),
-        leaf_sel("100%", [&state]{ state.map_overlay.opacity = 1.00f; }, [&state]{ return state.map_overlay.opacity == 1.00f; }),
-    };
 
     std::vector<MenuItem> map_size_menu = {
         leaf_sel("Small  (200px)", [&state]{ state.map_overlay.size_px = 200.f; }, [&state]{ return state.map_overlay.size_px == 200.f; }),
@@ -1665,7 +1659,9 @@ static std::vector<MenuItem> build_menu(
             state.map_overlay.map_north_deg = state.compass_heading;
             state.map_overlay.calibrated    = true;
         }),
-        submenu("Opacity",              std::move(map_opacity_menu)),
+        slider("Transparency", 0.f, 1.f, 0.05f, "",
+            [&state]{ return state.map_overlay.opacity; },
+            [&state](float v){ state.map_overlay.opacity = v; }),
         submenu("Size",                 std::move(map_size_menu)),
     };
 


### PR DESCRIPTION
## Summary

- Adds a **Map Overlay** subsystem that loads a PNG/JPG raster map (floor plan, convention map, venue layout, etc.) from a configurable directory and displays it as a NanoVG overlay centered on the HUD
- Map rotates with the wearer's heading after a one-tap **"Set My Direction"** calibration — so the direction you're currently facing is always pointing up
- Supports manual image rotation (5°/15°/45°/90° steps CW/CCW) to correct map orientation without re-exporting
- Pan controls to shift the overlay position; opacity and size options; can be toggled off without losing settings

## What was added

**`src/app_state.h`** — new `MapOverlayConfig` struct (`enabled`, `map_path`, `size_px`, `opacity`, `pan_x/y`, `rotate_with_heading`, `map_north_deg`, `calibrated`, `image_rotate_deg`); added as `map_overlay` field in `AppState`

**`src/hud/hud_renderer.cpp/h`** — `draw_map_overlay()`: lazy `nvgCreateImage` reload when path changes, scissor clip to hide rotated corners, heading-up rotation math, red crosshair at centre marking wearer position, border ring; called at the start of `draw_hud_frame` so HUD chrome renders on top

**`src/main.cpp`** — `scan_map_dir` lambda scans for PNG/JPG at menu build time; **Map Overlay** submenu in HUD menu with Select Map / Rotate Image / Pan / Rotate with Heading / Set My Direction / Opacity / Size; `cfg_map_dir` config key; `create_directories` ensures the maps folder exists at startup

**`config/config.json`** — added `map_dir` and `photo_dir` keys under `system`

## Test plan

- [ ] Drop a PNG map into `/home/user/Pictures/protohud/maps/`
- [ ] HUD → Map Overlay → Select Map → pick the file → Enable — overlay appears centered
- [ ] Enable "Rotate with Heading" → "Set My Direction" while facing a known direction on the map → turn head left/right → map counter-rotates keeping forward direction up
- [ ] Rotate Image CCW/CW steps correct map orientation
- [ ] Pan controls shift the overlay; Reset Pan recenters
- [ ] Opacity and Size options apply immediately
- [ ] Disable → map disappears; re-enable → reappears without reload
- [ ] No frame-rate regression (single `nvgImagePattern` + `nvgFill` per frame)

https://claude.ai/code/session_017xAaFHoiBHVqGLxVhohcAh

---
_Generated by [Claude Code](https://claude.ai/code/session_017xAaFHoiBHVqGLxVhohcAh)_