### PR TITLE
Add mounting orientation to onboard MPU-9250 compass (0/90/180/270° CCW)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1331,6 +1331,21 @@ static std::vector<MenuItem> build_menu(
 
     // ── Compass ───────────────────────────────────────────────────────────────
     // Onboard MPU-9250 backup compass (moved from root "Backup Compass")
+    std::vector<MenuItem> mpu_mount_menu = {
+        leaf_sel("0° — Default",
+            [mpu9250]{ if (mpu9250) mpu9250->set_mount_rotation(0); },
+            [mpu9250]{ return mpu9250 && mpu9250->get_mount_rotation() == 0; }),
+        leaf_sel("90° CCW",
+            [mpu9250]{ if (mpu9250) mpu9250->set_mount_rotation(1); },
+            [mpu9250]{ return mpu9250 && mpu9250->get_mount_rotation() == 1; }),
+        leaf_sel("180°",
+            [mpu9250]{ if (mpu9250) mpu9250->set_mount_rotation(2); },
+            [mpu9250]{ return mpu9250 && mpu9250->get_mount_rotation() == 2; }),
+        leaf_sel("270° CCW",
+            [mpu9250]{ if (mpu9250) mpu9250->set_mount_rotation(3); },
+            [mpu9250]{ return mpu9250 && mpu9250->get_mount_rotation() == 3; }),
+    };
+
     std::vector<MenuItem> onboard_compass_menu = {
         toggle("Active",
             [mpu9250]{ return mpu9250 && mpu9250->is_running(); },
@@ -1345,6 +1360,7 @@ static std::vector<MenuItem> build_menu(
                 if (v) mpu9250->begin_calibration();
                 else   mpu9250->end_calibration();
             }),
+        submenu("Mounting Orientation", std::move(mpu_mount_menu)),
     };
 
     std::vector<MenuItem> compass_bg_color_menu = make_color_items({
@@ -2425,6 +2441,7 @@ int main(int argc, char* argv[]) {
         mpu_cfg.mpu_addr        = jval(jm, "mpu_addr",       0x68);
         mpu_cfg.declination_deg = jval(jm, "declination_deg", 0.0f);
         mpu_cfg.heading_offset  = jval(jm, "heading_offset",  0.0f);
+        mpu_cfg.mount_rotation  = jval(jm, "mount_rotation",  0);
         if (jm.contains("mag_bias") && jm["mag_bias"].is_array() &&
             jm["mag_bias"].size() >= 3) {
             mpu_cfg.mag_bias_x = jm["mag_bias"][0].get<float>();
@@ -3995,7 +4012,8 @@ int main(int argc, char* argv[]) {
         if (mpu9250.is_running() || cfg.contains("mpu9250")) {
             float bx, by, bz;
             mpu9250.get_mag_bias(bx, by, bz);
-            cfg["mpu9250"]["mag_bias"] = json::array({ bx, by, bz });
+            cfg["mpu9250"]["mag_bias"]       = json::array({ bx, by, bz });
+            cfg["mpu9250"]["mount_rotation"] = mpu9250.get_mount_rotation();
         }
 
         FILE* f = fopen(cfg_path.c_str(), "w");

--- a/src/sensor/mpu9250.cpp
+++ b/src/sensor/mpu9250.cpp
@@ -39,7 +39,7 @@ static constexpr uint8_t AK_MODE_CONT2_16BIT = 0x16; // 100 Hz, 16-bit output
 
 // ── Constructor / Destructor ──────────────────────────────────────────────────
 
-Mpu9250::Mpu9250(const Config& cfg) : cfg_(cfg) {}
+Mpu9250::Mpu9250(const Config& cfg) : cfg_(cfg), mount_rotation_(cfg.mount_rotation) {}
 
 Mpu9250::~Mpu9250() { stop(); }
 
@@ -145,6 +145,9 @@ bool Mpu9250::init_ak8963() {
     return true;
 }
 
+void Mpu9250::set_mount_rotation(int r) { mount_rotation_.store(r & 3); }
+int  Mpu9250::get_mount_rotation() const { return mount_rotation_.load(); }
+
 // ── Heading computation ───────────────────────────────────────────────────────
 // Tilt-compensated heading using accelerometer pitch/roll.
 // Axis convention for GY-9250 breakout (chip face up, connector down):
@@ -159,6 +162,14 @@ float Mpu9250::compute_heading(float mx, float my, float mz,
     float ax_f = ax / 16384.0f; // ±2g range → LSB/g = 16384
     float ay_f = ay / 16384.0f;
     float az_f = az / 16384.0f;
+
+    // Rotate mag and accel XY plane to compensate for non-standard chip mounting.
+    // Each step is 90° CCW: (x, y) → (−y, x).  Z is always vertical so unchanged.
+    for (int i = 0, r = mount_rotation_.load() & 3; i < r; ++i) {
+        float t;
+        t = mx; mx = -my; my = t;
+        t = ax_f; ax_f = -ay_f; ay_f = t;
+    }
     float norm  = sqrtf(ax_f*ax_f + ay_f*ay_f + az_f*az_f);
 
     if (norm < 0.1f) {

--- a/src/sensor/mpu9250.h
+++ b/src/sensor/mpu9250.h
@@ -35,6 +35,9 @@ public:
         int         mpu_addr         = 0x68;          // 0x68 (AD0 low) or 0x69 (AD0 high)
         float       declination_deg  = 0.0f;          // local magnetic declination (+E/-W)
         float       heading_offset   = 0.0f;          // mechanical mounting offset (degrees)
+        // Mounting orientation: 0=default, 1=90°CCW, 2=180°, 3=270°CCW (in XY plane).
+        // Use when the chip is physically rotated relative to the expected axis convention.
+        int         mount_rotation   = 0;
         // Hard-iron calibration offsets — persisted to config
         float       mag_bias_x       = 0.0f;
         float       mag_bias_y       = 0.0f;
@@ -62,6 +65,11 @@ public:
     void end_calibration();   // also calls set_mag_bias() internally
     bool is_calibrating() const { return calibrating_.load(); }
 
+    // Runtime mounting orientation (0–3, same units as Config::mount_rotation).
+    // Thread-safe: read from sensor thread, written from menu/render thread.
+    void set_mount_rotation(int r);
+    int  get_mount_rotation() const;
+
     // Direct bias access (set on load from config; get to persist on exit).
     void get_mag_bias(float& x, float& y, float& z) const;
     void set_mag_bias(float  x, float  y, float  z);
@@ -87,8 +95,9 @@ private:
     float adj_x_  = 1.0f, adj_y_ = 1.0f, adj_z_ = 1.0f;
 
     std::thread        thread_;
-    std::atomic<bool>  running_     { false };
-    std::atomic<bool>  calibrating_ { false };
+    std::atomic<bool>  running_       { false };
+    std::atomic<bool>  calibrating_   { false };
+    std::atomic<int>   mount_rotation_{ 0 };
 
     // Hard-iron calibration accumulators
     float cal_min_x_, cal_max_x_;


### PR DESCRIPTION
When the chip is physically rotated relative to the expected axis convention (X=forward, Y=left) both the mag heading and the accelerometer tilt-compensation use the wrong axes, causing head tilt to move the compass instead of head turns.

mount_rotation applies a 90°-step CCW rotation to both the magnetometer and accelerometer XY vectors before compute_heading runs, correcting for any of the four horizontal mounting positions. The setting is runtime-configurable from Compass → Onboard Compass → Mounting Orientation and persists to config.json.

https://claude.ai/code/session_017xAaFHoiBHVqGLxVhohcAh