### PR TITLE
Validate MJPEG frame markers before decode to prevent focus stealing

### DIFF
--- a/src/camera/viture_camera.cpp
+++ b/src/camera/viture_camera.cpp
@@ -73,6 +73,15 @@ void VitureCamera::on_frame(const void* raw) {
 
     // The Beast camera delivers MJPEG — decode via OpenCV
     if (f->format == XR_CAMERA_FORMAT_MJPEG) {
+        // Validate JPEG framing before decode: libjpeg writes "Corrupt JPEG"
+        // warnings to stderr on truncated frames, which some Wayland compositors
+        // treat as terminal urgency and use to steal focus from our window.
+        // SOI = 0xFF 0xD8, EOI = 0xFF 0xD9.  Drop silently if either is missing.
+        if (f->size < 4
+            || f->data[0] != 0xFF || f->data[1] != 0xD8
+            || f->data[f->size - 2] != 0xFF || f->data[f->size - 1] != 0xD9)
+            return;
+
         std::vector<uint8_t> jpeg(f->data, f->data + f->size);
         cv::Mat decoded = cv::imdecode(jpeg, cv::IMREAD_COLOR);
         if (decoded.empty()) return;


### PR DESCRIPTION
Truncated Beast camera frames cause libjpeg to write "Corrupt JPEG data" warnings to stderr. On Wayland compositors (RPi OS Bookworm default), stderr output to a terminal triggers a window urgency/raise event that steals focus from the fullscreen ProtoHUD window.

Fix: check SOI (0xFF 0xD8) and EOI (0xFF 0xD9) markers before passing the buffer to cv::imdecode. Incomplete frames are dropped silently with no decoder invocation and no stderr output.

https://claude.ai/code/session_017xAaFHoiBHVqGLxVhohcAh