### PR TITLE
Fix ZBar C++ namespace build error in qr_scanner.cpp

### DIFF
--- a/src/qr_scanner.cpp
+++ b/src/qr_scanner.cpp
@@ -5,6 +5,9 @@
 #include <algorithm>
 #include <chrono>
 
+// Some distros ship ZBar as a C++ library with all symbols in namespace zbar.
+using namespace zbar;
+
 using clock_t2 = std::chrono::steady_clock;
 
 QrScanner::QrScanner() {


### PR DESCRIPTION
Some distros (e.g. Ubuntu 22.04+) ship libzbar as a C++ library where all symbols live in namespace zbar. Add using namespace zbar inside the #ifdef HAVE_ZBAR block so the code compiles against both C and C++ builds.

https://claude.ai/code/session_017xAaFHoiBHVqGLxVhohcAh