### PR TITLE
xr: enter native mode before setting Beast SBS display mode

### DIFF
--- a/src/vitrue/xr_display.cpp
+++ b/src/vitrue/xr_display.cpp
@@ -333,9 +333,19 @@ bool XRDisplay::find_and_connect() {
 
 void XRDisplay::set_sbs_display_mode() {
     if (!device_) return;
+    // The Beast boots in bypass mode, where native_set_display_mode /
+    // switch_dimension are rejected.  Enter native mode first.  On devices
+    // without native-DOF support this returns an error, which we ignore.
+    int nm_rc = xr_device_provider_native_set_mode(device_, 1);
+    if (nm_rc != VITURE_GLASSES_SUCCESS)
+        std::cerr << "[xr] native_set_mode(1) rc=" << nm_rc
+                  << " (expected on non-native-DOF devices)\n";
+
     const int mode = fps_to_display_mode(cfg_.target_fps, cfg_.sbs_height);
-    xr_device_provider_native_set_display_mode(device_, mode);
-    xr_device_provider_native_switch_dimension(device_, 1);
+    int dm_rc = xr_device_provider_native_set_display_mode(device_, mode);
+    int sd_rc = xr_device_provider_native_switch_dimension(device_, 1);
+    std::cerr << "[xr] native display_mode=0x" << std::hex << mode << std::dec
+              << " set_rc=" << dm_rc << " switch_dim_rc=" << sd_rc << "\n";
 }
 
 void XRDisplay::open_imu() {


### PR DESCRIPTION
The Beast boots in bypass mode, where native_set_display_mode and native_switch_dimension are rejected by the firmware — so ProtoHUD's SBS mode never engaged even when a device was connected.  Per the v2.2.1 SDK API rework, native_set_mode(1) switches the device into native operating mode; call it before the display-mode/dimension calls.

On devices without native-DOF support the call returns an error, which we log and ignore.  Also log the return codes of set_display_mode and switch_dimension so the supported-mode situation is visible (the Beast firmware only accepts 3D_SBS_3840_1200_60HZ / 1920_1200_60HZ in native mode, per Viture's documented Beast limitations).