### PR TITLE
Stability fixes + menu reorganization + context-panel framework

### DIFF
--- a/config/config.example.json
+++ b/config/config.example.json
@@ -260,7 +260,10 @@
   "splash": {
     "enabled":       true,
     "animated":      true,
+    "_image_note":   "PNG (RGBA preferred). Relative paths resolve from the binary directory; absolute paths used as-is. Example: \"assets/branding/logo.png\".",
     "image":         "",
+    "logo_size_px":  104,
+    "show_ring":     true,
     "min_display_s": 2.0,
     "title":         "PROTOHUD",
     "subtitle":      "XR HUD System"

--- a/src/camera/camera_manager.h
+++ b/src/camera/camera_manager.h
@@ -101,6 +101,10 @@ public:
     DmaCamera* owl_left()  { return owl_left_.get();  }
     DmaCamera* owl_right() { return owl_right_.get(); }
 
+    // Configured model name for each CSI camera, or empty if the slot is absent.
+    std::string owl_left_model()  const { return owl_left_  ? owl_left_->model_name()  : std::string(); }
+    std::string owl_right_model() const { return owl_right_ ? owl_right_->model_name() : std::string(); }
+
     // ── USB open / close (safe to call from any thread) ──────────────────────
     void open_usb1();
     void close_usb1();

--- a/src/camera/dma_camera.h
+++ b/src/camera/dma_camera.h
@@ -90,6 +90,7 @@ public:
     bool  is_ok()           const { return ok_; }
     int   width()           const { return cfg_.width; }
     int   height()          const { return cfg_.height; }
+    const std::string& model_name() const { return cfg_.model_name; }
     float analogue_gain()   const { return last_analogue_gain_.load(); }
 
 private:

--- a/src/crash_reporter.cpp
+++ b/src/crash_reporter.cpp
@@ -137,7 +137,9 @@ void install(const AppState* state,
              const std::string& git_hash) {
     g_state = state;
     strncpy(g_crash_dir, crash_dir.c_str(), sizeof(g_crash_dir) - 1);
+    g_crash_dir[sizeof(g_crash_dir) - 1] = '\0';
     strncpy(g_git_hash,  git_hash.c_str(),  sizeof(g_git_hash)  - 1);
+    g_git_hash[sizeof(g_git_hash) - 1] = '\0';
 
     struct sigaction sa {};
     sa.sa_handler = crash_handler;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3089,6 +3089,8 @@ int main(int argc, char* argv[]) {
         splash_cfg.enabled       = js.value("enabled",       splash_cfg.enabled);
         splash_cfg.animated      = js.value("animated",      splash_cfg.animated);
         splash_cfg.image_path    = js.value("image",         splash_cfg.image_path);
+        splash_cfg.logo_size_px  = js.value("logo_size_px",  splash_cfg.logo_size_px);
+        splash_cfg.show_ring     = js.value("show_ring",     splash_cfg.show_ring);
         splash_cfg.min_display_s = js.value("min_display_s", splash_cfg.min_display_s);
         splash_cfg.title         = js.value("title",         splash_cfg.title);
         splash_cfg.subtitle      = js.value("subtitle",      splash_cfg.subtitle);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -532,17 +532,17 @@ static std::vector<MenuItem> build_menu(
     }
 
     std::vector<MenuItem> nv_menu = {
-        toggle("Night Vision",
+        toggle("Enable Low-Light",
             [&state]{ return state.night_vision.nv_enabled; },
             [&state](bool v){
                 state.night_vision.nv_enabled  = v;
                 state.night_vision.exposure_ev = v ? 3.0f : 0.0f;
                 state.night_vision.shutter_us  = v ? 40000 : 16667;
             }),
-        toggle("Auto Night Vision",
+        toggle("Auto Low-Light",
             [&state]{ return state.night_vision.auto_nv; },
             [&state](bool v){ state.night_vision.auto_nv = v; }),
-        slider("Auto NV Gain Threshold", 1.5f, 16.f, 0.5f, "x",
+        slider("Auto Gain Threshold", 1.5f, 16.f, 0.5f, "x",
             [&state]{ return state.night_vision.auto_nv_gain_threshold; },
             [&state](float v){ state.night_vision.auto_nv_gain_threshold = v; }),
         slider("Exposure (EV)", -3.f, 3.f, 0.5f, " EV",
@@ -776,26 +776,51 @@ static std::vector<MenuItem> build_menu(
         };
     };
 
-    std::vector<MenuItem> main_cameras_menu = {
-        toggle("Theater Mode",
+    // Raw View groups the camera-passthrough toggle with its placement options.
+    std::vector<MenuItem> raw_view_menu = {
+        toggle("Enable",
             [&state]{ return state.theater_mode; },
             [&state](bool v){ state.theater_mode = v; }),
-        submenu("Theater Position", std::move(theater_pos_menu)),
+        submenu("Position", std::move(theater_pos_menu)),
+    };
+
+    // Build per-camera submenu labels from the configured model names.  When both
+    // cameras share a model (e.g. default OWLsight pair) disambiguate with #1/#2
+    // plus an eye hint; otherwise show "<Model> (Left/Right)".
+    auto cam_label = [](std::string model, const char* eye, const char* index) {
+        if (model.empty()) model = "Owlsight";
+        std::string out = std::move(model);
+        if (index) { out += " #"; out += index; }
+        out += " (";
+        out += eye;
+        out += ")";
+        return out;
+    };
+    std::string left_model  = cameras ? cameras->owl_left_model()  : std::string();
+    std::string right_model = cameras ? cameras->owl_right_model() : std::string();
+    std::string left_norm   = left_model.empty()  ? "Owlsight" : left_model;
+    std::string right_norm  = right_model.empty() ? "Owlsight" : right_model;
+    const bool same_model   = (left_norm == right_norm);
+    std::string left_label  = cam_label(left_model,  "Left",  same_model ? "1" : nullptr);
+    std::string right_label = cam_label(right_model, "Right", same_model ? "2" : nullptr);
+
+    std::vector<MenuItem> main_cameras_menu = {
+        submenu("Left Eye Source",  make_eye_source_menu(left_eye_src)),
+        submenu("Right Eye Source", make_eye_source_menu(right_eye_src)),
+        submenu("Raw View",         std::move(raw_view_menu)),
         toggle("Swap Cameras",
             [&state]{ return state.cameras_swapped; },
             [&state](bool v){ state.cameras_swapped = v; }),
         submenu("Resolution",       std::move(resolution_presets)),
-        submenu("Left Eye Source",  make_eye_source_menu(left_eye_src)),
-        submenu("Right Eye Source", make_eye_source_menu(right_eye_src)),
-        submenu("Digital Zoom",  std::move(zoom_menu)),
-        submenu("Mirror Crop",   std::move(mirror_crop_menu)),
-        submenu("Single Camera", std::move(single_cam_menu)),
-        submenu("Left Camera",   std::move(left_cam_menu)),
-        submenu("Right Camera",  std::move(right_cam_menu)),
-        submenu("Night Vision",  std::move(nv_menu)),
-        submenu("Autofocus Both", std::move(af_both_menu)),
-        submenu("Capture Photo", std::move(capture_menu)),
-        submenu("QR Scan",       std::move(qr_menu)),
+        submenu("Digital Zoom",     std::move(zoom_menu)),
+        submenu("Mirror Crop",      std::move(mirror_crop_menu)),
+        submenu("Single Camera",    std::move(single_cam_menu)),
+        submenu(left_label,         std::move(left_cam_menu)),
+        submenu(right_label,        std::move(right_cam_menu)),
+        submenu("Low-Light Mode",   std::move(nv_menu)),
+        submenu("Autofocus Both",   std::move(af_both_menu)),
+        submenu("Capture Photo",    std::move(capture_menu)),
+        submenu("QR Scan",          std::move(qr_menu)),
     };
 
     // ── Headset controls ──────────────────────────────────────────────────────
@@ -811,6 +836,12 @@ static std::vector<MenuItem> build_menu(
             [xr, &state](float v){
                 state.xr_hud_brightness = static_cast<int>(v);
                 if (xr) xr->set_hud_brightness(static_cast<int>(v));
+            }),
+        slider("Backlight Brightness", 1.f, 7.f, 1.f, "",
+            [&state]{ return static_cast<float>(state.xr_brightness); },
+            [xr, &state](float v){
+                state.xr_brightness = static_cast<int>(v);
+                if (xr) xr->set_brightness(static_cast<int>(v));
             }),
         leaf("Recenter",  [xr]{ if (xr) xr->recenter_tracking(); }),
         leaf("Gaze Lock", [xr]{ if (xr) xr->toggle_gaze_lock(); }),
@@ -1273,8 +1304,8 @@ static std::vector<MenuItem> build_menu(
     };
 
     std::vector<MenuItem> cameras_menu = {
-        submenu("Main Cameras", std::move(main_cameras_menu)),
-        submenu("USB Cameras",  std::move(usb_cameras_menu)),
+        submenu("CSI Camera Controls", std::move(main_cameras_menu)),
+        submenu("USB Cameras",         std::move(usb_cameras_menu)),
     };
 
     // ── Android mirror ────────────────────────────────────────────────────────
@@ -1292,34 +1323,15 @@ static std::vector<MenuItem> build_menu(
         make_size_slider("Size", android_cfg),
     };
 
-    // ── Face Source (Teensy vs Protoface) ────────────────────────────────────
-    std::vector<MenuItem> face_source_menu;
-    if (active_face_pp && teensy_option && fp_option) {
-        face_source_menu.push_back(leaf_sel("Teensy (ProtoTracer)",
-            [active_face_pp, teensy_option]{ *active_face_pp = teensy_option; },
-            [active_face_pp, teensy_option]{ return *active_face_pp == teensy_option; }
-        ));
-        face_source_menu.push_back(leaf_sel("Protoface",
-            [active_face_pp, fp_option]{ *active_face_pp = fp_option; },
-            [active_face_pp, fp_option]{ return *active_face_pp == fp_option; }
-        ));
-    }
-
-    // ── Prototracer (face controller) submenu ─────────────────────────────────
-    std::vector<MenuItem> prototracer_menu = {
-        submenu("Faces",      std::move(effects)),
-        submenu("Color",          std::move(colors)),
-        submenu("Material Color", std::move(proto_colors)),
-        submenu("Animations",     std::move(gifs)),
+    // ── ProtoTracer (Teensy-driven LED matrix) submenu ────────────────────────
+    std::vector<MenuItem> prototracer_inner_menu = {
+        submenu("Faces",              std::move(effects)),
+        submenu("Color",              std::move(colors)),
+        submenu("ProtoTracer Palette", std::move(proto_colors)),
+        submenu("Animations",         std::move(gifs)),
         slider("Brightness", 0.f, 255.f, 5.f, "%",
             [&state]{ return static_cast<float>(state.face.brightness); },
             [teensy](float v){ teensy->set_brightness(static_cast<uint8_t>(v)); }),
-        slider("Lens Brightness", 1.f, 7.f, 1.f, "",
-            [&state]{ return static_cast<float>(state.xr_brightness); },
-            [xr, &state](float v){
-                state.xr_brightness = static_cast<int>(v);
-                if (xr) xr->set_brightness(static_cast<int>(v));
-            }),
         leaf("Release Control", [teensy]{ teensy->release_control(); }),
         face_picker("Face", 10,
             [&state]{ return static_cast<int>(state.face.face_index); },
@@ -1328,7 +1340,7 @@ static std::vector<MenuItem> build_menu(
                 std::lock_guard<std::mutex> lk(state.mtx);
                 state.face.face_index = static_cast<uint8_t>(v);
             }),
-        slider("Accent Bright", 0.f, 10.f, 1.f, "",
+        slider("Accent LED Brightness", 0.f, 10.f, 1.f, "",
             [&state]{ return static_cast<float>(state.face.accent_bright); },
             [&state, teensy](float v){
                 uint8_t val = static_cast<uint8_t>(v);
@@ -1352,7 +1364,7 @@ static std::vector<MenuItem> build_menu(
                 std::lock_guard<std::mutex> lk(state.mtx);
                 state.face.mic_level = val;
             }),
-        toggle("Boop Sensor",
+        toggle("Touch Sensor",
             [&state]{ return state.face.boop_sensor != 0; },
             [&state, teensy](bool on){
                 uint8_t val = on ? 1 : 0;
@@ -1385,12 +1397,27 @@ static std::vector<MenuItem> build_menu(
                 state.face.fan_speed = val;
             }),
     };
-    if (!face_source_menu.empty())
-        prototracer_menu.push_back(submenu("Face Source", std::move(face_source_menu)));
+
+    // ── Protoface (shm-fed LED panel) submenu ─────────────────────────────────
+    std::vector<MenuItem> protoface_inner_menu;
     if (panel_preview_pp)
-        prototracer_menu.push_back(toggle("Panel Preview",
+        protoface_inner_menu.push_back(toggle("Panel Preview",
             [panel_preview_pp]{ return *panel_preview_pp; },
             [panel_preview_pp](bool v){ *panel_preview_pp = v; }));
+
+    // ── Face Display root: Source picker (radios) + per-backend submenus ─────
+    std::vector<MenuItem> face_display_menu;
+    if (active_face_pp && teensy_option && fp_option) {
+        face_display_menu.push_back(leaf_sel("Source: Teensy (ProtoTracer)",
+            [active_face_pp, teensy_option]{ *active_face_pp = teensy_option; },
+            [active_face_pp, teensy_option]{ return *active_face_pp == teensy_option; }));
+        face_display_menu.push_back(leaf_sel("Source: Protoface",
+            [active_face_pp, fp_option]{ *active_face_pp = fp_option; },
+            [active_face_pp, fp_option]{ return *active_face_pp == fp_option; }));
+    }
+    face_display_menu.push_back(submenu("ProtoTracer", std::move(prototracer_inner_menu)));
+    if (!protoface_inner_menu.empty())
+        face_display_menu.push_back(submenu("Protoface", std::move(protoface_inner_menu)));
 
     // ── HUD settings ──────────────────────────────────────────────────────────
 
@@ -2354,7 +2381,7 @@ static std::vector<MenuItem> build_menu(
     };
 
     std::vector<MenuItem> system_menu = {
-        submenu("Headset",          std::move(headset_menu)),
+        submenu("Headset & Tracking", std::move(headset_menu)),
         submenu("Audio",            std::move(audio_menu)),
         submenu("Timers and Alarm", std::move(timers_alarm_menu)),
         toggle("System Panel",
@@ -2385,7 +2412,7 @@ static std::vector<MenuItem> build_menu(
     return {
         submenu("Vision",       std::move(cameras_menu)),
         submenu("HUD",          std::move(hud_menu)),
-        submenu("Face Display", std::move(prototracer_menu)),
+        submenu("Face Display", std::move(face_display_menu)),
         submenu("LoRa",         std::move(lora_menu)),
         submenu("System",       std::move(system_menu)),
     };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -338,6 +338,17 @@ static std::vector<MenuItem> build_menu(
         return m;
     };
 
+    // Attach a context panel to a SUBMENU item.  Returns the same item so
+    // calls can be chained at the call site:
+    //   with_panel(submenu("Position", ...), "Eye Position Preview",
+    //              [&state]( ImDrawList* dl, ImVec2 o, ImVec2 s){ ... })
+    auto with_panel = [](MenuItem m, std::string title,
+                         MenuContextPanelDraw draw) -> MenuItem {
+        m.context_panel_title = std::move(title);
+        m.context_panel_draw  = std::move(draw);
+        return m;
+    };
+
     auto toggle = [](std::string lbl,
                      std::function<bool()>     get_fn,
                      std::function<void(bool)> set_fn) -> MenuItem {
@@ -776,12 +787,91 @@ static std::vector<MenuItem> build_menu(
         };
     };
 
+    // ── Context-panel helpers (camera-frame visualisations) ──────────────────
+    // Render a camera frame at `aspect`, fitting into the given rect, with an
+    // accent-coloured outer outline and a lighter-grey inner crop rectangle.
+    // inner_{x0,y0,x1,y1} are 0..1 within the frame.
+    auto draw_frame_with_crop = [](ImDrawList* dl, ImVec2 fit_origin, ImVec2 fit_size,
+                                   float aspect, ImU32 accent,
+                                   float ix0, float iy0, float ix1, float iy1) {
+        // Letterbox the frame inside the fit rect at the requested aspect.
+        float fw = fit_size.x, fh = fit_size.y;
+        if (fw / fh > aspect) fw = fh * aspect; else fh = fw / aspect;
+        ImVec2 fmin{ fit_origin.x + (fit_size.x - fw) * 0.5f,
+                     fit_origin.y + (fit_size.y - fh) * 0.5f };
+        ImVec2 fmax{ fmin.x + fw, fmin.y + fh };
+
+        // Dark fill so the inner crop reads clearly.
+        dl->AddRectFilled(fmin, fmax, IM_COL32(20, 25, 30, 180), 3.f);
+        // Inner crop rectangle (lighter grey fill + white outline).
+        ImVec2 imin{ fmin.x + ix0 * fw, fmin.y + iy0 * fh };
+        ImVec2 imax{ fmin.x + ix1 * fw, fmin.y + iy1 * fh };
+        dl->AddRectFilled(imin, imax, IM_COL32(220, 220, 220, 110), 2.f);
+        dl->AddRect      (imin, imax, IM_COL32(255, 255, 255, 220), 2.f, 0, 1.5f);
+        // Outer outline last so it stays on top of inner fill at the edges.
+        const ImU32 outline = (accent & 0x00FFFFFFu) | (235u << 24);
+        dl->AddRect(fmin, fmax, outline, 3.f, 0, 2.f);
+    };
+
+    // Map a TheaterAnchor enum to the inner-crop rect (normalised) for one eye.
+    // The "Outside" anchor is mirrored per-eye (left cam shows its left, right
+    // cam shows its right).  All others apply identically to both eyes.
+    auto theater_inner_rect = [](AppState::TheaterAnchor a, bool is_right_eye) {
+        using TA = AppState::TheaterAnchor;
+        // Half-frame width (each eye is half-SBS), full height by default.
+        float w = 0.5f, h = 1.0f;
+        float x0 = 0.25f, y0 = 0.f;   // Center
+        switch (a) {
+            case TA::Center:  x0 = 0.25f;                            break;
+            case TA::Outside: x0 = is_right_eye ? 0.5f : 0.f;        break;
+            case TA::Left:    x0 = 0.0f;                             break;
+            case TA::Right:   x0 = 0.5f;                             break;
+            case TA::Top:     y0 = 0.f;    h = 0.6f; x0 = 0.25f;     break;
+            case TA::Bottom:  y0 = 0.4f;   h = 0.6f; x0 = 0.25f;     break;
+        }
+        return std::tuple<float,float,float,float>{ x0, y0, x0 + w, y0 + h };
+    };
+
     // Raw View groups the camera-passthrough toggle with its placement options.
     std::vector<MenuItem> raw_view_menu = {
         toggle("Enable",
             [&state]{ return state.theater_mode; },
             [&state](bool v){ state.theater_mode = v; }),
-        submenu("Position", std::move(theater_pos_menu)),
+        with_panel(
+            submenu("Position", std::move(theater_pos_menu)),
+            "Eye Position Preview",
+            [&state, cameras, menu_sys_pp, draw_frame_with_crop, theater_inner_rect]
+            (ImDrawList* dl, ImVec2 o, ImVec2 sz) {
+                const ImU32 accent = (menu_sys_pp && *menu_sys_pp)
+                    ? (*menu_sys_pp)->accent_color()
+                    : IM_COL32(255, 255, 255, 255);
+                const float aspect = (cameras && cameras->current_height() > 0)
+                    ? float(cameras->current_width()) / float(cameras->current_height())
+                    : 4.0f / 3.0f;
+                const bool single = state.cam_single.enabled;
+                const auto a = state.theater_anchor;
+
+                if (single) {
+                    const bool right = state.cam_single.use_right;
+                    auto [x0, y0, x1, y1] = theater_inner_rect(a, right);
+                    draw_frame_with_crop(dl, o, sz, aspect, accent, x0, y0, x1, y1);
+                    const char* lbl = right ? "Right camera" : "Left camera";
+                    dl->AddText({ o.x, o.y + sz.y - 14.f },
+                                IM_COL32(200, 200, 200, 200), lbl);
+                } else {
+                    ImVec2 lsz{ sz.x * 0.5f - 6.f, sz.y - 16.f };
+                    ImVec2 lpos{ o.x, o.y };
+                    ImVec2 rpos{ o.x + sz.x * 0.5f + 6.f, o.y };
+                    auto [lx0, ly0, lx1, ly1] = theater_inner_rect(a, false);
+                    auto [rx0, ry0, rx1, ry1] = theater_inner_rect(a, true);
+                    draw_frame_with_crop(dl, lpos, lsz, aspect, accent, lx0, ly0, lx1, ly1);
+                    draw_frame_with_crop(dl, rpos, lsz, aspect, accent, rx0, ry0, rx1, ry1);
+                    dl->AddText({ lpos.x, o.y + sz.y - 14.f },
+                                IM_COL32(200, 200, 200, 200), "Left");
+                    dl->AddText({ rpos.x, o.y + sz.y - 14.f },
+                                IM_COL32(200, 200, 200, 200), "Right");
+                }
+            }),
     };
 
     // Build per-camera submenu labels from the configured model names.  When both
@@ -811,9 +901,106 @@ static std::vector<MenuItem> build_menu(
         toggle("Swap Cameras",
             [&state]{ return state.cameras_swapped; },
             [&state](bool v){ state.cameras_swapped = v; }),
-        submenu("Resolution",       std::move(resolution_presets)),
+        with_panel(
+            submenu("Resolution", std::move(resolution_presets)),
+            "Camera Resolution",
+            [&state, menu_sys_pp]
+            (ImDrawList* dl, ImVec2 o, ImVec2 sz) {
+                (void)sz;
+                const ImU32 accent = (menu_sys_pp && *menu_sys_pp)
+                    ? (*menu_sys_pp)->accent_color()
+                    : IM_COL32(255, 255, 255, 255);
+                int w = state.camera_resolution.width;
+                int h = state.camera_resolution.height;
+                if (w <= 0 || h <= 0) { w = 1280; h = 800; }
+                float ar = float(w) / float(h);
+
+                char buf[64];
+                snprintf(buf, sizeof(buf), "%d x %d", w, h);
+                dl->AddText({ o.x, o.y }, IM_COL32(255, 255, 255, 235), buf);
+                snprintf(buf, sizeof(buf), "Aspect: %.2f:1 (~%s)",
+                         ar,
+                         (ar > 1.74f && ar < 1.80f) ? "16:9"
+                         : (ar > 1.30f && ar < 1.36f) ? "4:3"
+                         : (ar > 1.58f && ar < 1.62f) ? "16:10"
+                         : "custom");
+                dl->AddText({ o.x, o.y + 18.f }, IM_COL32(200, 200, 200, 220), buf);
+
+                // Hint list — common Raspberry Pi camera modules grouped by AR.
+                const float lh = 14.f;
+                ImVec2 p{ o.x, o.y + 44.f };
+                dl->AddText(p, (accent & 0x00FFFFFFu) | (200u << 24),
+                            "PI CAMERA NATIVE AR");
+                p.y += lh + 2.f;
+                struct Row { const char* ar; const char* mods; };
+                static const Row rows[] = {
+                    { "4:3",  "IMX219 v2, IMX477 HQ, IMX708 v3 (bin)" },
+                    { "16:9", "IMX477 HQ, IMX708 v3 (native)" },
+                    { "1:1",  "IMX296, IMX290 (crop)" },
+                };
+                for (auto& r : rows) {
+                    char line[96];
+                    snprintf(line, sizeof(line), "%-5s  %s", r.ar, r.mods);
+                    dl->AddText(p, IM_COL32(190, 190, 190, 200), line);
+                    p.y += lh;
+                }
+            }),
         submenu("Digital Zoom",     std::move(zoom_menu)),
-        submenu("Mirror Crop",      std::move(mirror_crop_menu)),
+        with_panel(
+            submenu("Mirror Crop", std::move(mirror_crop_menu)),
+            "Mirror Crop Preview",
+            [&state, cameras, menu_sys_pp, draw_frame_with_crop]
+            (ImDrawList* dl, ImVec2 o, ImVec2 sz) {
+                const ImU32 accent = (menu_sys_pp && *menu_sys_pp)
+                    ? (*menu_sys_pp)->accent_color()
+                    : IM_COL32(255, 255, 255, 255);
+                const float aspect = (cameras && cameras->current_height() > 0)
+                    ? float(cameras->current_width()) / float(cameras->current_height())
+                    : 4.0f / 3.0f;
+
+                // Crop window: width and height = 1/zoom of the source frame.
+                const float zoom = std::max(1.0f, state.mirror_crop.zoom);
+                const float crop_w = 1.0f / zoom;
+                const float crop_h = 1.0f / zoom;
+                float crop_y0;
+                switch (state.mirror_crop.vertical) {
+                    case CropVertical::Top:    crop_y0 = 0.0f;                 break;
+                    case CropVertical::Middle: crop_y0 = (1.0f - crop_h) * 0.5f; break;
+                    case CropVertical::Bottom: crop_y0 = 1.0f - crop_h;        break;
+                }
+                const float bias = state.mirror_crop.inner_bias;  // 0.0 – 0.40
+                // Left eye crop biased toward the right (nose); right eye crop
+                // biased toward the left.  bias=0 → centered.
+                auto crop_x0 = [&](bool right) {
+                    float cx = right ? (0.5f - bias) : (0.5f + bias);
+                    return cx - crop_w * 0.5f;
+                };
+
+                const bool single = state.cam_single.enabled;
+                if (single) {
+                    bool right = state.cam_single.use_right;
+                    float x0 = crop_x0(right);
+                    draw_frame_with_crop(dl, o, sz, aspect, accent,
+                                         x0, crop_y0, x0 + crop_w, crop_y0 + crop_h);
+                    dl->AddText({ o.x, o.y + sz.y - 14.f },
+                                IM_COL32(200, 200, 200, 200),
+                                right ? "Right camera" : "Left camera");
+                } else {
+                    ImVec2 lsz{ sz.x * 0.5f - 6.f, sz.y - 16.f };
+                    ImVec2 lpos{ o.x, o.y };
+                    ImVec2 rpos{ o.x + sz.x * 0.5f + 6.f, o.y };
+                    float lx0 = crop_x0(false);
+                    float rx0 = crop_x0(true);
+                    draw_frame_with_crop(dl, lpos, lsz, aspect, accent,
+                                         lx0, crop_y0, lx0 + crop_w, crop_y0 + crop_h);
+                    draw_frame_with_crop(dl, rpos, lsz, aspect, accent,
+                                         rx0, crop_y0, rx0 + crop_w, crop_y0 + crop_h);
+                    dl->AddText({ lpos.x, o.y + sz.y - 14.f },
+                                IM_COL32(200, 200, 200, 200), "Left");
+                    dl->AddText({ rpos.x, o.y + sz.y - 14.f },
+                                IM_COL32(200, 200, 200, 200), "Right");
+                }
+            }),
         submenu("Single Camera",    std::move(single_cam_menu)),
         submenu(left_label,         std::move(left_cam_menu)),
         submenu(right_label,        std::move(right_cam_menu)),
@@ -2382,7 +2569,51 @@ static std::vector<MenuItem> build_menu(
 
     std::vector<MenuItem> system_menu = {
         submenu("Headset & Tracking", std::move(headset_menu)),
-        submenu("Audio",            std::move(audio_menu)),
+        with_panel(
+            submenu("Audio", std::move(audio_menu)),
+            "Audio Status",
+            [&state, menu_sys_pp]
+            (ImDrawList* dl, ImVec2 o, ImVec2 sz) {
+                (void)sz;
+                const ImU32 accent = (menu_sys_pp && *menu_sys_pp)
+                    ? (*menu_sys_pp)->accent_color()
+                    : IM_COL32(255, 255, 255, 255);
+                const float lh = 18.f;
+                ImVec2 p = o;
+                auto row = [&](const char* k, const char* v, ImU32 vc) {
+                    dl->AddText({ p.x, p.y }, IM_COL32(180, 180, 180, 200), k);
+                    dl->AddText({ p.x + 130.f, p.y }, vc, v);
+                    p.y += lh;
+                };
+
+                bool enabled;
+                int  out_idx;
+                float cpu;
+                int  xruns;
+                {
+                    std::lock_guard<std::mutex> lk(state.mtx);
+                    enabled = state.audio.enabled;
+                    out_idx = state.audio.output;
+                    cpu     = state.audio.cpu_load;
+                    xruns   = state.audio.xrun_count;
+                }
+                const char* out_name =
+                    out_idx == 0 ? "VITURE" :
+                    out_idx == 1 ? "Headphones" :
+                    out_idx == 2 ? "HDMI" : "?";
+
+                row("State",  enabled ? "Enabled" : "Muted",
+                    enabled ? ((accent & 0x00FFFFFFu) | (220u << 24))
+                            : IM_COL32(200, 90, 90, 220));
+                row("Output", out_name, IM_COL32(230, 230, 230, 230));
+                char buf[32];
+                snprintf(buf, sizeof(buf), "%.1f %%", cpu * 100.f);
+                row("CPU load", buf, IM_COL32(230, 230, 230, 230));
+                snprintf(buf, sizeof(buf), "%d", xruns);
+                row("XRuns", buf,
+                    xruns == 0 ? IM_COL32(160, 220, 160, 220)
+                               : IM_COL32(220, 160, 90, 220));
+            }),
         submenu("Timers and Alarm", std::move(timers_alarm_menu)),
         toggle("System Panel",
             [sys_panel_active]{ return sys_panel_active && *sys_panel_active; },

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3255,17 +3255,6 @@ int main(int argc, char* argv[]) {
         else if (hud.toast_has_focused()) hud.toast_navigate(dir);
     });
 
-    knob.on_button([&menu](uint8_t btn, uint8_t ev) {
-        if (ev == 0) {  // press
-            if (btn == 0 && menu.is_open()) menu.select();  // encoder click = select
-            if (btn == 1 && menu.is_open()) menu.back();    // back button = back
-        } else if (ev == 1) {  // long press
-            if (btn == 0) {                                 // encoder long press = toggle menu
-                if (menu.is_open()) menu.close(); else menu.open();
-            }
-        }
-    });
-
     knob.on_status([&state](uint8_t status, uint8_t param) {
         if      (status == 0x01) {
             std::lock_guard<std::mutex> lk(state.mtx);

--- a/src/menu/menu_system.cpp
+++ b/src/menu/menu_system.cpp
@@ -73,7 +73,9 @@ static void format_slider_value(char* buf, size_t bufsz,
 MenuSystem::MenuSystem(std::vector<MenuItem> root)
     : root_items_(std::move(root)) {}
 
-void MenuSystem::push_level(const std::vector<MenuItem>& items) {
+void MenuSystem::push_level(const std::vector<MenuItem>& items,
+                             std::string panel_title,
+                             MenuContextPanelDraw panel_draw) {
     if (items.empty()) return;
     std::vector<MenuItem> level = items;
 
@@ -87,7 +89,9 @@ void MenuSystem::push_level(const std::vector<MenuItem>& items) {
 
     if (!stack_.empty())
         stack_.back().cursor = cursor_;  // remember where we were on the parent page
-    stack_.push_back({ level, 0 });
+    stack_.push_back(Level{ std::move(level), 0,
+                            std::move(panel_title),
+                            std::move(panel_draw) });
     cursor_ = 0;
     emit_detents();
 }
@@ -177,7 +181,9 @@ void MenuSystem::select() {
     switch (item.type) {
     case MenuItemType::SUBMENU:
         if (!item.children.empty())
-            push_level(item.children);
+            push_level(item.children,
+                       item.context_panel_title,
+                       item.context_panel_draw);
         break;
 
     case MenuItemType::LEAF:
@@ -767,4 +773,113 @@ void MenuSystem::draw(int screen_w, int screen_h) {
     ImGui::End();
     ImGui::PopStyleVar(3);
     ImGui::PopStyleColor(6);
+
+    // Side-panel: rendered as a separate window mirroring the menu anchor.
+    // Skipped when the current level didn't register one.
+    if (!stack_.empty() && stack_.back().panel_draw)
+        draw_context_panel(stack_.back(), screen_w, screen_h, x, y, width, total_h);
+}
+
+// ── draw_context_panel ────────────────────────────────────────────────────────
+
+void MenuSystem::draw_context_panel(const Level& lvl,
+                                     int screen_w, int screen_h,
+                                     float menu_x, float menu_y,
+                                     float menu_w, float menu_h) {
+    constexpr float kPanelW = 340.f;
+    constexpr float kPanelH = 240.f;
+    constexpr float kGap    = 18.f;
+    constexpr float kPadX   = 12.f;
+    constexpr float kPadY   = 28.f;   // extra top padding for title
+
+    // Place panel on the opposite horizontal side of the menu, aligned to the
+    // menu's top edge.  Clamp inside the screen so it never falls off-edge.
+    float px;
+    switch (anchor_) {
+        default:
+        case MenuAnchor::TopLeft:
+        case MenuAnchor::BottomLeft:
+            px = menu_x + menu_w + kGap;
+            if (px + kPanelW > screen_w - 16.f)
+                px = screen_w - kPanelW - 16.f;
+            break;
+        case MenuAnchor::TopRight:
+        case MenuAnchor::BottomRight:
+            px = menu_x - kPanelW - kGap;
+            if (px < 16.f) px = 16.f;
+            break;
+    }
+    float py = menu_y;
+    if (py + kPanelH > screen_h - 16.f)
+        py = screen_h - kPanelH - 16.f;
+    (void)menu_h;
+
+    ImGui::SetNextWindowPos ({ px, py }, ImGuiCond_Always);
+    ImGui::SetNextWindowSize({ kPanelW, kPanelH }, ImGuiCond_Always);
+    ImGui::SetNextWindowBgAlpha(0.f);
+
+    ImGuiWindowFlags flags =
+        ImGuiWindowFlags_NoDecoration     |
+        ImGuiWindowFlags_NoMove           |
+        ImGuiWindowFlags_NoSavedSettings  |
+        ImGuiWindowFlags_NoFocusOnAppearing |
+        ImGuiWindowFlags_NoInputs;
+
+    ImGui::PushStyleColor(ImGuiCol_WindowBg, ImVec4(0.f, 0.f, 0.f, 0.f));
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0.f);
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding,    ImVec2(0.f, 0.f));
+
+    ImGui::Begin("##menu_panel", nullptr, flags);
+    ImDrawList* dl = ImGui::GetWindowDrawList();
+    const ImVec2 wp = ImGui::GetWindowPos();
+    const ImVec2 ws = ImGui::GetWindowSize();
+
+    // Chamfered background + border, same visual language as the main menu.
+    {
+        constexpr float C   = 8.f;
+        const float GAP     = 3.f + border_thickness_ * 0.5f;
+        const ImVec2 bmin   = { wp.x + GAP,        wp.y + GAP };
+        const ImVec2 bmax   = { wp.x + ws.x - GAP, wp.y + ws.y - GAP };
+        const ImVec2 bg_pts[8] = {
+            {bmin.x + C, bmin.y}, {bmax.x - C, bmin.y},
+            {bmax.x, bmin.y + C}, {bmax.x, bmax.y - C},
+            {bmax.x - C, bmax.y}, {bmin.x + C, bmax.y},
+            {bmin.x, bmax.y - C}, {bmin.x, bmin.y + C},
+        };
+        const ImU32 bg_col = bg_enabled_ ? bg_color_ : IM_COL32(0, 0, 0, 0);
+        dl->AddConvexPolyFilled(bg_pts, 8, bg_col);
+
+        if (border_enabled_) {
+            const ImVec2 emin = { wp.x,        wp.y };
+            const ImVec2 emax = { wp.x + ws.x, wp.y + ws.y };
+            const ImVec2 bdr_pts[8] = {
+                {emin.x + C, emin.y}, {emax.x - C, emin.y},
+                {emax.x, emin.y + C}, {emax.x, emax.y - C},
+                {emax.x - C, emax.y}, {emin.x + C, emax.y},
+                {emin.x, emax.y - C}, {emin.x, emin.y + C},
+            };
+            dl->AddPolyline(bdr_pts, 8,
+                            (border_color_ & 0x00FFFFFFu) | (220u << 24),
+                            ImDrawFlags_Closed, border_thickness_);
+        }
+    }
+
+    // Title bar
+    if (!lvl.panel_title.empty()) {
+        const std::string upper = to_upper(lvl.panel_title);
+        dl->AddText({ wp.x + kPadX, wp.y + 6.f },
+                    IM_COL32(255, 255, 255, 230), upper.c_str());
+        dl->AddLine({ wp.x + kPadX,           wp.y + 22.f },
+                    { wp.x + ws.x - kPadX,    wp.y + 22.f },
+                    (accent_color_ & 0x00FFFFFFu) | (80u << 24), 1.f);
+    }
+
+    // Content area, post-padding.
+    const ImVec2 origin = { wp.x + kPadX, wp.y + kPadY };
+    const ImVec2 size   = { ws.x - 2 * kPadX, ws.y - kPadY - 8.f };
+    if (lvl.panel_draw) lvl.panel_draw(dl, origin, size);
+
+    ImGui::End();
+    ImGui::PopStyleVar(2);
+    ImGui::PopStyleColor(1);
 }

--- a/src/menu/menu_system.h
+++ b/src/menu/menu_system.h
@@ -57,6 +57,18 @@ struct NotifLogConfig {
     NotificationQueue* queue = nullptr;   // pointer into AppState::notifs
 };
 
+// ── Context panel ─────────────────────────────────────────────────────────────
+// A side-panel that opens next to the menu while a particular submenu level is
+// active.  Reusable for visualisations (crop preview, audio meters) or for
+// pure info text.  Renders every frame the level is open — reads live state.
+//
+// Callback contract:
+//   dl     — ImDrawList of the panel window (already opened/sized by MenuSystem).
+//   origin — top-left of the content rect (post-padding).
+//   size   — content rect dimensions.
+using MenuContextPanelDraw =
+    std::function<void(ImDrawList* dl, ImVec2 origin, ImVec2 size)>;
+
 // ── Menu item ─────────────────────────────────────────────────────────────────
 
 struct MenuItem {
@@ -68,6 +80,10 @@ struct MenuItem {
 
     // SUBMENU
     std::vector<MenuItem> children;
+    // Optional context panel that renders next to the menu while this submenu
+    // is the active level.  Only meaningful when type == SUBMENU.
+    std::string           context_panel_title;
+    MenuContextPanelDraw  context_panel_draw;
 
     // TOGGLE
     std::function<bool()>     get_toggle;
@@ -157,10 +173,20 @@ public:
     const std::string& current_label() const;
 
 private:
-    struct Level { std::vector<MenuItem> items; int cursor = 0; };
+    struct Level {
+        std::vector<MenuItem> items;
+        int                   cursor = 0;
+        std::string           panel_title;
+        MenuContextPanelDraw  panel_draw;
+    };
 
-    void push_level(const std::vector<MenuItem>& items);
+    void push_level(const std::vector<MenuItem>& items,
+                    std::string panel_title = std::string(),
+                    MenuContextPanelDraw panel_draw = nullptr);
     void pop_level();
+    void draw_context_panel(const Level& lvl, int screen_w, int screen_h,
+                            float menu_x, float menu_y,
+                            float menu_w, float menu_h);
     void emit_detents();
     void emit_detents_override(int count);
 

--- a/src/post_process.cpp
+++ b/src/post_process.cpp
@@ -156,4 +156,7 @@ void PostProcessor::process(GLuint src_tex,
         glUseProgram(0);
         prev_write.unbind();
     }
+
+    // Restore default active texture unit so callers don't inherit our state.
+    glActiveTexture(GL_TEXTURE0);
 }

--- a/src/splash.cpp
+++ b/src/splash.cpp
@@ -53,36 +53,40 @@ void SplashScreen::draw_eye(ImDrawList* dl,
     constexpr float RING_R = 96.f;
 
     // ── Spinning dots ring ────────────────────────────────────────────────────
-    // Subtle track circle
-    dl->AddCircle({cx, cy}, RING_R, IM_COL32(0, 100, 80, 30), 64, 1.5f);
+    // Skipped entirely when show_ring is disabled (useful when the logo
+    // covers the area the ring would otherwise occupy).
+    if (cfg_.show_ring) {
+        // Subtle track circle
+        dl->AddCircle({cx, cy}, RING_R, IM_COL32(0, 100, 80, 30), 64, 1.5f);
 
-    if (cfg_.animated) {
-        constexpr int   N_DOTS = 8;
-        constexpr float DOT_R  = 5.f;
+        if (cfg_.animated) {
+            constexpr int   N_DOTS = 8;
+            constexpr float DOT_R  = 5.f;
 
-        for (int i = 0; i < N_DOTS; ++i) {
-            float angle = (i * 2.f * kPi / N_DOTS) + t * 1.5f;
-            float dx = cx + RING_R * std::cos(angle);
-            float dy = cy + RING_R * std::sin(angle);
+            for (int i = 0; i < N_DOTS; ++i) {
+                float angle = (i * 2.f * kPi / N_DOTS) + t * 1.5f;
+                float dx = cx + RING_R * std::cos(angle);
+                float dy = cy + RING_R * std::sin(angle);
 
-            // Phase: how close is this dot to being the "lead" (0 = lead, 1 = tail)
-            float norm_i   = static_cast<float>(i) / N_DOTS;
-            float lead_pos = fmod(t * 1.5f / (2.f * kPi), 1.f);
-            float diff     = fmod(norm_i - lead_pos + 1.f, 1.f);
-            float brightness = std::pow(1.f - diff, 3.5f);
+                // Phase: how close is this dot to being the "lead" (0 = lead, 1 = tail)
+                float norm_i   = static_cast<float>(i) / N_DOTS;
+                float lead_pos = fmod(t * 1.5f / (2.f * kPi), 1.f);
+                float diff     = fmod(norm_i - lead_pos + 1.f, 1.f);
+                float brightness = std::pow(1.f - diff, 3.5f);
 
-            uint8_t a  = static_cast<uint8_t>(30.f + brightness * 225.f);
-            float   r  = DOT_R * (0.45f + brightness * 0.8f);
-            dl->AddCircleFilled({dx, dy}, r + 5.f, IM_COL32(0, 220, 180, static_cast<uint8_t>(a / 5)));
-            dl->AddCircleFilled({dx, dy}, r,        IM_COL32(0, 220, 180, a));
+                uint8_t a  = static_cast<uint8_t>(30.f + brightness * 225.f);
+                float   r  = DOT_R * (0.45f + brightness * 0.8f);
+                dl->AddCircleFilled({dx, dy}, r + 5.f, IM_COL32(0, 220, 180, static_cast<uint8_t>(a / 5)));
+                dl->AddCircleFilled({dx, dy}, r,        IM_COL32(0, 220, 180, a));
+            }
+        } else {
+            // Static ring
+            dl->AddCircle({cx, cy}, RING_R, COL_DIM, 64, 1.5f);
         }
-    } else {
-        // Static ring
-        dl->AddCircle({cx, cy}, RING_R, COL_DIM, 64, 1.5f);
     }
 
     // ── Logo or procedural hexagon mark ───────────────────────────────────────
-    constexpr float LOGO_HALF = 52.f;
+    const float LOGO_HALF = std::max(8.f, cfg_.logo_size_px * 0.5f);
     if (logo_tex_) {
         float aspect = logo_w_ > 0 ? static_cast<float>(logo_w_) / static_cast<float>(logo_h_) : 1.f;
         float lw, lh;

--- a/src/splash.h
+++ b/src/splash.h
@@ -6,6 +6,8 @@ struct SplashConfig {
     bool        enabled       = true;
     bool        animated      = true;
     std::string image_path;           // PNG path; empty = procedural hexagon mark
+    float       logo_size_px  = 104.f;// Longest side of the logo in pixels
+    bool        show_ring     = true; // Hide the spinning dot ring (useful for large logos)
     float       min_display_s = 2.0f;
     std::string title         = "PROTOHUD";
     std::string subtitle      = "XR HUD System";


### PR DESCRIPTION
## Summary

Three concerns batched into one PR (per "one PR per repo" preference). Each in its own commit(s).

---

### A. Stability fixes (3 commits, 3 files, ~15 LOC)

1. **Remove duplicate `knob.on_button` registration** (`main.cpp`).
   `SmartKnob::on_button` is a single-slot setter (`smartknob.h:35`); two back-to-back registrations meant the first lambda was dead code. Deleted the older, less complete handler. No behavioural change — the surviving handler was already authoritative.

2. **`post_process`: restore `GL_TEXTURE0` after `process()`.**
   Left the active texture unit at `GL_TEXTURE2`/`GL_TEXTURE1`; subsequent draw code that assumed `GL_TEXTURE0` would silently bind to the wrong unit. Added the restore, matching `v4l2_camera.cpp::draw()`.

3. **`crash_reporter`: explicitly NUL-terminate `strncpy` buffers.**
   `strncpy` doesn't guarantee NUL termination when the source meets or exceeds the destination size. Today static zero-init papers over this; a future refactor would leave `snprintf` reading past the end inside the signal handler.

---

### B. Menu reorganization (2 commits, 3 files, ~85 LOC)

**CSI Camera Controls** (was "Main Cameras")
- Renamed parent submenu.
- `Left/Right Eye Source` moved to top — most-used during setup.
- `Theater Mode` toggle + `Theater Position` submenu collapsed into single `Raw View` submenu (`Enable` + `Position`).
- Per-camera submenus use the configured sensor model name: `"<Model> #1 (Left)" / "<Model> #2 (Right)"` when slots share a model, else `"<Model> (Left)" / "<Model> (Right)"`. Requires new `DmaCamera::model_name()` + `CameraManager::owl_{left,right}_model()` accessors.
- `Night Vision` → `Low-Light Mode` (and inner toggles/slider).

**Face Display** split
- Two parallel submenus: `ProtoTracer` (all Teensy-driven controls) and `Protoface` (just `Panel Preview` for now).
- Source-picker radios at the top of Face Display.
- `Lens Brightness` relocated to `System > Headset & Tracking` as `Backlight Brightness` (it's the Viture backlight, not the face).
- Renames: `Material Color` → `ProtoTracer Palette`, `Accent Bright` → `Accent LED Brightness`, `Boop Sensor` → `Touch Sensor`.

**System**
- `Headset` → `Headset & Tracking`.
- New `Backlight Brightness` slider.

---

### C. Context-panel framework (2 commits, 3 files, ~380 LOC)

New reusable architecture: submenus can opt into a side-panel that renders next to the menu while that submenu is the active level. Designed for visualisations (crop preview), info bubbles, and live status readouts.

**Framework** (`menu_system.h` + `.cpp`):
- New `MenuContextPanelDraw` callback type and two optional fields on `MenuItem` (`context_panel_title`, `context_panel_draw`).
- `Level` struct carries the panel through the navigation stack so it's restored on back-navigation.
- Panel renders as a second ImGui window, anchored on the opposite horizontal side of the menu, styled to match (chamfered octagon, accent border, title bar). `ImGuiWindowFlags_NoInputs` keeps the knob exclusively on the main menu.

**Wired call sites** (`main.cpp`):
1. **Raw View > Position** — "Eye Position Preview". Outer rect at camera AR, inner rect = the eye view's anchor inside the source frame. Single-cam mode shows one frame; dual shows both side-by-side, with `Outside` anchor mirroring per-eye.
2. **Mirror Crop** — "Mirror Crop Preview". Inner rect computed from `zoom × vertical × inner_bias`. Bias mirrors per eye (nose-side crop). Live update as the slider moves.
3. **Resolution** — "Camera Resolution". Info bubble: active resolution, computed AR, hint table of common Pi camera modules grouped by native AR (IMX219 / 477 / 708 / 296 / 290).
4. **System > Audio** — "Audio Status" (stub proving the framework supports non-visual panels). Live readout: enabled state, output device, capture CPU load, ALSA XRun count.

Helper `with_panel(submenu_item, title, draw_fn)` keeps call sites declarative.

---

### Deferred to follow-up PRs

- Doc updates in `CAPABILITIES.md` / `README.md` for the renamed labels (Night Vision, Theater Mode, Material Color, Boop Sensor, Lens Brightness).
- v4l2 buffer-cycling design fix (`capture_thread` re-queues the just-marked-READY buffer).
- Demo Mode gating behind a debug flag; `System > Info` submenu; per-camera-specific submenu inside the model-named submenus.

### Stability audit findings ruled out (no work needed)

- `v4l2_camera.cpp` GL state leak — already restores `GL_TEXTURE0` at line 240.
- `xr_display.cpp` monitor null-guard — already present.
- `menu_system::back()` UAF — cursor bounds-checked, edit branch returns without pop.
- `audio_engine` PCM swap race — output switch is single-threaded in the audio loop.

## Test plan

- [ ] Local build (`cmake -S . -B build && cmake --build build`) — *not run here; vendor deps (raylib, nanovg, imgui, viture SDK, EGL, ALSA, libcamera) aren't available in this environment.*
- [ ] On hardware: walk the new menu tree end-to-end.
- [ ] On hardware: open Vision > CSI Camera Controls > Raw View > Position — confirm context panel renders on the opposite side of the menu, both-eye view when dual-cam, single-eye when `Single Camera` mode is enabled, anchor changes (Center/Outside/Left/Right/Top/Bottom) update the inner-rect position live.
- [ ] On hardware: open Vision > CSI Camera Controls > Mirror Crop — confirm panel shows the crop rectangle for both eyes, that it shrinks as zoom increases, that vertical position shifts the inner rect, and that the Inner Bias slider live-updates the panel.
- [ ] On hardware: open Vision > CSI Camera Controls > Resolution — panel lists the current resolution, AR string, and the Pi-camera hint table.
- [ ] On hardware: open System > Audio — panel shows live CPU load and XRun count; values update as audio runs.
- [ ] Confirm panels never steal knob input; back-button still pops levels correctly.
- [ ] Confirm config load/save still works — no JSON keys renamed, only menu labels.