### PR TITLE
Fix clock arm diagonal length to match face/lora arms

### DIFF
--- a/src/hud/hud_renderer.cpp
+++ b/src/hud/hud_renderer.cpp
@@ -1038,7 +1038,7 @@ void HudRenderer::draw_clock_indicator(NVGcontext* vg, const AppState& s,
     const float scale     = std::max(0.5f, s.clock_cfg.font_scale);
     const float eff_row_h = ROW_H * scale;
     const int   n_rows    = s.clock_cfg.show_date ? 2 : 1;
-    const float diag_len  = static_cast<float>(n_rows + 1) * eff_row_h;
+    constexpr float diag_len = 90.f;  // fixed to match face/lora arms: (MAX_ROWS+1)*ROW_H
 
     NVGcolor cm = nvg_col(col_.glow_base);
     NVGcolor g1 = nvg_col_a(col_.glow_base, 70);


### PR DESCRIPTION
The diagonal arm was scaled by font size and row count, making it shorter than the other arms. Now uses the same fixed 90 px constant as face/lora arms ((MAX_ROWS+1)*ROW_H = 5*18).

https://claude.ai/code/session_017xAaFHoiBHVqGLxVhohcAh