### PR TITLE
Map overlay, QR actions, clock arm centering, build fixes

### DIFF
--- a/src/hud/hud_renderer.cpp
+++ b/src/hud/hud_renderer.cpp
@@ -1070,13 +1070,13 @@ void HudRenderer::draw_clock_indicator(NVGcontext* vg, const AppState& s,
 
     const float font_size = 14.f * cfg_.text_scale * scale;
     nvg_set_font_mono(font_size);
-    const char* rows[2] = { time_str, date_str };
+    nvgTextAlign(nvg_, NVG_ALIGN_CENTER | NVG_ALIGN_MIDDLE);
+    const float arm_cx    = clock_anchor_x + ARM_EXT * 0.5f;
+    const char* rows[2]   = { time_str, date_str };
     for (int i = 0; i < n_rows; ++i) {
         const float t  = static_cast<float>(i + 1) * eff_row_h;
-        const float ix = clock_anchor_x + dir_x * t;
-        const float iy = anchor_y       + dir_y * t;
-        nvg_glow_text(vg, ix + 6.f, iy - font_size * 0.5f,
-                      rows[i], true, col_.glow_base, col_.text_fill);
+        const float iy = anchor_y + dir_y * t;
+        nvg_glow_text(vg, arm_cx, iy, rows[i], true, col_.glow_base, col_.text_fill);
     }
 }
 


### PR DESCRIPTION
## Summary

- **Map overlay**: Load PNG/JPG floor plans or venue maps from a configurable directory and display as a HUD overlay. Supports heading-up rotation (calibrated with "Set My Direction"), static mode, manual CCW/CW image rotation, pan (5 directions + reset), transparency slider (0–1), and four size presets. The map is clipped to a square and renders beneath HUD chrome with a crosshair at wearer position.
- **QR code toast actions**: Adds OPEN LINK, SAVE LINK, and MUTE 1 MIN buttons to QR scan notifications. OPEN uses `xdg-open`; SAVE writes the scanned text to a timestamped `.txt` in the photo directory; MUTE suppresses further scans for 60 s via an `std::atomic<int64_t>` timestamp.
- **Clock arm text centering**: Time and date strings are now centered horizontally within the indicator arm extent (`NVG_ALIGN_CENTER | NVG_ALIGN_MIDDLE` anchored at `clock_anchor_x + ARM_EXT * 0.5f`).
- **Build fixes**: Added `#include <cstdint>` to `capture.h` (missing `uint8_t`); added `using namespace zbar;` in `qr_scanner.cpp` for Ubuntu 22.04+ C++ ZBar builds; fixed hardcoded `/home/user/` path to use `getenv("HOME")` with non-throwing `create_directories`.

## Test plan

- [ ] Build with `cmake --build build` — no errors
- [ ] Drop a PNG in `~/Pictures/protohud/maps/`, open HUD → Map Overlay → Select Map → Enable — map appears centered
- [ ] Enable Rotate with Heading → Set My Direction — map counter-rotates as head turns
- [ ] Pan items shift the map; Reset Pan recenters
- [ ] Transparency slider changes opacity continuously
- [ ] Size presets (Small/Medium/Large/Full) resize the overlay
- [ ] QR scan of a URL shows OPEN LINK, SAVE LINK, MUTE 1 MIN buttons; each works correctly
- [ ] Clock arm text is centered horizontally inside the arm at all font scales
- [ ] Build succeeds on a machine where `$HOME` is not `/home/user`

https://claude.ai/code/session_017xAaFHoiBHVqGLxVhohcAh

---
_Generated by [Claude Code](https://claude.ai/code/session_017xAaFHoiBHVqGLxVhohcAh)_