### PR TITLE
Fix compass axis: use roll (head turn) not yaw for bearing

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2619,7 +2619,7 @@ int main(int argc, char* argv[]) {
     xr.on_imu_pose([&state, &last_xr_imu_us](float roll, float pitch, float yaw) {
         last_xr_imu_us = std::chrono::duration_cast<std::chrono::microseconds>(
             std::chrono::steady_clock::now().time_since_epoch()).count();
-        float bearing = fmod(360.0f - yaw, 360.0f);
+        float bearing = fmod(360.0f - roll, 360.0f);
         std::lock_guard<std::mutex> lk(state.mtx);
         state.compass_heading = bearing;
         state.imu_pose = { roll, pitch, yaw };


### PR DESCRIPTION
Physical VITURE glasses orientation has the left/right rotation (head turning) mapped to data[0] (roll in the SDK's label), not data[2] (yaw). Driving the compass off yaw caused side-tilt to move the compass instead of left/right head turns.

https://claude.ai/code/session_017xAaFHoiBHVqGLxVhohcAh