### PR TITLE
Rendering improvements: NVG consolidation, USB resolution menu, particle redesign, desktop fullscreen

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2481,6 +2481,7 @@ int main(int argc, char* argv[]) {
     xr_cfg.use_beast_camera = jval(jvtr,  "use_beast_camera", true);
     xr_cfg.enable_imu       = jval(jvtr,  "enable_imu",       true);
     xr_cfg.frameless        = jval(jdisp, "frameless",         false);
+    xr_cfg.fullscreen       = jval(jdisp, "fullscreen",        false);
 
     CamConfig owl_left, owl_right;
 

--- a/src/vitrue/xr_display.cpp
+++ b/src/vitrue/xr_display.cpp
@@ -97,14 +97,20 @@ bool XRDisplay::init() {
     glfwWindowHint(GLFW_DOUBLEBUFFER,          GLFW_TRUE);
     glfwWindowHint(GLFW_STENCIL_BITS,          8);  // required for NanoVG stencil fills
     glfwWindowHint(GLFW_RESIZABLE,  GLFW_FALSE);
-    glfwWindowHint(GLFW_DECORATED,  cfg_.frameless ? GLFW_FALSE : GLFW_TRUE);
+    const bool do_fullscreen = cfg_.fullscreen && !mon;
+    glfwWindowHint(GLFW_DECORATED, (cfg_.frameless || do_fullscreen) ? GLFW_FALSE : GLFW_TRUE);
+    glfwWindowHint(GLFW_FLOATING,  do_fullscreen ? GLFW_TRUE : GLFW_FALSE);
 
-    mon = choose_monitor();
     window_ = glfwCreateWindow(disp_w_, disp_h_, "ProtoHUD", mon, nullptr);
     if (!window_) {
         std::cerr << "[xr] glfwCreateWindow failed\n";
         glfwTerminate();
         return false;
+    }
+
+    if (do_fullscreen) {
+        glfwSetWindowPos(window_, 0, 0);
+        glfwFocusWindow(window_);
     }
 
     glfwMakeContextCurrent(window_);

--- a/src/vitrue/xr_display.h
+++ b/src/vitrue/xr_display.h
@@ -29,6 +29,7 @@ struct XRConfig {
     bool use_beast_camera = true;
     bool enable_imu       = true;
     bool frameless        = false;  // remove OS window decorations (windowed mode only)
+    bool fullscreen       = false;  // borderless always-on-top window covering taskbar (desktop only)
 };
 
 class XRDisplay {


### PR DESCRIPTION
## Summary

- **NVG frame consolidation**: Merges three separate `nvgBeginFrame/nvgEndFrame` pairs (pip underlays, HUD chrome, toasts) into one shared frame per render cycle via `begin_nvg_overlay`/`end_nvg_overlay` — saves 2× GL state flush round-trips per frame (~1–2 ms)
- **`glTexSubImage2D` for USB cameras**: Reuses GPU texture allocation when frame dimensions are unchanged, falling back to `glTexImage2D` only on resolution change (~1–2 ms per active camera per frame)
- **USB camera resolution menu**: High/Med/Low resolution submenu (1280×720 / 960×540 / 640×360) per USB slot; default lowered to 640×360; resolution persisted to config
- **Particle visual redesign**: Dot particles replaced with 6-pointed sparkles; line particles replaced with gradient-fade comet tails (radial glow head + linear gradient tail)
- **SmartKnob button protocol**: Added `BUTTON_EVENT (0x04)` to `protocols.h`; wired encoder and back buttons to menu open/select/back actions
- **Desktop fullscreen/borderless window**: When `"fullscreen": true` in config and no XR glasses are detected, the GLFW window is created borderless + always-on-top and positioned at (0,0) — covers the taskbar with no title bar. Glasses-connected path is unchanged.

## Test plan

- [ ] Build on device: `cmake --build build`
- [ ] With USB pip active: verify FPS improvement vs baseline; pip border behind HUD chrome
- [ ] Toasts render above HUD chrome
- [ ] Change USB resolution via menu while pip is open — stream restarts at new resolution
- [ ] Restart app — resolution preference persists from config
- [ ] Sparkle dots and comet tails visible on particle effects
- [ ] SmartKnob encoder button opens/closes menu; back button navigates up
- [ ] Run on desktop with glasses disconnected + `"fullscreen": true` — window fills screen, no title bar, above taskbar
- [ ] Run with `"fullscreen": false` — original windowed behaviour restored
- [ ] Run with glasses connected — exclusive fullscreen on glasses monitor unchanged

https://claude.ai/code/session_017xAaFHoiBHVqGLxVhohcAh

---
_Generated by [Claude Code](https://claude.ai/code/session_017xAaFHoiBHVqGLxVhohcAh)_