### PR TITLE
Fix draw_pip_underlays: restore parameter names dropped during no-op …

### DIFF
--- a/src/hud/hud_renderer.cpp
+++ b/src/hud/hud_renderer.cpp
@@ -550,7 +550,7 @@ void HudRenderer::draw_pip_nvg_single(NVGcontext* vg, unsigned int tex,
 }
 
 void HudRenderer::draw_pip_underlays(
-    unsigned int /*tex1*/, bool /*act1*/, const OverlayConfig& /*c1*/,
+    unsigned int tex1, bool act1, const OverlayConfig& c1,
     unsigned int tex2, bool act2, const OverlayConfig& c2,
     unsigned int tex3, bool act3, const OverlayConfig& c3,
     int ew, int eh)


### PR DESCRIPTION
…swap

tex1/act1/c1 were left commented out when the function was re-activated, causing undeclared identifier errors at build time.

https://claude.ai/code/session_017xAaFHoiBHVqGLxVhohcAh