### PR TITLE
xr: stop fullscreen window from dropping to desktop on focus loss

### DIFF
--- a/src/vitrue/xr_display.cpp
+++ b/src/vitrue/xr_display.cpp
@@ -105,6 +105,11 @@ bool XRDisplay::init() {
     glfwWindowHint(GLFW_DOUBLEBUFFER,          GLFW_TRUE);
     glfwWindowHint(GLFW_STENCIL_BITS,          8);  // required for NanoVG stencil fills
     glfwWindowHint(GLFW_RESIZABLE,  GLFW_FALSE);
+    // Keep a fullscreen window from minimising itself when it loses input focus.
+    // Without this GLFW auto-iconifies fullscreen windows on focus loss, so on a
+    // desktop WM the window repeatedly drops back to the desktop (and only flashes
+    // when re-focused).  Harmless for windowed mode (hint applies to fullscreen).
+    glfwWindowHint(GLFW_AUTO_ICONIFY, GLFW_FALSE);
     // do_fullscreen: glasses not found AND fullscreen requested in config
     const bool do_fullscreen = cfg_.fullscreen && !mon;
     glfwWindowHint(GLFW_DECORATED, (cfg_.frameless || do_fullscreen) ? GLFW_FALSE : GLFW_TRUE);


### PR DESCRIPTION
On a desktop WM the window opened then immediately fell behind the desktop, only flashing when re-focused.  Cause: GLFW auto-iconifies exclusive-fullscreen windows when they lose input focus (default GLFW_AUTO_ICONIFY=TRUE), and the desktop-fallback path uses glfwSetWindowMonitor() for fullscreen, so any focus change minimised it and clicking just restarted the cycle.

Set GLFW_AUTO_ICONIFY=FALSE before window creation so a fullscreen window stays up across focus changes.  The hint only affects fullscreen windows, so windowed/frameless modes are unaffected, and it also keeps the headset (glasses-monitor) fullscreen window from minimising if focus shifts.