### PR TITLE
Fix crash on close and startup USB timeouts in XRDisplay

### DIFF
--- a/src/vitrue/xr_display.cpp
+++ b/src/vitrue/xr_display.cpp
@@ -12,6 +12,7 @@
 #include <iostream>
 #include <sstream>
 #include <cstring>
+#include <thread>
 
 // ── Singleton trampoline ──────────────────────────────────────────────────────
 XRDisplay* XRDisplay::s_instance_ = nullptr;
@@ -246,6 +247,11 @@ void XRDisplay::present() {
 
 // ── shutdown ──────────────────────────────────────────────────────────────────
 void XRDisplay::shutdown() {
+    // Null the static instance pointer first so any in-flight SDK callbacks
+    // (IMU, state) see nullptr and return immediately rather than touching
+    // fields we're about to destroy.
+    if (s_instance_ == this) s_instance_ = nullptr;
+
     rt_left_.destroy();
     rt_right_.destroy();
     if (blit_prog_) { glDeleteProgram(blit_prog_); blit_prog_ = 0; }
@@ -260,8 +266,11 @@ void XRDisplay::shutdown() {
         device_ = nullptr;
     }
 
-    if (window_) { glfwDestroyWindow(window_); window_ = nullptr; }
-    glfwTerminate();
+    if (window_) {
+        glfwDestroyWindow(window_);
+        window_ = nullptr;
+        glfwTerminate();  // only called once: when we actually destroy the window
+    }
 }
 
 // ── VITURE SDK init ───────────────────────────────────────────────────────────
@@ -284,6 +293,9 @@ bool XRDisplay::find_and_connect() {
     }
 
     xr_device_provider_register_state_callback(device_, s_state_cb);
+    // Give the glasses ~150 ms to settle after start() before sending display
+    // mode commands — without this the USB transfers time out (-7) on cold plug.
+    std::this_thread::sleep_for(std::chrono::milliseconds(150));
     set_sbs_display_mode();
     if (cfg_.enable_imu) open_imu();
     return true;


### PR DESCRIPTION
Two shutdown bugs and one init timing issue:

1. glfwTerminate() was called unconditionally in shutdown(), causing a double-free when main() calls xr.shutdown() explicitly and then the XRDisplay destructor calls shutdown() again on stack unwind. Fixed by moving glfwTerminate() inside the if(window_) guard so it only runs when the window is actually being destroyed.

2. s_instance_ was cleared in the destructor after shutdown() completed, leaving a window where in-flight IMU/state SDK callbacks could fire on the SDK thread and access a partially-destroyed object. Now cleared at the start of shutdown() so callbacks see nullptr immediately.

3. set_sbs_display_mode() was called immediately after start(), before the glasses finish USB enumeration. Added 150ms settle delay to prevent the -7 timeout errors on cold plug.

https://claude.ai/code/session_017xAaFHoiBHVqGLxVhohcAh