### PR TITLE
Fix first-run config load: read from config.example.json, write to co…

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2239,29 +2239,30 @@ int main(int argc, char* argv[]) {
     //                                                settings to config.json on exit, so
     //                                                the example is only read once.
     //   3. <bin_dir>/config.json                   — installed/packaged layout fallback.
-    std::string cfg_path;
+    std::string cfg_path;   // write path
+    std::string cfg_load;   // read path (may differ from cfg_path on first run)
     if (argc > 1) {
-        cfg_path = argv[1];
+        cfg_path = cfg_load = argv[1];
     } else {
         std::string dev_cfg     = bin_dir + "/../config/config.json";
         std::string example_cfg = bin_dir + "/../config/config.example.json";
         std::string def_cfg     = res("config.json");
         try {
-            if (fs::exists(dev_cfg))         cfg_path = dev_cfg;
-            else if (fs::exists(example_cfg)) cfg_path = example_cfg;
-            else                              cfg_path = def_cfg;
+            if (fs::exists(dev_cfg)) {
+                cfg_path = cfg_load = dev_cfg;
+            } else if (fs::exists(example_cfg)) {
+                cfg_load = example_cfg;  // read defaults from example
+                cfg_path = dev_cfg;      // write user settings to config.json
+                std::cout << "[cfg] first run — loading defaults from config.example.json, "
+                             "will write to config.json\n";
+            } else {
+                cfg_path = cfg_load = def_cfg;
+            }
         } catch (...) {
-            cfg_path = def_cfg;
-        }
-        // Always write back to config.json so user settings are persisted there,
-        // not into the example file.
-        if (cfg_path == example_cfg) {
-            cfg_path = dev_cfg;  // redirect writes; example stays pristine
-            std::cout << "[cfg] first run — loading defaults from config.example.json, "
-                         "will write to config.json\n";
+            cfg_path = cfg_load = def_cfg;
         }
     }
-    json cfg = load_config(cfg_path);
+    json cfg = load_config(cfg_load);
 
     // ── Config extraction ─────────────────────────────────────────────────────
 


### PR DESCRIPTION
…nfig.json

On the very first run (no config.json yet) the code redirected cfg_path to config.json for writes, then called load_config(cfg_path) — but config.json doesn't exist yet, so load_config returned empty JSON. Both OWLsight cameras fell back to libcamera_id=0; only one can acquire camera 0 at a time, so the second camera failed with "Camera in Running state trying acquire()".

Separate cfg_load (read path) from cfg_path (write path): on a fresh install cfg_load points at config.example.json while cfg_path still points at config.json so user edits are saved there.

https://claude.ai/code/session_017xAaFHoiBHVqGLxVhohcAh