### PR TITLE
Add FPS average, I2C scanner, and GPIO monitor to sys panel

### DIFF
--- a/src/app_state.h
+++ b/src/app_state.h
@@ -263,6 +263,7 @@ struct SysMetrics {
     // Frame-time metrics — updated by render thread each frame
     float    frame_time_ms  = 0.f;    // last frame duration in ms
     float    fps_avg        = 0.f;    // 1000 / frame_time_ms (instantaneous)
+    float    fps_avg_smooth = 0.f;    // EMA-smoothed FPS over fps_avg_interval_s
     float    ft_history[kSysHistLen]  = {};
     int      ft_history_head = 0;
 };
@@ -454,6 +455,19 @@ struct AppState {
     int xr_brightness     = 5;   // 1–7; mirrors last xr->set_brightness() call
     int xr_dimming        = 5;   // 0–9; mirrors last xr->set_dimming() call
     int xr_hud_brightness = 5;   // 1–9; mirrors last xr->set_hud_brightness() call
+
+    // FPS display smoothing: EMA time constant in seconds (1 / 5 / 10).
+    // Written by menu (render thread); read in render loop EMA computation.
+    int fps_avg_interval_s = 1;
+
+    // I2C bus scanner — triggered from menu, results written by background thread.
+    std::vector<uint8_t> i2c_scan_results;
+    bool                 i2c_scan_busy = false;
+    std::string          i2c_scan_bus  = "/dev/i2c-1";
+
+    // GPIO pin monitor — populated at startup from config; values updated ~1 Hz.
+    struct GpioPinState { int pin; int value; };  // value: 0/1, -1=unavailable
+    std::vector<GpioPinState> gpio_states;
 
     // Signals render thread to quit.
     std::atomic<bool> quit { false };

--- a/src/hud/hud_renderer.cpp
+++ b/src/hud/hud_renderer.cpp
@@ -422,7 +422,9 @@ void HudRenderer::draw_map_overlay(NVGcontext* vg, const AppState& s, float fw, 
 }
 
 void HudRenderer::draw_fps_nvg(NVGcontext* vg, const AppState& snap, float fw, float fh) {
-    const float fps = snap.sys_metrics.fps_avg;
+    const float fps = snap.sys_metrics.fps_avg_smooth > 0.f
+                        ? snap.sys_metrics.fps_avg_smooth
+                        : snap.sys_metrics.fps_avg;
     const float ft  = snap.sys_metrics.frame_time_ms;
     char buf[32];
     if (fps > 0.f)
@@ -2194,7 +2196,7 @@ void HudRenderer::draw_sys_panel(const AppState& snap, int w, int h, bool active
 
     // Panel geometry — top-left, fixed size
     constexpr float PW    = 340.f;
-    constexpr float PH    = 580.f;
+    constexpr float PH    = 750.f;
     constexpr float PAD   = 10.f;
     constexpr float MRG   = 14.f;   // left margin from screen edge
     const float px = MRG;
@@ -2360,21 +2362,30 @@ void HudRenderer::draw_sys_panel(const AppState& snap, int w, int h, bool active
     // ── PERFORMANCE ───────────────────────────────────────────────────────────
     section("PERFORMANCE");
 
-    // FPS + frame time sparkline
+    // FPS (smoothed) + frame time sparkline
     {
-        const float fps = snap.sys_metrics.fps_avg;
-        const float ft  = snap.sys_metrics.frame_time_ms;
-        char buf[48];
-        if (fps > 0.f)
-            snprintf(buf, sizeof(buf), "FPS  %4.1f", static_cast<double>(fps));
+        const float fps_s = snap.sys_metrics.fps_avg_smooth;
+        const float fps_r = snap.sys_metrics.fps_avg;
+        const float ft    = snap.sys_metrics.frame_time_ms;
+        char buf[64];
+        const float fps_show = fps_s > 0.f ? fps_s : fps_r;
+        if (fps_show > 0.f)
+            snprintf(buf, sizeof(buf), "FPS  %4.1f", static_cast<double>(fps_show));
         else
             snprintf(buf, sizeof(buf), "FPS  --");
-        hud_glow_text(dl, {px + PAD, cy}, buf, fps > 0.f, col_.glow_base, col_.text_fill);
+        hud_glow_text(dl, {px + PAD, cy}, buf, fps_show > 0.f, col_.glow_base, col_.text_fill);
         const float spw = PW - PAD * 2.f - 80.f;
         // Sparkline: frame time in ms, capped at 50ms (20 FPS floor)
         sparkline(snap.sys_metrics.ft_history, kSysHistLen, snap.sys_metrics.ft_history_head,
                   {px + PAD + 78.f, cy}, spw, lh, 50.f, col_.primary);
         cy += lh + 4.f;
+
+        if (fps_r > 0.f && fps_s > 0.f)
+            snprintf(buf, sizeof(buf), "Inst  %4.1f", static_cast<double>(fps_r));
+        else
+            snprintf(buf, sizeof(buf), "Inst  --");
+        hud_glow_text(dl, {px + PAD, cy}, buf, false, col_.glow_base, col_.text_dim);
+        cy += lh + 2.f;
 
         if (ft > 0.f)
             snprintf(buf, sizeof(buf), "Frame  %.1fms", static_cast<double>(ft));
@@ -2447,6 +2458,54 @@ void HudRenderer::draw_sys_panel(const AppState& snap, int w, int h, bool active
         }
         hud_glow_text(dl, {px + PAD + 4.f, cy}, buf, snap.ssh.active,
                       col_.glow_base, col_.text_fill);
+    }
+
+    // ── I2C ───────────────────────────────────────────────────────────────────
+    section("I2C");
+    {
+        char buf[64];
+        if (snap.i2c_scan_busy) {
+            hud_glow_text(dl, {px + PAD, cy}, "Scanning...", true, col_.glow_base, col_.warn);
+            cy += lh + 4.f;
+        } else if (snap.i2c_scan_results.empty()) {
+            snprintf(buf, sizeof(buf), "%s  no scan", snap.i2c_scan_bus.c_str());
+            hud_glow_text(dl, {px + PAD, cy}, buf, false, col_.glow_base, col_.text_dim);
+            cy += lh + 4.f;
+        } else {
+            snprintf(buf, sizeof(buf), "Bus: %s", snap.i2c_scan_bus.c_str());
+            hud_glow_text(dl, {px + PAD, cy}, buf, false, col_.glow_base, col_.text_dim);
+            cy += lh + 2.f;
+            constexpr int kCols = 6;
+            int col_idx = 0;
+            const float cell_w = (PW - PAD * 2.f) / kCols;
+            for (uint8_t addr : snap.i2c_scan_results) {
+                snprintf(buf, sizeof(buf), "0x%02X", static_cast<int>(addr));
+                const float ax = px + PAD + col_idx * cell_w;
+                dl->AddRectFilled({ax, cy}, {ax + cell_w - 2.f, cy + lh},
+                                  with_alpha(col_.primary, 30), 2.f);
+                hud_glow_text(dl, {ax + 2.f, cy}, buf, true, col_.glow_base, col_.text_fill);
+                if (++col_idx >= kCols) { col_idx = 0; cy += lh + 3.f; }
+            }
+            if (col_idx > 0) cy += lh + 3.f;
+            cy += 2.f;
+        }
+    }
+
+    // ── GPIO ──────────────────────────────────────────────────────────────────
+    if (!snap.gpio_states.empty()) {
+        section("GPIO");
+        for (const auto& ps : snap.gpio_states) {
+            char buf[32];
+            const bool hi  = (ps.value == 1);
+            const bool na  = (ps.value < 0);
+            const ImU32 vc = na ? col_.ind_inactive : (hi ? col_.ind_good : col_.text_dim);
+            snprintf(buf, sizeof(buf), "  GPIO%-3d  %s", ps.pin,
+                     na ? "N/A" : (hi ? "HI" : "LO"));
+            dl->AddCircleFilled({px + PAD + 5.f, cy + lh * 0.5f}, 4.f, vc);
+            hud_glow_text(dl, {px + PAD + 4.f, cy}, buf, !na, col_.glow_base, vc);
+            cy += lh + 3.f;
+        }
+        cy += 2.f;
     }
 
     if (font_mono_) ImGui::PopFont();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,8 +47,11 @@
 #define GIT_HASH "unknown"
 #endif
 
-#include <fstream>
 #include <unistd.h>
+#include <fcntl.h>
+#include <cerrno>
+#include <sys/ioctl.h>
+#include <linux/i2c-dev.h>
 
 using json = nlohmann::json;
 
@@ -220,6 +223,72 @@ struct KeyRepeat {
         return false;
     }
 };
+
+// ── I2C bus scanner ───────────────────────────────────────────────────────────
+// Runs in a background thread. Opens the bus, probes addresses 0x08–0x77, stores
+// found addresses in state.i2c_scan_results, then clears i2c_scan_busy.
+static void run_i2c_scan(AppState* sp) {
+    std::string bus;
+    { std::lock_guard<std::mutex> lk(sp->mtx); bus = sp->i2c_scan_bus; }
+
+    std::vector<uint8_t> found;
+    int fd = open(bus.c_str(), O_RDWR);
+    if (fd >= 0) {
+        for (int addr = 0x08; addr <= 0x77; ++addr) {
+            if (ioctl(fd, I2C_SLAVE, addr) < 0) continue;
+            uint8_t buf = 0;
+            if (read(fd, &buf, 1) >= 0 || (errno != ENODEV && errno != ENXIO))
+                found.push_back(static_cast<uint8_t>(addr));
+        }
+        close(fd);
+    }
+
+    std::lock_guard<std::mutex> lk(sp->mtx);
+    sp->i2c_scan_results = std::move(found);
+    sp->i2c_scan_busy    = false;
+}
+
+// ── GPIO poll (sysfs) ─────────────────────────────────────────────────────────
+// Called from main loop ~1 Hz. Reads each monitored pin via sysfs export path.
+static void poll_gpio_states(AppState& state) {
+    // Export unexported pins and read values
+    for (auto& ps : state.gpio_states) {
+        // Try export (idempotent — ignore EBUSY)
+        {
+            int efd = open("/sys/class/gpio/export", O_WRONLY);
+            if (efd >= 0) {
+                char buf[16];
+                int n = snprintf(buf, sizeof(buf), "%d", ps.pin);
+                (void)write(efd, buf, n);
+                close(efd);
+            }
+        }
+        // Set direction to "in" (idempotent)
+        {
+            char path[64];
+            snprintf(path, sizeof(path), "/sys/class/gpio/gpio%d/direction", ps.pin);
+            int dfd = open(path, O_WRONLY);
+            if (dfd >= 0) {
+                (void)write(dfd, "in", 2);
+                close(dfd);
+            }
+        }
+        // Read value
+        {
+            char path[64];
+            snprintf(path, sizeof(path), "/sys/class/gpio/gpio%d/value", ps.pin);
+            int vfd = open(path, O_RDONLY);
+            if (vfd >= 0) {
+                char val = '?';
+                if (read(vfd, &val, 1) == 1)
+                    ps.value = (val == '1') ? 1 : 0;
+                close(vfd);
+            } else {
+                ps.value = -1;
+            }
+        }
+    }
+}
 
 // ── Menu definition ───────────────────────────────────────────────────────────
 
@@ -2210,6 +2279,30 @@ static std::vector<MenuItem> build_menu(
         }),
     };
 
+    std::vector<MenuItem> fps_interval_menu = {
+        leaf_sel("1 second",  [state_ptr]{ state_ptr->fps_avg_interval_s = 1;  }, [state_ptr]{ return state_ptr->fps_avg_interval_s == 1;  }),
+        leaf_sel("5 seconds", [state_ptr]{ state_ptr->fps_avg_interval_s = 5;  }, [state_ptr]{ return state_ptr->fps_avg_interval_s == 5;  }),
+        leaf_sel("10 seconds",[state_ptr]{ state_ptr->fps_avg_interval_s = 10; }, [state_ptr]{ return state_ptr->fps_avg_interval_s == 10; }),
+    };
+
+    std::vector<MenuItem> i2c_bus_menu = {
+        leaf_sel("/dev/i2c-0", [state_ptr]{ std::lock_guard<std::mutex> lk(state_ptr->mtx); state_ptr->i2c_scan_bus = "/dev/i2c-0"; }, [state_ptr]{ return state_ptr->i2c_scan_bus == "/dev/i2c-0"; }),
+        leaf_sel("/dev/i2c-1", [state_ptr]{ std::lock_guard<std::mutex> lk(state_ptr->mtx); state_ptr->i2c_scan_bus = "/dev/i2c-1"; }, [state_ptr]{ return state_ptr->i2c_scan_bus == "/dev/i2c-1"; }),
+        leaf_sel("/dev/i2c-2", [state_ptr]{ std::lock_guard<std::mutex> lk(state_ptr->mtx); state_ptr->i2c_scan_bus = "/dev/i2c-2"; }, [state_ptr]{ return state_ptr->i2c_scan_bus == "/dev/i2c-2"; }),
+    };
+
+    std::vector<MenuItem> diagnostics_menu = {
+        leaf("Scan I2C Bus", [state_ptr]{
+            bool already;
+            { std::lock_guard<std::mutex> lk(state_ptr->mtx); already = state_ptr->i2c_scan_busy; }
+            if (!already) {
+                { std::lock_guard<std::mutex> lk(state_ptr->mtx); state_ptr->i2c_scan_busy = true; state_ptr->i2c_scan_results.clear(); }
+                std::thread(run_i2c_scan, state_ptr).detach();
+            }
+        }),
+        submenu("I2C Bus",    std::move(i2c_bus_menu)),
+    };
+
     std::vector<MenuItem> system_menu = {
         submenu("Headset",          std::move(headset_menu)),
         submenu("Audio",            std::move(audio_menu)),
@@ -2220,6 +2313,8 @@ static std::vector<MenuItem> build_menu(
         toggle("FPS Overlay",
             [fps_overlay_active]{ return fps_overlay_active && *fps_overlay_active; },
             [fps_overlay_active](bool v){ if (fps_overlay_active) *fps_overlay_active = v; }),
+        submenu("FPS Average",   std::move(fps_interval_menu)),
+        submenu("Diagnostics",   std::move(diagnostics_menu)),
         toggle("SSH Access",
             [state_ptr]{ return state_ptr && state_ptr->ssh.active; },
             [state_ptr](bool v){
@@ -2640,6 +2735,18 @@ int main(int argc, char* argv[]) {
     if (cfg.contains("qr")) {
         state.qr_scan_main = cfg["qr"].value("scan_main", state.qr_scan_main);
         state.qr_scan_usb  = cfg["qr"].value("scan_usb",  state.qr_scan_usb);
+    }
+
+    // FPS average interval
+    state.fps_avg_interval_s = jval(cfg, "fps_avg_interval_s", 1);
+
+    // I2C scanner bus
+    state.i2c_scan_bus = cfg.value("i2c_scan_bus", std::string("/dev/i2c-1"));
+
+    // GPIO monitor pins (array of integers in config)
+    if (cfg.contains("gpio_monitor_pins") && cfg["gpio_monitor_pins"].is_array()) {
+        for (auto& p : cfg["gpio_monitor_pins"])
+            state.gpio_states.push_back({ p.get<int>(), -1 });
     }
 
     SplashConfig splash_cfg;
@@ -3458,6 +3565,17 @@ int main(int argc, char* argv[]) {
                 const int h2    = (m.ft_history_head + 1) % kSysHistLen;
                 m.ft_history[h2]   = m.frame_time_ms;
                 m.ft_history_head  = h2;
+
+                // EMA-smoothed FPS — alpha = exp(-dt / interval)
+                static float fps_ema = 0.f;
+                const float  fps_inst  = m.fps_avg;
+                const float  interval  = static_cast<float>(state.fps_avg_interval_s > 0
+                                             ? state.fps_avg_interval_s : 1);
+                const float  alpha     = (dt > 0.f) ? expf(-dt / interval) : 0.99f;
+                fps_ema = (fps_ema > 0.f)
+                    ? fps_ema * alpha + fps_inst * (1.f - alpha)
+                    : fps_inst;
+                m.fps_avg_smooth = fps_ema;
             }
             // Knob event age (computed on render thread, written here)
             state.serial_metrics.knob_event_age_ms = knob.event_age_ms();
@@ -3497,6 +3615,10 @@ int main(int argc, char* argv[]) {
             snap.qr_scan_main       = state.qr_scan_main;
             snap.qr_scan_usb        = state.qr_scan_usb;
             snap.notifs             = state.notifs;
+            snap.i2c_scan_results   = state.i2c_scan_results;
+            snap.i2c_scan_busy      = state.i2c_scan_busy;
+            snap.i2c_scan_bus       = state.i2c_scan_bus;
+            snap.gpio_states        = state.gpio_states;
             memcpy(snap.lora_node_colors, state.lora_node_colors,
                    sizeof(state.lora_node_colors));
         }
@@ -3546,6 +3668,17 @@ int main(int argc, char* argv[]) {
                 if (s_smooth < 0.f) s_smooth += 360.f;
             }
             snap.compass_heading = s_smooth;
+        }
+
+        // GPIO monitor: poll sysfs ~1 Hz (every ~60 frames at 60 FPS).
+        // gpio_states is render-thread-only; no mutex needed for either access.
+        if (!state.gpio_states.empty()) {
+            static int gpio_frame_ctr = 0;
+            if (++gpio_frame_ctr >= 60) {
+                gpio_frame_ctr = 0;
+                poll_gpio_states(state);
+                snap.gpio_states = state.gpio_states;
+            }
         }
 
         // Overlay-active flags mirror the exact condition used in draw_pip calls.
@@ -3992,6 +4125,9 @@ int main(int argc, char* argv[]) {
 
         cfg["qr"]["scan_main"] = state.qr_scan_main;
         cfg["qr"]["scan_usb"]  = state.qr_scan_usb;
+
+        cfg["fps_avg_interval_s"] = state.fps_avg_interval_s;
+        cfg["i2c_scan_bus"]       = state.i2c_scan_bus;
 
         {
             const auto& mo          = state.map_overlay;


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **FPS average display**: EMA-smoothed FPS replaces instantaneous in the corner overlay and sys panel. Time constant is configurable (1s/5s/10s) via System → FPS Average menu. The instantaneous value is shown as a secondary "Inst" line in the sys panel.
- **I2C bus scanner**: System → Diagnostics → Scan I2C Bus runs a background probe of addresses 0x08–0x77 on the selected bus (`/dev/i2c-0/1/2`). Found device addresses are displayed in a grid in the new "I2C" section of the sys panel. Results persist until the next scan.
- **GPIO pin monitor**: Reads configured pins via Linux sysfs ~1 Hz. Pins are set in `config.json` as `"gpio_monitor_pins": [4, 17, 27]`. Current state (HI/LO/N/A) is shown in a new "GPIO" section of the sys panel.

## Config additions

```json
"fps_avg_interval_s": 1,
"i2c_scan_bus": "/dev/i2c-1",
"gpio_monitor_pins": [4, 17, 27]
```

## Test plan

- [ ] Build on CM5 target
- [ ] FPS overlay shows smoothed value; changing interval (1s/5s/10s) from menu visibly changes how quickly the displayed FPS reacts to load changes
- [ ] Sys panel PERFORMANCE section shows smoothed FPS + "Inst" secondary line
- [ ] System → Diagnostics → Scan I2C Bus starts scan (shows "Scanning..." briefly), then populates addresses
- [ ] Try with `/dev/i2c-1` (MPU-9250 at 0x68 should appear)
- [ ] Sys panel I2C section shows addresses in hex grid after scan
- [ ] Add `"gpio_monitor_pins": [4]` to config, restart; sys panel GPIO section shows GPIO4 with current level

https://claude.ai/code/session_017xAaFHoiBHVqGLxVhohcAh
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_017xAaFHoiBHVqGLxVhohcAh)_