### PR TITLE
Add mirror crop and single-camera view modes for main cameras

### DIFF
--- a/src/app_state.h
+++ b/src/app_state.h
@@ -175,6 +175,25 @@ struct ZoomCropState {
     float center_y = 0.5f;
 };
 
+// Synchronized mirror crop: both eyes zoom to the same level and pan to their
+// inner (nose-side) edges. The left eye pans right (center_x > 0.5) and the
+// right eye pans left (center_x < 0.5) by the same inner_bias offset.
+enum class CropVertical { Top, Middle, Bottom };
+struct MirrorCropState {
+    bool         enabled    = false;
+    float        zoom       = 2.0f;
+    CropVertical vertical   = CropVertical::Middle;
+    float        inner_bias = 0.15f;   // UV offset from center toward nose
+};
+
+// Single-camera full/partial-screen mode: one eye's feed fills an anchor region.
+enum class CamSingleAnchor { Full, Top, Bottom, Left, Right };
+struct CamSingleState {
+    bool           enabled   = false;
+    bool           use_right = false;  // false = left camera, true = right camera
+    CamSingleAnchor anchor   = CamSingleAnchor::Full;
+};
+
 struct ImuPose {
     float roll  = 0.0f;
     float pitch = 0.0f;
@@ -372,6 +391,8 @@ struct AppState {
     ClockConfig          clock_cfg;
     CameraResolutionState camera_resolution;
     ZoomCropState        zoom_left, zoom_right;
+    MirrorCropState      mirror_crop;
+    CamSingleState       cam_single;
 
     // Post-processing (edge highlight + background desaturation)
     PostProcessConfig    pp_cfg;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -577,6 +577,60 @@ static std::vector<MenuItem> build_menu(
         }),
     };
 
+    // ── Mirror Crop ────────────────────────────────────────────────────────────
+    // Both eyes zoom to the same level and pan inward (nose-side crop).
+    // Vertical position (top/middle/bottom) is shared. inner_bias controls how
+    // far from center the crop window is placed.
+    std::vector<MenuItem> mirror_crop_zoom_items = {
+        leaf_sel("1.5×", [&state]{ state.mirror_crop.zoom = 1.5f; },
+                         [&state]{ return state.mirror_crop.zoom == 1.5f; }),
+        leaf_sel("2.0×", [&state]{ state.mirror_crop.zoom = 2.0f; },
+                         [&state]{ return state.mirror_crop.zoom == 2.0f; }),
+        leaf_sel("2.5×", [&state]{ state.mirror_crop.zoom = 2.5f; },
+                         [&state]{ return state.mirror_crop.zoom == 2.5f; }),
+        leaf_sel("3.0×", [&state]{ state.mirror_crop.zoom = 3.0f; },
+                         [&state]{ return state.mirror_crop.zoom == 3.0f; }),
+    };
+    std::vector<MenuItem> mirror_crop_vert_items = {
+        leaf_sel("Top",    [&state]{ state.mirror_crop.vertical = CropVertical::Top;    },
+                           [&state]{ return state.mirror_crop.vertical == CropVertical::Top;    }),
+        leaf_sel("Middle", [&state]{ state.mirror_crop.vertical = CropVertical::Middle; },
+                           [&state]{ return state.mirror_crop.vertical == CropVertical::Middle; }),
+        leaf_sel("Bottom", [&state]{ state.mirror_crop.vertical = CropVertical::Bottom; },
+                           [&state]{ return state.mirror_crop.vertical == CropVertical::Bottom; }),
+    };
+    std::vector<MenuItem> mirror_crop_menu = {
+        toggle("Enable", [&state]{ return state.mirror_crop.enabled; },
+                         [&state](bool v){ state.mirror_crop.enabled = v; }),
+        submenu("Zoom",           std::move(mirror_crop_zoom_items)),
+        submenu("Vertical",       std::move(mirror_crop_vert_items)),
+        slider("Inner Bias", 0.f, 0.40f, 0.05f, "",
+            [&state]{ return state.mirror_crop.inner_bias; },
+            [&state](float v){ state.mirror_crop.inner_bias = v; }),
+    };
+
+    // ── Single Camera ──────────────────────────────────────────────────────────
+    // Fill one anchor region of the screen with a single camera feed.
+    std::vector<MenuItem> single_cam_anchor_items = {
+        leaf_sel("Full Screen", [&state]{ state.cam_single.anchor = CamSingleAnchor::Full;   },
+                                [&state]{ return state.cam_single.anchor == CamSingleAnchor::Full;   }),
+        leaf_sel("Top Half",    [&state]{ state.cam_single.anchor = CamSingleAnchor::Top;    },
+                                [&state]{ return state.cam_single.anchor == CamSingleAnchor::Top;    }),
+        leaf_sel("Bottom Half", [&state]{ state.cam_single.anchor = CamSingleAnchor::Bottom; },
+                                [&state]{ return state.cam_single.anchor == CamSingleAnchor::Bottom; }),
+        leaf_sel("Left Half",   [&state]{ state.cam_single.anchor = CamSingleAnchor::Left;   },
+                                [&state]{ return state.cam_single.anchor == CamSingleAnchor::Left;   }),
+        leaf_sel("Right Half",  [&state]{ state.cam_single.anchor = CamSingleAnchor::Right;  },
+                                [&state]{ return state.cam_single.anchor == CamSingleAnchor::Right;  }),
+    };
+    std::vector<MenuItem> single_cam_menu = {
+        toggle("Enable", [&state]{ return state.cam_single.enabled; },
+                         [&state](bool v){ state.cam_single.enabled = v; }),
+        toggle("Use Right Camera", [&state]{ return state.cam_single.use_right; },
+                                   [&state](bool v){ state.cam_single.use_right = v; }),
+        submenu("Anchor", std::move(single_cam_anchor_items)),
+    };
+
     std::vector<MenuItem> main_cameras_menu = {
         toggle("Theater Mode",
             [&state]{ return state.theater_mode; },
@@ -589,7 +643,9 @@ static std::vector<MenuItem> build_menu(
                                     [&state](bool v){ state.qr_scan_main = v; }),
         toggle("QR Scan USB Cams",  [&state]{ return state.qr_scan_usb; },
                                     [&state](bool v){ state.qr_scan_usb = v; }),
-        submenu("Digital Zoom", std::move(zoom_menu)),
+        submenu("Digital Zoom",  std::move(zoom_menu)),
+        submenu("Mirror Crop",   std::move(mirror_crop_menu)),
+        submenu("Single Camera", std::move(single_cam_menu)),
         submenu("Focus Mode",  std::move(focus_modes)),
         slider("Focus Position", 0.f, 1000.f, 50.f, "",
             [&state]{ return static_cast<float>(state.focus_left.focus_position); },
@@ -3190,6 +3246,8 @@ int main(int argc, char* argv[]) {
             snap.zoom_left          = state.zoom_left;
             snap.zoom_right         = state.zoom_right;
             snap.theater_mode       = state.theater_mode;
+            snap.mirror_crop        = state.mirror_crop;
+            snap.cam_single         = state.cam_single;
             snap.capture_request    = state.capture_request;
             snap.qr_scan_main       = state.qr_scan_main;
             snap.qr_scan_usb        = state.qr_scan_usb;
@@ -3259,6 +3317,22 @@ int main(int argc, char* argv[]) {
                 s_last_nv = nv;
                 s_first   = false;
             }
+        }
+
+        // ── Mirror crop override ──────────────────────────────────────────────
+        // When enabled, both eyes zoom to the same level and pan inward (toward
+        // the nose). Left eye pans right (+inner_bias), right eye pans left
+        // (-inner_bias). The vertical position is shared.
+        if (snap.mirror_crop.enabled) {
+            float cy = (snap.mirror_crop.vertical == CropVertical::Top)    ? 0.25f
+                     : (snap.mirror_crop.vertical == CropVertical::Bottom) ? 0.75f
+                     : 0.5f;
+            snap.zoom_left.zoom      = snap.mirror_crop.zoom;
+            snap.zoom_right.zoom     = snap.mirror_crop.zoom;
+            snap.zoom_left.center_x  = 0.5f + snap.mirror_crop.inner_bias;
+            snap.zoom_right.center_x = 0.5f - snap.mirror_crop.inner_bias;
+            snap.zoom_left.center_y  = cy;
+            snap.zoom_right.center_y = cy;
         }
 
         // ── Render cameras into per-eye FBOs ──────────────────────────────────
@@ -3383,7 +3457,12 @@ int main(int argc, char* argv[]) {
         // ── Composite or timewarp ─────────────────────────────────────────────
         ImuPose current_pose = xr.get_latest_imu_pose();
 
-        if (use_timewarp) {
+        if (snap.cam_single.enabled) {
+            // Single-camera fill: draw one eye's (post-processed) feed to an
+            // anchor region of the screen; the rest is cleared to black.
+            GLuint src = snap.cam_single.use_right ? right_src : left_src;
+            xr.composite_single(src, snap.cam_single.anchor);
+        } else if (use_timewarp) {
             // Apply rotational timewarp: warp each eye FBO into its half of the
             // default framebuffer using the latest IMU pose.
             glBindFramebuffer(GL_FRAMEBUFFER, 0);

--- a/src/vitrue/xr_display.cpp
+++ b/src/vitrue/xr_display.cpp
@@ -187,6 +187,37 @@ void XRDisplay::composite() {
     glUseProgram(0);
 }
 
+// ── composite_single ─────────────────────────────────────────────────────────
+// Blit one texture to an anchor region; clear rest to black.
+
+void XRDisplay::composite_single(GLuint src_tex, CamSingleAnchor anchor) {
+    static const float rects[5][4] = {
+        {-1.f, -1.f,  1.f,  1.f},  // Full
+        {-1.f,  0.f,  1.f,  1.f},  // Top half
+        {-1.f, -1.f,  1.f,  0.f},  // Bottom half
+        {-1.f, -1.f,  0.f,  1.f},  // Left half
+        { 0.f, -1.f,  1.f,  1.f},  // Right half
+    };
+    int i = static_cast<int>(anchor);
+    if (i < 0 || i > 4) i = 0;
+
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    glViewport(0, 0, disp_w_, disp_h_);
+    glClearColor(0.f, 0.f, 0.f, 1.f);
+    glClear(GL_COLOR_BUFFER_BIT);
+
+    glUseProgram(blit_prog_);
+    glActiveTexture(GL_TEXTURE0);
+    glUniform1i(glGetUniformLocation(blit_prog_, "u_tex"), 0);
+    gl::bind_quad(quad_vbo_);
+    glBindTexture(GL_TEXTURE_2D, src_tex);
+    glUniform4f(glGetUniformLocation(blit_prog_, "u_rect"),
+                rects[i][0], rects[i][1], rects[i][2], rects[i][3]);
+    gl::draw_quad();
+    gl::unbind_quad();
+    glUseProgram(0);
+}
+
 // ── present ───────────────────────────────────────────────────────────────────
 // Swap the GLFW window buffer and poll events.
 

--- a/src/vitrue/xr_display.h
+++ b/src/vitrue/xr_display.h
@@ -50,6 +50,11 @@ public:
     // Does NOT swap — call present() afterwards (after ImGui overlay).
     void composite();
 
+    // Blit a single texture to an anchor region of the default framebuffer.
+    // Clears the screen to black first. anchor controls which NDC sub-rect
+    // the texture fills (Full / Top / Bottom / Left / Right half).
+    void composite_single(GLuint src_tex, CamSingleAnchor anchor);
+
     // Swap the GLFW window buffer and poll events.
     // Call after composite() and after the ImGui overlay is rendered.
     void present();


### PR DESCRIPTION
Mirror Crop: both eyes share the same zoom level and each pans inward (nose-side) by a configurable inner_bias. The left eye pans right (center_x > 0.5) and right eye pans left (center_x < 0.5), giving a naturally mirrored stereo crop. Vertical position (top/middle/bottom) is shared. Enabled via Menu → Main Cameras → Mirror Crop.

Single Camera: replaces the SBS composite with a single eye FBO blitted to an anchor region (full screen, top/bottom/left/right half). Useful for monitor passthrough or diagnostic views. Enabled via Menu → Main Cameras → Single Camera → Enable, with camera selection and anchor submenu.

Both modes work with the existing post-processing pipeline (left_src / right_src are post-processed textures).

https://claude.ai/code/session_017xAaFHoiBHVqGLxVhohcAh