### PR TITLE
Map overlay, USB camera discovery, per-camera controls, theater anchor, and various HUD improvements

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2307,17 +2307,6 @@ int main(int argc, char* argv[]) {
     xr_cfg.frameless        = jval(jdisp, "frameless",         false);
 
     CamConfig owl_left, owl_right;
-    state.cameras_swapped = jcam.value("swapped", false);
-    {
-        using TA = AppState::TheaterAnchor;
-        static const std::pair<const char*, TA> kAnchors[] = {
-            {"top_left",     TA::TopLeft},    {"top",    TA::Top},    {"top_right",    TA::TopRight},
-            {"left",         TA::Left},       {"center", TA::Center}, {"right",        TA::Right},
-            {"bottom_left",  TA::BottomLeft}, {"bottom", TA::Bottom}, {"bottom_right", TA::BottomRight},
-        };
-        std::string a = jcam.value("theater_anchor", "center");
-        for (auto& [k, v] : kAnchors) if (a == k) { state.theater_anchor = v; break; }
-    }
 
     if (jcam.contains("owlsight_left")) {
         auto& jl              = jcam["owlsight_left"];
@@ -2478,6 +2467,18 @@ int main(int argc, char* argv[]) {
         state.night_vision.auto_nv_gain_threshold = jnv.value("auto_nv_gain_threshold",  4.0f);
         state.night_vision.csi_awb_left           = jnv.value("csi_awb_left",            true);
         state.night_vision.csi_awb_right          = jnv.value("csi_awb_right",           true);
+    }
+
+    state.cameras_swapped = jcam.value("swapped", false);
+    {
+        using TA = AppState::TheaterAnchor;
+        static const std::pair<const char*, TA> kAnchors[] = {
+            {"top_left",     TA::TopLeft},    {"top",    TA::Top},    {"top_right",    TA::TopRight},
+            {"left",         TA::Left},       {"center", TA::Center}, {"right",        TA::Right},
+            {"bottom_left",  TA::BottomLeft}, {"bottom", TA::Bottom}, {"bottom_right", TA::BottomRight},
+        };
+        std::string a = jcam.value("theater_anchor", "center");
+        for (auto& [k, v] : kAnchors) if (a == k) { state.theater_anchor = v; break; }
     }
 
     if (cfg.contains("clock")) {


### PR DESCRIPTION
## Summary

- **Map overlay**: Raster map image displayed as HUD overlay with heading-based rotation, calibration, pan, opacity, and size controls. Clamped to screen edges so it never clips past the viewport.
- **USB camera auto-discovery**: Scans `/dev/video0..63` and lists connectable devices; per-USB-camera device reassignment from the menu (thread-safe, supports hub-connected cameras).
- **Per-camera OWLsight controls**: Independent Focus Mode, Focus Position, and White Balance per eye (left/right), with camera swap toggle persisted to config.
- **Theater mode position anchor**: 9-way snap (TopLeft/Top/TopRight/Left/Center/Right/BottomLeft/Bottom/BottomRight) for letterbox/pillarbox placement.
- **NV indicator inline**: Night Vision badge moved from arm tip to inline after the Focus label on main camera HUD rows.
- **PiP underlay**: Corner-anchored USB cameras drawn behind HUD chrome via NanoVG (`nvglCreateImageFromHandleGLES2`), no pixel copy.
- **Vignette/nebula**: Halved reach, smoother inner falloff (feather = 1.4× depth).
- **Config persistence**: `cameras_swapped`, `theater_anchor`, and `csi_awb_left/right` all round-trip through config.json.
- **config.json git hygiene**: Renamed to `config.example.json` as the tracked reference; runtime `config.json` is gitignored to prevent pull conflicts.
- **Build fix**: `configure_file` updated to reference `config.example.json`; `state.cameras_swapped`/`state.theater_anchor` config reads moved to after `AppState state;` declaration (was causing `'state' was not declared in this scope` at line 2310).

## Test plan

- [ ] Fresh clone: `config.json` absent → falls back to `config.example.json`, starts cleanly
- [ ] `ninja -C build` completes without errors
- [ ] Map overlay: drop a PNG in `~/Pictures/protohud/maps/`, HUD → Map Overlay → Select Map → Enable → map renders; rotate head → map counter-rotates
- [ ] Theater anchor: switch between 9 positions in pillarbox and letterbox modes; feed snaps to correct edge
- [ ] Swap cameras toggle: left/right eye feeds exchange; persists after restart
- [ ] USB device select: plug camera through hub → appears in device list → reassign without restart
- [ ] Per-eye focus/WB: adjust left eye independently, right eye unchanged
- [ ] NV badge: appears inline after "Focus" text on HUD arm rows when NV enabled
- [ ] `git pull` on device: no conflict on config.json

https://claude.ai/code/session_017xAaFHoiBHVqGLxVhohcAh

---
_Generated by [Claude Code](https://claude.ai/code/session_017xAaFHoiBHVqGLxVhohcAh)_