### PR TITLE
main: exit cleanly on signal-triggered shutdown timeout

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3670,11 +3670,15 @@ int main(int argc, char* argv[]) {
         static std::atomic<bool>* g_quit = &state.quit;
         auto handler = [](int) {
             if (g_quit) g_quit->store(true);
-            // If cleanup stalls, force-exit after 5 seconds.
+            // If cleanup stalls, force-exit after 5 seconds.  Exit 0, not 1:
+            // SIGINT/SIGTERM is an explicit quit request (Ctrl+C, `kill`, or the
+            // watchdog forwarding a stop), so report a clean exit — otherwise the
+            // respawn supervisor (scripts/watchdog.sh) treats the non-zero code as
+            // a crash and relaunches the program.
             std::thread([] {
                 std::this_thread::sleep_for(std::chrono::seconds(5));
-                std::cerr << "[signal] cleanup timed out — forcing exit\n";
-                std::_Exit(1);
+                std::cerr << "[signal] cleanup timed out — forcing clean exit\n";
+                std::_Exit(0);
             }).detach();
         };
         std::signal(SIGINT,  handler);


### PR DESCRIPTION
scripts/watchdog.sh relaunches ProtoHUD on any non-zero exit, so the signal handler's 5s cleanup-timeout force-exit (std::_Exit(1)) caused the program to respawn whenever the user killed it or cleanup stalled — appearing to "crash and stay fullscreen" as the new instance grabbed the screen again.

SIGINT/SIGTERM is an explicit quit request (Ctrl+C, kill, or the watchdog forwarding a stop), so the timeout now exits 0.  The watchdog treats that as a clean shutdown and stops relaunching.

The render-loop watchdog's _Exit(1) on an 8s stall is left as-is — that path really is a hang/crash and should respawn.