### PR TITLE
Draw corner-anchored USB camera PiP windows behind HUD chrome

### DIFF
--- a/src/hud/hud_renderer.cpp
+++ b/src/hud/hud_renderer.cpp
@@ -222,6 +222,11 @@ void HudRenderer::load(void* glfw_window) {
 void HudRenderer::unload() {
     if (!ctx_) return;
     if (nvg_ && map_img_ >= 0) { nvgDeleteImage(nvg_, map_img_); map_img_ = -1; }
+    if (nvg_) {
+        for (auto& [tex, img] : pip_nvg_cache_)
+            if (img >= 0) nvgDeleteImage(nvg_, img);
+        pip_nvg_cache_.clear();
+    }
     if (nvg_) { nvgDeleteGLES2(nvg_); nvg_ = nullptr; }
     ImGui::SetCurrentContext(ctx_);
     ImGui_ImplOpenGL3_Shutdown();
@@ -461,6 +466,81 @@ static ImVec2 overlay_origin(const OverlayConfig& cfg,
         case OverlayConfig::Anchor::BOTTOM_RIGHT:  return { sw - ov_w - kEdge,      bottom_y };
     }
     return { kEdge, kEdge }; // unreachable
+}
+
+// ── PiP underlay (NanoVG, drawn before HUD chrome) ───────────────────────────
+
+static bool is_corner_anchor(OverlayConfig::Anchor a) {
+    using A = OverlayConfig::Anchor;
+    return a == A::TOP_LEFT || a == A::TOP_RIGHT ||
+           a == A::BOTTOM_LEFT || a == A::BOTTOM_RIGHT;
+}
+
+void HudRenderer::draw_pip_underlays(
+    unsigned int tex1, bool act1, const OverlayConfig& c1,
+    unsigned int tex2, bool act2, const OverlayConfig& c2,
+    unsigned int tex3, bool act3, const OverlayConfig& c3,
+    int ew, int eh)
+{
+    if (!nvg_) return;
+
+    struct Entry { unsigned int tex; bool act; const OverlayConfig* cfg; };
+    const Entry entries[3] = {
+        { tex1, act1, &c1 }, { tex2, act2, &c2 }, { tex3, act3, &c3 }
+    };
+
+    // Early-out if no corner pip is active
+    bool any = false;
+    for (auto& e : entries)
+        if (e.act && e.tex && is_corner_anchor(e.cfg->anchor)) { any = true; break; }
+    if (!any) return;
+
+    const float fw     = static_cast<float>(ew);
+    const float fh     = static_cast<float>(eh);
+    const float margin = static_cast<float>(cfg_.compass_height);
+    const float C      = cfg_.pip_corner_clip_px;
+
+    nvgBeginFrame(nvg_, fw, fh, 1.0f);
+
+    for (auto& e : entries) {
+        if (!e.act || !e.tex || !is_corner_anchor(e.cfg->anchor)) continue;
+
+        const float ov_h = fh * e.cfg->size;
+        const float ov_w = ov_h * (16.f / 9.f);
+        const auto  pos  = overlay_origin(*e.cfg, fw, fh, ov_w, ov_h, margin);
+
+        // Wrap the GL texture as an NVG image (cached; no pixel copy)
+        auto it = pip_nvg_cache_.find(e.tex);
+        if (it == pip_nvg_cache_.end()) {
+            int img = nvglCreateImageFromHandleGLES2(nvg_, e.tex, 1280, 720, 0);
+            pip_nvg_cache_[e.tex] = img;
+            it = pip_nvg_cache_.find(e.tex);
+        }
+        const int img = it->second;
+        if (img < 0) continue;
+
+        // Background fill
+        nvgBeginPath(nvg_);
+        nvgRoundedRect(nvg_, pos.x, pos.y, ov_w, ov_h, C);
+        nvgFillColor(nvg_, nvgRGBA(10, 15, 20, 200));
+        nvgFill(nvg_);
+
+        // Camera image
+        NVGpaint paint = nvgImagePattern(nvg_, pos.x, pos.y, ov_w, ov_h, 0.f, img, 1.0f);
+        nvgBeginPath(nvg_);
+        nvgRoundedRect(nvg_, pos.x, pos.y, ov_w, ov_h, C);
+        nvgFillPaint(nvg_, paint);
+        nvgFill(nvg_);
+
+        // Thin border
+        nvgBeginPath(nvg_);
+        nvgRoundedRect(nvg_, pos.x, pos.y, ov_w, ov_h, C);
+        nvgStrokeColor(nvg_, nvgRGBA(100, 130, 160, 140));
+        nvgStrokeWidth(nvg_, 1.5f);
+        nvgStroke(nvg_);
+    }
+
+    nvgEndFrame(nvg_);
 }
 
 // ── PiP ──────────────────────────────────────────────────────────────────────

--- a/src/hud/hud_renderer.h
+++ b/src/hud/hud_renderer.h
@@ -20,6 +20,7 @@
 #include <nanovg.h>
 #include <string>
 #include <deque>
+#include <unordered_map>
 #include <vector>
 
 struct HudColors {
@@ -105,7 +106,17 @@ public:
     // Start an ImGui frame for menu + debug overlays.
     void begin_menu_frame();
 
+    // NanoVG underlay: draw corner-anchored PiP cameras BEFORE HUD chrome.
+    // The anchor check is done internally; pass the full active state.
+    // Call this before draw_hud_frame, after composite.
+    void draw_pip_underlays(
+        unsigned int tex1, bool act1, const OverlayConfig& c1,
+        unsigned int tex2, bool act2, const OverlayConfig& c2,
+        unsigned int tex3, bool act3, const OverlayConfig& c3,
+        int ew, int eh);
+
     // Build PiP draw commands for a USB camera overlay (ImGui pass).
+    // For corner-anchored pips drawn by draw_pip_underlays, pass active=false.
     void draw_pip(unsigned int tex, const char* label,
                   int w, int h, bool active, const OverlayConfig& cfg,
                   const CameraFocusState& focus = {},
@@ -222,6 +233,10 @@ private:
     int         map_img_w_    = 0;
     int         map_img_h_    = 0;
     std::string map_img_path_;
+
+    // NVG image cache for PiP underlays: GL tex ID → NVG image handle.
+    // Created via nvglCreateImageFromHandleGLES2 on first use; freed in unload().
+    std::unordered_map<unsigned int, int> pip_nvg_cache_;
 
     HudConfig     cfg_;
     HudColors     col_;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3555,6 +3555,20 @@ int main(int argc, char* argv[]) {
             xr.composite();
         }
 
+        // ── Phase 0: PiP underlay — corner-anchored cameras behind HUD chrome ─
+        // Drawn via NanoVG in eye-space (ew × eh) before the HUD chrome so the
+        // compass, arms, and health panel render on top of them.
+        glViewport(0, 0, xr.display_width(), xr.display_height());
+        {
+            bool p1 = pip_cam1_overlay_active || pip_left_active  || kb_pip_left  || wc_pip_left;
+            bool p2 = pip_cam2_overlay_active || pip_right_active || kb_pip_right || wc_pip_right;
+            bool p3 = pip_cam3_overlay_active;
+            hud.draw_pip_underlays(tex_usb1, p1, pip_overlay_cfg1,
+                                   tex_usb2, p2, pip_overlay_cfg2,
+                                   tex_usb3, p3, pip_overlay_cfg3,
+                                   xr.eye_width(), xr.eye_height());
+        }
+
         // ── Phase 1: NanoVG HUD chrome (compass, arms, particles) ───────────
         // Reset viewport to full framebuffer — timewarp leaves it at right-eye half.
         // Pass full display dimensions so NanoVG covers both eye halves.
@@ -3566,19 +3580,27 @@ int main(int argc, char* argv[]) {
         menu.set_glow_enabled(hud.config().glow_enabled);
         menu.draw(xr.eye_width(), xr.eye_height());
 
+        // Corner-anchored pips were already drawn in the underlay pass; suppress
+        // them here so they don't overdraw on top of the HUD chrome.
+        auto pip_front_active = [](bool act, const OverlayConfig& cfg) {
+            using A = OverlayConfig::Anchor;
+            bool corner = cfg.anchor == A::TOP_LEFT  || cfg.anchor == A::TOP_RIGHT ||
+                          cfg.anchor == A::BOTTOM_LEFT || cfg.anchor == A::BOTTOM_RIGHT;
+            return act && !corner;
+        };
         hud.draw_pip(tex_usb1, "Cam 1",
                      xr.eye_width(), xr.eye_height(),
-                     pip_cam1_overlay_active || pip_left_active || kb_pip_left || wc_pip_left,
+                     pip_front_active(pip_cam1_overlay_active || pip_left_active || kb_pip_left || wc_pip_left, pip_overlay_cfg1),
                      pip_overlay_cfg1,
                      snap.focus_left, snap.night_vision.nv_enabled);
         hud.draw_pip(tex_usb2, "Cam 2",
                      xr.eye_width(), xr.eye_height(),
-                     pip_cam2_overlay_active || pip_right_active || kb_pip_right || wc_pip_right,
+                     pip_front_active(pip_cam2_overlay_active || pip_right_active || kb_pip_right || wc_pip_right, pip_overlay_cfg2),
                      pip_overlay_cfg2,
                      snap.focus_right, snap.night_vision.nv_enabled);
         hud.draw_pip(tex_usb3, "Cam 3",
                      xr.eye_width(), xr.eye_height(),
-                     pip_cam3_overlay_active,
+                     pip_front_active(pip_cam3_overlay_active, pip_overlay_cfg3),
                      pip_overlay_cfg3,
                      snap.focus_left, snap.night_vision.nv_enabled);
 


### PR DESCRIPTION
Use NanoVG (renders immediately on nvgEndFrame) to draw corner-anchored USB camera feeds in a dedicated underlay pass before draw_hud_frame, so they appear beneath the compass, arms, and health panels rather than on top.

GL textures are wrapped as NVG images via nvglCreateImageFromHandleGLES2 and cached per GL tex ID (pip_nvg_cache_) to avoid per-frame recreation. The ImGui pip pass is suppressed for corner-anchored cameras via a pip_front_active lambda so each camera is drawn exactly once.

https://claude.ai/code/session_017xAaFHoiBHVqGLxVhohcAh