### PR TITLE
xr: support 3840x1200 SBS and self-heal display-mode drift

### DIFF
--- a/config/config.example.json
+++ b/config/config.example.json
@@ -5,6 +5,8 @@
     "fullscreen": true,
     "frameless": false,
     "target_fps": 90,
+    "_sbs_height_note": "SBS panel height: 1080 (default) or 1200 for the Viture Beast's full native panel.",
+    "sbs_height": 1080,
     "eye_separation": 0.064,
     "hud_opacity": 0.85,
     "hud_scale": 1.0

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2770,6 +2770,7 @@ int main(int argc, char* argv[]) {
     xr_cfg.product_id       = jval(jvtr,  "product_id",       0);
     xr_cfg.monitor_index    = jval(jvtr,  "monitor_index",    -1);
     xr_cfg.target_fps       = jval(jdisp, "target_fps",       90);
+    xr_cfg.sbs_height       = jval(jdisp, "sbs_height",       1080);
     xr_cfg.use_beast_camera = jval(jvtr,  "use_beast_camera", true);
     xr_cfg.enable_imu       = jval(jvtr,  "enable_imu",       true);
     xr_cfg.frameless        = jval(jdisp, "frameless",         false);

--- a/src/vitrue/xr_display.cpp
+++ b/src/vitrue/xr_display.cpp
@@ -36,7 +36,14 @@ static int scan_usb_for_viture() {
     return 0;
 }
 
-static uint8_t fps_to_display_mode(int fps) {
+static uint8_t fps_to_display_mode(int fps, int height) {
+    if (height >= 1200) {
+        switch (fps) {
+            case 60:  return VITURE_NATIVE_DISPLAY_MODE_3D_SBS_3840_1200_60HZ;
+            case 120: return VITURE_NATIVE_DISPLAY_MODE_3D_SBS_3840_1200_120HZ;
+            default:  return VITURE_NATIVE_DISPLAY_MODE_3D_SBS_3840_1200_90HZ;
+        }
+    }
     switch (fps) {
         case 60:  return VITURE_NATIVE_DISPLAY_MODE_3D_SBS_3840_1080_60HZ;
         case 120: return VITURE_NATIVE_DISPLAY_MODE_3D_SBS_3840_1080_120HZ;
@@ -47,6 +54,12 @@ static uint8_t fps_to_display_mode(int fps) {
 // ── SDK callbacks ─────────────────────────────────────────────────────────────
 void XRDisplay::s_state_cb(int id, int val) {
     if (!s_instance_) return;
+    // The glasses changed display mode (often the hardware mode button). Flag a
+    // resync; service_display_mode() restores our SBS mode on the render thread.
+    // We only use this as a trigger — the callback's value is in the
+    // VITURE_DISPLAY_MODE_* namespace, distinct from native_set/get's namespace.
+    if (id == VITURE_CALLBACK_ID_DISPLAY_MODE)
+        s_instance_->mode_resync_pending_.store(true);
     std::lock_guard<std::mutex> lk(s_instance_->cb_mtx_);
     if (s_instance_->state_cb_) s_instance_->state_cb_(id, val);
 }
@@ -241,6 +254,7 @@ void XRDisplay::composite_single(GLuint src_tex, CamSingleAnchor anchor) {
 // Swap the GLFW window buffer and poll events.
 
 void XRDisplay::present() {
+    service_display_mode();
     glfwSwapBuffers(window_);
     glfwPollEvents();
 }
@@ -303,7 +317,28 @@ bool XRDisplay::find_and_connect() {
 
 void XRDisplay::set_sbs_display_mode() {
     if (!device_) return;
-    xr_device_provider_native_set_display_mode(device_, fps_to_display_mode(cfg_.target_fps));
+    const int mode = fps_to_display_mode(cfg_.target_fps, cfg_.sbs_height);
+    intended_native_mode_.store(mode);
+    xr_device_provider_native_set_display_mode(device_, mode);
+    xr_device_provider_native_switch_dimension(device_, 1);
+}
+
+// Snap the glasses back to our intended SBS mode if they drifted (e.g. the user
+// pressed the Beast's hardware mode button).  Driven by the display-mode
+// callback; the actual USB query/re-assert happens here on the render thread.
+void XRDisplay::service_display_mode() {
+    if (!device_) return;
+    if (!mode_resync_pending_.exchange(false)) return;
+
+    const int want = intended_native_mode_.load();
+    if (want == 0) return;
+    // Compare in the native-mode namespace (same as set), so this never fights
+    // the callback's VITURE_DISPLAY_MODE_* namespace nor loops on itself.
+    const int cur = xr_device_provider_native_get_display_mode(device_);
+    if (cur == want) return;
+    std::cerr << "[xr] display mode drifted (" << cur << " != " << want
+              << ") — restoring SBS\n";
+    xr_device_provider_native_set_display_mode(device_, want);
     xr_device_provider_native_switch_dimension(device_, 1);
 }
 

--- a/src/vitrue/xr_display.h
+++ b/src/vitrue/xr_display.h
@@ -26,6 +26,7 @@ struct XRConfig {
     int  product_id      = 0;
     int  monitor_index   = -1;   // -1 = auto (prefer 3840-wide monitor)
     int  target_fps      = 90;
+    int  sbs_height      = 1080; // SBS panel height: 1080 or 1200 (Beast native panel)
     bool use_beast_camera = true;
     bool enable_imu       = true;
     bool frameless        = false;  // remove OS window decorations (windowed mode only)
@@ -59,6 +60,12 @@ public:
     // Swap the GLFW window buffer and poll events.
     // Call after composite() and after the ImGui overlay is rendered.
     void present();
+
+    // Re-assert ProtoHUD's intended SBS display mode if the glasses drifted to
+    // a different mode (e.g. the user pressed the Beast's hardware mode button).
+    // Safe to call every frame from the render thread — only does USB work when
+    // a drift has been flagged by the display-mode callback.
+    void service_display_mode();
 
     // Convenience: composite() + present() in one call (no ImGui overlay).
     void submit_frame() { composite(); present(); }
@@ -124,4 +131,10 @@ private:
     std::atomic<float>    imu_roll_  { 0.f };
     std::atomic<float>    imu_pitch_ { 0.f };
     std::atomic<float>    imu_yaw_   { 0.f };
+
+    // Display-mode self-healing: the native SBS mode we asked the glasses for,
+    // and a flag the display-mode callback raises when the device reports a
+    // mode change.  service_display_mode() (render thread) snaps it back.
+    std::atomic<int>      intended_native_mode_ { 0 };
+    std::atomic<bool>     mode_resync_pending_  { false };
 };


### PR DESCRIPTION
Two related fixes for the Viture Beast going black when its hardware mode button is pressed.

1. 3840x1200 SBS support. fps_to_display_mode() now takes the panel height and can select the 1200-tall native SBS variants (the Beast's full panel) in addition to the existing 1080 ones.  New XRConfig.sbs_height (JSON display.sbs_height) selects it; defaults to 1080 so existing setups are unchanged.  The window, eye FBOs and post-process FBOs already derive from eye_height(), so the taller mode flows through with no other changes.

2. Display-mode self-healing. Previously the SBS mode was set once at startup and the window/FBOs were locked to it.  Pressing the Beast's hardware mode button changed the glasses to a mode ProtoHUD wasn't rendering for (e.g. ultrawide 3840x1200, or 2D), producing a black screen.

   The SDK reports mode changes via VITURE_CALLBACK_ID_DISPLAY_MODE. We now flag a resync from that callback and, on the render thread in present(), compare the actual native mode (native_get_display_mode) against the mode we asked for and re-assert ours if they differ.

   The callback value is only a trigger: it lives in the VITURE_DISPLAY_MODE_* namespace, whereas native get/set use VITURE_NATIVE_DISPLAY_MODE_*, so comparing the queried native mode against our stored native mode avoids both a namespace mismatch and a re-assert feedback loop.

NOTE: requires on-hardware verification — this environment can't build against the Viture SDK or test on glasses.  In particular confirm that id=2 fires for native-mode changes on the Beast; if it doesn't, a low-rate poll of native_get_display_mode() can be added as a fallback.