### PR TITLE
Add heading axes preset to MPU-9250 for non-face-up chip mounting

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1346,6 +1346,27 @@ static std::vector<MenuItem> build_menu(
             [mpu9250]{ return mpu9250 && mpu9250->get_mount_rotation() == 3; }),
     };
 
+    std::vector<MenuItem> mpu_axes_menu = {
+        leaf_sel("0 — XY (chip flat, default)",
+            [mpu9250]{ if (mpu9250) mpu9250->set_heading_axes(0); },
+            [mpu9250]{ return mpu9250 && mpu9250->get_heading_axes() == 0; }),
+        leaf_sel("1 — ZY (chip face-forward)",
+            [mpu9250]{ if (mpu9250) mpu9250->set_heading_axes(1); },
+            [mpu9250]{ return mpu9250 && mpu9250->get_heading_axes() == 1; }),
+        leaf_sel("2 — XZ (chip on left side)",
+            [mpu9250]{ if (mpu9250) mpu9250->set_heading_axes(2); },
+            [mpu9250]{ return mpu9250 && mpu9250->get_heading_axes() == 2; }),
+        leaf_sel("3 — ZX (chip face-forward 90°)",
+            [mpu9250]{ if (mpu9250) mpu9250->set_heading_axes(3); },
+            [mpu9250]{ return mpu9250 && mpu9250->get_heading_axes() == 3; }),
+        leaf_sel("4 — YX (chip on right side)",
+            [mpu9250]{ if (mpu9250) mpu9250->set_heading_axes(4); },
+            [mpu9250]{ return mpu9250 && mpu9250->get_heading_axes() == 4; }),
+        leaf_sel("5 — YZ (chip face-up alt)",
+            [mpu9250]{ if (mpu9250) mpu9250->set_heading_axes(5); },
+            [mpu9250]{ return mpu9250 && mpu9250->get_heading_axes() == 5; }),
+    };
+
     std::vector<MenuItem> onboard_compass_menu = {
         toggle("Active",
             [mpu9250]{ return mpu9250 && mpu9250->is_running(); },
@@ -1361,6 +1382,7 @@ static std::vector<MenuItem> build_menu(
                 else   mpu9250->end_calibration();
             }),
         submenu("Mounting Orientation", std::move(mpu_mount_menu)),
+        submenu("Heading Axes",         std::move(mpu_axes_menu)),
     };
 
     std::vector<MenuItem> compass_bg_color_menu = make_color_items({
@@ -2442,6 +2464,7 @@ int main(int argc, char* argv[]) {
         mpu_cfg.declination_deg = jval(jm, "declination_deg", 0.0f);
         mpu_cfg.heading_offset  = jval(jm, "heading_offset",  0.0f);
         mpu_cfg.mount_rotation  = jval(jm, "mount_rotation",  0);
+        mpu_cfg.heading_axes    = jval(jm, "heading_axes",    0);
         if (jm.contains("mag_bias") && jm["mag_bias"].is_array() &&
             jm["mag_bias"].size() >= 3) {
             mpu_cfg.mag_bias_x = jm["mag_bias"][0].get<float>();
@@ -4014,6 +4037,7 @@ int main(int argc, char* argv[]) {
             mpu9250.get_mag_bias(bx, by, bz);
             cfg["mpu9250"]["mag_bias"]       = json::array({ bx, by, bz });
             cfg["mpu9250"]["mount_rotation"] = mpu9250.get_mount_rotation();
+            cfg["mpu9250"]["heading_axes"]   = mpu9250.get_heading_axes();
         }
 
         FILE* f = fopen(cfg_path.c_str(), "w");

--- a/src/sensor/mpu9250.cpp
+++ b/src/sensor/mpu9250.cpp
@@ -39,7 +39,8 @@ static constexpr uint8_t AK_MODE_CONT2_16BIT = 0x16; // 100 Hz, 16-bit output
 
 // ── Constructor / Destructor ──────────────────────────────────────────────────
 
-Mpu9250::Mpu9250(const Config& cfg) : cfg_(cfg), mount_rotation_(cfg.mount_rotation) {}
+Mpu9250::Mpu9250(const Config& cfg)
+    : cfg_(cfg), mount_rotation_(cfg.mount_rotation), heading_axes_(cfg.heading_axes) {}
 
 Mpu9250::~Mpu9250() { stop(); }
 
@@ -148,53 +149,69 @@ bool Mpu9250::init_ak8963() {
 void Mpu9250::set_mount_rotation(int r) { mount_rotation_.store(r & 3); }
 int  Mpu9250::get_mount_rotation() const { return mount_rotation_.load(); }
 
+void Mpu9250::set_heading_axes(int a) { heading_axes_.store(a); }
+int  Mpu9250::get_heading_axes() const { return heading_axes_.load(); }
+
 // ── Heading computation ───────────────────────────────────────────────────────
-// Tilt-compensated heading using accelerometer pitch/roll.
-// Axis convention for GY-9250 breakout (chip face up, connector down):
-//   MPU accel: X = forward, Y = right, Z = up (right-hand)
-//   AK8963 mag: X = forward, Y = left, Z = up
-//   (AK8963 Y is inverted relative to MPU Y — applied below)
-// Output is degrees true north, 0–360, increasing clockwise.
+// Preset 0 (default):  chip face-up,       X=fwd, Y=left, Z=up
+//   → tilt-compensated atan2(-my_h, mx_h)
+// Presets 1-5: chip in non-horizontal orientation — flat (no tilt comp)
+//   The formula is atan2(-B, A) where A/B are chosen per preset:
+//   1  ZY   chip face-forward / perpendicular to face (Z=fwd, Y=left)
+//   2  XZ   chip on its left side  (X=fwd, Z=left)
+//   3  ZX   chip face-forward, rotated 90° (Z=fwd, X=left)
+//   4  YX   chip on its right side (Y=fwd, X=left)
+//   5  YZ   chip face-up, alt 90°  (Y=fwd, Z=left)
+// mount_rotation (0-3) first rotates the XY plane in 90° CCW steps; use
+// this for fine-tuning within a given preset.
 
 float Mpu9250::compute_heading(float mx, float my, float mz,
                                 int16_t ax, int16_t ay, int16_t az) const {
-    // Normalize accelerometer to unit vector
-    float ax_f = ax / 16384.0f; // ±2g range → LSB/g = 16384
+    float ax_f = ax / 16384.0f;
     float ay_f = ay / 16384.0f;
     float az_f = az / 16384.0f;
 
-    // Rotate mag and accel XY plane to compensate for non-standard chip mounting.
-    // Each step is 90° CCW: (x, y) → (−y, x).  Z is always vertical so unchanged.
+    // In-plane mounting correction (XY rotation, 90° CCW per step)
     for (int i = 0, r = mount_rotation_.load() & 3; i < r; ++i) {
         float t;
         t = mx; mx = -my; my = t;
         t = ax_f; ax_f = -ay_f; ay_f = t;
     }
-    float norm  = sqrtf(ax_f*ax_f + ay_f*ay_f + az_f*az_f);
 
-    if (norm < 0.1f) {
-        // Sensor in free-fall or uninitialised — flat heading only
-        float heading = atan2f(-my, mx) * (180.0f / M_PI)
-                      + cfg_.declination_deg + cfg_.heading_offset;
-        if (heading < 0.f)   heading += 360.f;
-        if (heading >= 360.f) heading -= 360.f;
-        return heading;
+    // Select axis pair for the heading formula atan2(-B, A)
+    const int axes = heading_axes_.load();
+    float A, B;
+    switch (axes) {
+        case 1:  A =  mz; B =  my; break;   // ZY  — face-forward
+        case 2:  A =  mx; B = -mz; break;   // XZ  — left-side
+        case 3:  A = -mz; B =  mx; break;   // ZX  — face-forward 90°
+        case 4:  A =  my; B = -mx; break;   // YX  — right-side
+        case 5:  A =  my; B =  mz; break;   // YZ  — face-up alt
+        default: A =  mx; B =  my; break;   // 0: XY standard
     }
-    ax_f /= norm; ay_f /= norm; az_f /= norm;
 
-    // Pitch and roll from accelerometer (small-angle NED convention)
-    float pitch = asinf(-ax_f);               // nose-up positive
-    float roll  = atan2f(ay_f, az_f);         // right-up positive
+    float heading;
+    if (axes == 0) {
+        // Full tilt-compensated heading for the standard face-up orientation
+        float norm = sqrtf(ax_f*ax_f + ay_f*ay_f + az_f*az_f);
+        if (norm >= 0.1f) {
+            ax_f /= norm; ay_f /= norm; az_f /= norm;
+            float pitch = asinf(-ax_f);
+            float roll  = atan2f(ay_f, az_f);
+            float cp = cosf(pitch), sp = sinf(pitch);
+            float cr = cosf(roll),  sr = sinf(roll);
+            float mx_h =  mx * cp + mz * sp;
+            float my_h =  mx * sr * sp + my * cr - mz * sr * cp;
+            heading = atan2f(-my_h, mx_h) * (180.0f / M_PI);
+        } else {
+            heading = atan2f(-B, A) * (180.0f / M_PI);
+        }
+    } else {
+        // Flat heading for non-face-up orientations (no tilt compensation)
+        heading = atan2f(-B, A) * (180.0f / M_PI);
+    }
 
-    float cp = cosf(pitch), sp = sinf(pitch);
-    float cr = cosf(roll),  sr = sinf(roll);
-
-    // Rotate magnetometer into horizontal plane
-    float mx_h =  mx * cp + mz * sp;
-    float my_h =  mx * sr * sp + my * cr - mz * sr * cp;
-
-    float heading = atan2f(-my_h, mx_h) * (180.0f / M_PI)
-                  + cfg_.declination_deg + cfg_.heading_offset;
+    heading += cfg_.declination_deg + cfg_.heading_offset;
     if (heading < 0.f)   heading += 360.f;
     if (heading >= 360.f) heading -= 360.f;
     return heading;

--- a/src/sensor/mpu9250.h
+++ b/src/sensor/mpu9250.h
@@ -38,6 +38,7 @@ public:
         // Mounting orientation: 0=default, 1=90°CCW, 2=180°, 3=270°CCW (in XY plane).
         // Use when the chip is physically rotated relative to the expected axis convention.
         int         mount_rotation   = 0;
+        int         heading_axes     = 0;  // 0=XY(default) 1=ZY 2=XZ 3=ZX 4=YX 5=YZ
         // Hard-iron calibration offsets — persisted to config
         float       mag_bias_x       = 0.0f;
         float       mag_bias_y       = 0.0f;
@@ -70,6 +71,11 @@ public:
     void set_mount_rotation(int r);
     int  get_mount_rotation() const;
 
+    // Heading axis preset for 3-D mounting orientations (see mpu9250.cpp for values).
+    // Use when mount_rotation doesn't help, i.e. chip is not face-up.
+    void set_heading_axes(int a);
+    int  get_heading_axes() const;
+
     // Direct bias access (set on load from config; get to persist on exit).
     void get_mag_bias(float& x, float& y, float& z) const;
     void set_mag_bias(float  x, float  y, float  z);
@@ -98,6 +104,7 @@ private:
     std::atomic<bool>  running_       { false };
     std::atomic<bool>  calibrating_   { false };
     std::atomic<int>   mount_rotation_{ 0 };
+    std::atomic<int>   heading_axes_  { 0 };
 
     // Hard-iron calibration accumulators
     float cal_min_x_, cal_max_x_;


### PR DESCRIPTION
mount_rotation only rotated within the XY plane, which doesn't help when the chip's Z axis is horizontal (e.g. face-forward on a helmet). In that case atan2(-my, mx) reads the near-constant vertical field component, so turning the head barely changes the heading but tilting does — matching the reported symptom.

Six presets select which raw component pair feeds atan2(-B, A):
  0 XY — chip face-up, default (tilt-compensated)
  1 ZY — chip face-forward (Z points toward user's front)
  2 XZ — chip on its left side
  3 ZX — chip face-forward, rotated 90°
  4 YX — chip on its right side
  5 YZ — chip face-up alt

Presets 1-5 use flat heading (no tilt compensation, which is only valid for the standard face-up orientation). mount_rotation still applies first as an in-plane fine-tune within any preset. Persists to config.json as "mpu9250": {"heading_axes": N}.

https://claude.ai/code/session_017xAaFHoiBHVqGLxVhohcAh