### PR TITLE
Add MP4 video recording ('v' key / button double-tap)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,6 +189,7 @@ set(SOURCES
     src/net/bt_monitor.cpp
     src/crash_reporter.cpp
     src/capture.cpp
+    src/video_recorder.cpp
     src/qr_scanner.cpp
     src/splash.cpp
     src/nanovg_gl_impl.cpp

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -233,6 +233,13 @@
     "photo_dir":  "",
     "map_dir":    ""
   },
+  "video": {
+    "_note": "Video recording. camera = left|right|both; fourcc is a 4-char OpenCV codec (mp4v widely available, avc1 needs H.264).",
+    "dir":    "",
+    "fps":    30,
+    "fourcc": "mp4v",
+    "camera": "left"
+  },
   "resolution": {
     "_note": "Persisted OWLsight resolution. Overrides cameras.owlsight_left/right width/height/fps on startup.",
     "width":  1280,

--- a/src/app_state.h
+++ b/src/app_state.h
@@ -354,6 +354,12 @@ struct NotificationQueue {
     }
 };
 
+// ── Video recording control ───────────────────────────────────────────────────
+// Requests are posted by input handlers / toast actions (any thread) and consumed
+// by the render thread, which owns the VideoRecorder. Start acts as a toggle.
+enum class VideoRequest : uint8_t { None, Start, Stop, Pause, Resume };
+enum class VideoCamera  : uint8_t { Left, Right, Both };
+
 // ── Master state ──────────────────────────────────────────────────────────────
 // Mutable fields are updated from serial/camera threads and read by the
 // render thread.  Callers must hold the mutex for any multi-field access.
@@ -398,6 +404,14 @@ struct AppState {
 
     // Photo capture: set by menu or GPIO long-press; consumed by the render thread.
     CaptureRequest capture_request = CaptureRequest::None;
+
+    // Video recording: video_request is posted by input/toast handlers and consumed
+    // by the render thread's VideoRecorder; video_recording/paused are status mirrors
+    // written by the recorder for the menu/HUD to read.
+    VideoRequest video_request   = VideoRequest::None;
+    VideoCamera  video_camera    = VideoCamera::Left;
+    bool         video_recording = false;
+    bool         video_paused    = false;
 
     // QR / barcode scanning (requires libzbar-dev).
     // qr_scan_main: periodic glReadPixels from OWLsight FBO → ZBar.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,6 +40,7 @@
 #include "net/bt_monitor.h"
 #include "crash_reporter.h"
 #include "capture.h"
+#include "video_recorder.h"
 #include "qr_scanner.h"
 #include "splash.h"
 
@@ -738,6 +739,23 @@ static std::vector<MenuItem> build_menu(
         leaf("Both Eyes",  [&state]{ std::lock_guard lk(state.mtx); state.capture_request = CaptureRequest::Stereo; }),
     };
 
+    std::vector<MenuItem> video_camera_menu = {
+        leaf_sel("Left",  [&state]{ std::lock_guard lk(state.mtx); state.video_camera = VideoCamera::Left;  },
+                          [&state]{ return state.video_camera == VideoCamera::Left;  }),
+        leaf_sel("Right", [&state]{ std::lock_guard lk(state.mtx); state.video_camera = VideoCamera::Right; },
+                          [&state]{ return state.video_camera == VideoCamera::Right; }),
+        leaf_sel("Both",  [&state]{ std::lock_guard lk(state.mtx); state.video_camera = VideoCamera::Both;  },
+                          [&state]{ return state.video_camera == VideoCamera::Both;  }),
+    };
+
+    std::vector<MenuItem> video_menu = {
+        toggle("Record",
+            [&state]{ return state.video_recording; },
+            [&state](bool v){ std::lock_guard lk(state.mtx);
+                              state.video_request = v ? VideoRequest::Start : VideoRequest::Stop; }),
+        submenu("Camera", std::move(video_camera_menu)),
+    };
+
     std::vector<MenuItem> qr_menu = {
         toggle("Main Cameras", [&state]{ return state.qr_scan_main; },
                                [&state](bool v){ state.qr_scan_main = v; }),
@@ -795,6 +813,7 @@ static std::vector<MenuItem> build_menu(
         submenu("Night Vision",  std::move(nv_menu)),
         submenu("Autofocus Both", std::move(af_both_menu)),
         submenu("Capture Photo", std::move(capture_menu)),
+        submenu("Record Video",  std::move(video_menu)),
         submenu("QR Scan",       std::move(qr_menu)),
     };
 
@@ -2777,6 +2796,20 @@ int main(int argc, char* argv[]) {
         { auto v = js.value("map_dir",   std::string{}); if (!v.empty()) cfg_map_dir   = v; }
         cfg_ssh_port     = js.value("ssh_port",   cfg_ssh_port);
     }
+
+    // Video recording config (see "video" section of config.json).
+    VideoConfig cfg_video;
+    cfg_video.dir = home_dir + "/Videos/protohud";
+    if (cfg.contains("video")) {
+        auto& jv      = cfg["video"];
+        { auto v = jv.value("dir", std::string{}); if (!v.empty()) cfg_video.dir = v; }
+        cfg_video.fps    = jv.value("fps",    cfg_video.fps);
+        cfg_video.fourcc = jv.value("fourcc", cfg_video.fourcc);
+        std::string camsel = jv.value("camera", std::string("left"));
+        state.video_camera = (camsel == "right") ? VideoCamera::Right
+                           : (camsel == "both")  ? VideoCamera::Both
+                                                 : VideoCamera::Left;
+    }
     // Ensure the maps directory exists
     { std::error_code ec; std::filesystem::create_directories(cfg_map_dir, ec); }
     state.ssh.port = cfg_ssh_port;
@@ -3277,6 +3310,14 @@ int main(int argc, char* argv[]) {
     });
 
     knob.on_button([&menu, &hud, &state](uint8_t btn, uint8_t ev) {
+        if (ev == KnobButtonEvent::DOUBLE_TAP) {
+            // Double-tap BACK = start/stop video recording (Start toggles).
+            if (btn == KnobButton::BACK) {
+                std::lock_guard<std::mutex> lk(state.mtx);
+                state.video_request = VideoRequest::Start;
+            }
+            return;
+        }
         if (ev != KnobButtonEvent::PRESS && ev != KnobButtonEvent::LONG_PRESS) return;
         if (btn == KnobButton::ENCODER) {
             if (ev == KnobButtonEvent::LONG_PRESS) {
@@ -3410,6 +3451,9 @@ int main(int argc, char* argv[]) {
     double m_press_t    = -1.0;
     bool   m_long_fired = false;
 
+    // Video recorder — driven once per frame from the render thread.
+    VideoRecorder video_recorder;
+
     double prev_time = glfwGetTime();
 
     while (!glfwWindowShouldClose(xr.glfw_window()) && !state.quit) {
@@ -3461,6 +3505,12 @@ int main(int argc, char* argv[]) {
         if (key_pressed(ImGuiKey_C)) {
             std::lock_guard<std::mutex> lk(state.mtx);
             state.capture_request = CaptureRequest::Stereo;
+        }
+        // V — start/stop video recording (same flow as the assigned button's
+        // double-tap). Start toggles: starts when idle, stops when recording.
+        if (key_pressed(ImGuiKey_V)) {
+            std::lock_guard<std::mutex> lk(state.mtx);
+            state.video_request = VideoRequest::Start;
         }
         // F — toggle FPS overlay
         if (key_pressed(ImGuiKey_F)) fps_overlay_active = !fps_overlay_active;
@@ -4005,6 +4055,10 @@ int main(int argc, char* argv[]) {
         // Reads directly from the camera eye FBOs (no HUD). Async PNG write.
         if (snap.capture_request != CaptureRequest::None)
             do_capture(snap.capture_request, xr, cfg_photo_dir, state);
+
+        // ── Video recording ───────────────────────────────────────────────────
+        // Same clean eye-FBO source as photos; encodes on a worker thread.
+        video_recorder.tick(xr, state, cfg_video);
 
         // ── QR scan — main cameras ────────────────────────────────────────────
         // Periodic glReadPixels from the left eye FBO (rate-limited to 2 Hz by

--- a/src/protocols.h
+++ b/src/protocols.h
@@ -150,6 +150,7 @@ namespace KnobButtonEvent {
     static constexpr uint8_t PRESS      = 0;
     static constexpr uint8_t LONG_PRESS = 1;
     static constexpr uint8_t RELEASE    = 2;
+    static constexpr uint8_t DOUBLE_TAP = 3;
 }
 
 #pragma pack(push, 1)

--- a/src/video_recorder.cpp
+++ b/src/video_recorder.cpp
@@ -1,0 +1,363 @@
+#include "video_recorder.h"
+
+#include "app_state.h"
+#include "gl_utils.h"
+#include "vitrue/xr_display.h"
+
+#include <opencv2/core.hpp>
+#include <opencv2/imgproc.hpp>
+#include <opencv2/videoio.hpp>
+
+#include <GLES2/gl2.h>
+
+#include <algorithm>
+#include <chrono>
+#include <condition_variable>
+#include <cstdio>
+#include <ctime>
+#include <deque>
+#include <filesystem>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+namespace fs = std::filesystem;
+using clock_t_ = std::chrono::steady_clock;
+
+namespace {
+
+// Read an FBO into a top-down RGBA buffer (OpenGL is bottom-up). Render thread only.
+std::vector<uint8_t> read_fbo_rgba(gl::Fbo& fbo) {
+    const int w = fbo.w, h = fbo.h;
+    std::vector<uint8_t> px(static_cast<size_t>(w) * h * 4);
+    fbo.bind();
+    glReadPixels(0, 0, w, h, GL_RGBA, GL_UNSIGNED_BYTE, px.data());
+    fbo.unbind();
+    for (int row = 0; row < h / 2; ++row)
+        std::swap_ranges(px.begin() + static_cast<size_t>(row) * w * 4,
+                         px.begin() + static_cast<size_t>(row + 1) * w * 4,
+                         px.begin() + static_cast<size_t>(h - 1 - row) * w * 4);
+    return px;
+}
+
+std::string now_stamp() {
+    auto tt = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+    struct tm tm_buf {};
+    localtime_r(&tt, &tm_buf);
+    char ts[32];
+    std::strftime(ts, sizeof(ts), "%Y%m%d_%H%M%S", &tm_buf);
+    return ts;
+}
+
+std::string fmt_mmss(double secs) {
+    if (secs < 0) secs = 0;
+    int total = static_cast<int>(secs);
+    char buf[16];
+    std::snprintf(buf, sizeof(buf), "%02d:%02d", total / 60, total % 60);
+    return buf;
+}
+
+int parse_fourcc(const std::string& s) {
+    if (s.size() == 4)
+        return cv::VideoWriter::fourcc(s[0], s[1], s[2], s[3]);
+    return cv::VideoWriter::fourcc('m', 'p', '4', 'v');
+}
+
+constexpr size_t kMaxQueue = 8;  // frames buffered before the encoder; drop oldest if full
+
+} // namespace
+
+struct VideoRecorder::Impl {
+    // ── Encode worker ──────────────────────────────────────────────────────────
+    struct Frame { std::vector<uint8_t> rgba; int w = 0, h = 0; int stream = 0; };
+
+    std::thread             worker;
+    std::mutex              qmtx;
+    std::condition_variable qcv;          // wakes worker when a frame arrives / on stop
+    std::condition_variable drained_cv;   // signalled when the queue empties
+    std::deque<Frame>       queue;
+    bool                    busy        = false;
+    bool                    stop_worker = false;
+
+    std::mutex      writer_mtx;           // guards writers during open/close vs write
+    cv::VideoWriter writers[2];           // 0 = left eye, 1 = right eye
+    bool            writer_open[2] = {false, false};
+
+    // ── Recording state (render thread only) ────────────────────────────────────
+    bool        recording = false;
+    bool        paused    = false;
+    VideoCamera cam       = VideoCamera::Left;
+    int         fps       = 30;
+    int         fourcc    = 0;
+    std::string dir;
+    std::string base_ts;                  // shared timestamp for this recording's files
+    int         segment   = 0;            // current segment / run index (1-based)
+    clock_t_::time_point seg_start;       // start of the current (un-paused) run
+    double      accumulated_s = 0.0;      // recorded time across runs, excluding pauses
+    clock_t_::time_point last_grab;
+    std::vector<std::string> files;       // every file written this session
+
+    uint32_t toast_id = 0;
+
+    Impl() {
+        worker = std::thread([this] { worker_loop(); });
+    }
+    ~Impl() {
+        {
+            std::lock_guard<std::mutex> lk(qmtx);
+            stop_worker = true;
+        }
+        qcv.notify_all();
+        if (worker.joinable()) worker.join();
+        close_writers();
+    }
+
+    void worker_loop() {
+        for (;;) {
+            Frame f;
+            {
+                std::unique_lock<std::mutex> lk(qmtx);
+                qcv.wait(lk, [this] { return stop_worker || !queue.empty(); });
+                if (queue.empty()) {
+                    if (stop_worker) return;
+                    continue;
+                }
+                f = std::move(queue.front());
+                queue.pop_front();
+                busy = true;
+            }
+            {
+                cv::Mat rgba(f.h, f.w, CV_8UC4, f.rgba.data());
+                cv::Mat bgr;
+                cv::cvtColor(rgba, bgr, cv::COLOR_RGBA2BGR);
+                std::lock_guard<std::mutex> wl(writer_mtx);
+                if (f.stream >= 0 && f.stream < 2 && writer_open[f.stream])
+                    writers[f.stream].write(bgr);
+            }
+            {
+                std::lock_guard<std::mutex> lk(qmtx);
+                busy = false;
+                if (queue.empty()) drained_cv.notify_all();
+            }
+        }
+    }
+
+    // Block until every queued frame has been written. Render thread, rare events only.
+    void drain() {
+        std::unique_lock<std::mutex> lk(qmtx);
+        drained_cv.wait(lk, [this] { return queue.empty() && !busy; });
+    }
+
+    void close_writers() {
+        std::lock_guard<std::mutex> wl(writer_mtx);
+        for (int i = 0; i < 2; ++i) {
+            if (writer_open[i]) { writers[i].release(); writer_open[i] = false; }
+        }
+    }
+
+    // Which writer/eye streams are active for the selected camera.
+    void active_streams(int out[2], int& n) const {
+        n = 0;
+        if (cam == VideoCamera::Left  || cam == VideoCamera::Both) out[n++] = 0;
+        if (cam == VideoCamera::Right || cam == VideoCamera::Both) out[n++] = 1;
+    }
+
+    // Open writers for the current segment. Returns false (and rolls back) on failure.
+    bool open_segment(XRDisplay& xr) {
+        int streams[2], n;
+        active_streams(streams, n);
+        std::lock_guard<std::mutex> wl(writer_mtx);
+        for (int i = 0; i < n; ++i) {
+            int s = streams[i];
+            gl::Fbo& fbo = (s == 0) ? xr.eye_left() : xr.eye_right();
+            const char* tag = (s == 0) ? "L" : "R";
+            std::string path = dir + "/video_" + base_ts + "_" + tag +
+                               "_seg" + std::to_string(segment) + ".mp4";
+            bool ok = writers[s].open(path, fourcc, static_cast<double>(fps),
+                                      cv::Size(fbo.w, fbo.h), /*isColor=*/true);
+            if (!ok || !writers[s].isOpened()) {
+                for (int j = 0; j < 2; ++j)
+                    if (writer_open[j]) { writers[j].release(); writer_open[j] = false; }
+                return false;
+            }
+            writer_open[s] = true;
+            files.push_back(path);
+        }
+        return true;
+    }
+
+    void enqueue(Frame f) {
+        {
+            std::lock_guard<std::mutex> lk(qmtx);
+            if (queue.size() >= kMaxQueue) queue.pop_front();  // drop oldest, keep latency bounded
+            queue.push_back(std::move(f));
+        }
+        qcv.notify_one();
+    }
+
+    // ── Toast helpers (state.mtx held by caller) ────────────────────────────────
+    static uint32_t push_toast(AppState& s, std::string title, std::string body,
+                               float auto_dismiss, std::vector<NotifAction> actions) {
+        Notification n;
+        n.type           = NotifType::App;
+        n.title          = std::move(title);
+        n.body           = std::move(body);
+        n.auto_dismiss_s = auto_dismiss;
+        n.actions        = std::move(actions);
+        s.notifs.push(std::move(n));
+        return s.notifs.items.front().id;
+    }
+
+    double elapsed() const {
+        double e = accumulated_s;
+        if (recording && !paused)
+            e += std::chrono::duration<double>(clock_t_::now() - seg_start).count();
+        return e;
+    }
+};
+
+// ── Public API ──────────────────────────────────────────────────────────────
+
+VideoRecorder::VideoRecorder()  : impl_(std::make_unique<Impl>()) {}
+VideoRecorder::~VideoRecorder() = default;
+bool VideoRecorder::recording() const { return impl_->recording; }
+
+void VideoRecorder::tick(XRDisplay& xr, AppState& state, const VideoConfig& cfg) {
+    Impl& d = *impl_;
+
+    // 1. Snapshot + clear the pending request.
+    VideoRequest req;
+    VideoCamera  sel_cam;
+    {
+        std::lock_guard<std::mutex> lk(state.mtx);
+        req     = state.video_request;
+        sel_cam = state.video_camera;
+        state.video_request = VideoRequest::None;
+    }
+
+    auto set_action = [](VideoRequest r) {
+        return [r](AppState& s) { std::lock_guard<std::mutex> lk(s.mtx); s.video_request = r; };
+    };
+
+    // 2. Apply control transitions.
+    if (req == VideoRequest::Start) req = d.recording ? VideoRequest::Stop : VideoRequest::Start;
+
+    if (req == VideoRequest::Start && !d.recording) {
+        d.cam    = sel_cam;
+        d.fps    = std::max(1, cfg.fps);
+        d.fourcc = parse_fourcc(cfg.fourcc);
+        d.dir    = cfg.dir;
+        d.base_ts       = now_stamp();
+        d.segment       = 1;
+        d.accumulated_s = 0.0;
+        d.paused        = false;
+        d.files.clear();
+        std::error_code ec; fs::create_directories(d.dir, ec);
+
+        if (!d.open_segment(xr)) {
+            std::lock_guard<std::mutex> lk(state.mtx);
+            Impl::push_toast(state, "Recording failed",
+                             "Could not open encoder (" + cfg.fourcc + ")", 6.f, {});
+            return;
+        }
+        d.recording = true;
+        d.seg_start = clock_t_::now();
+        d.last_grab = d.seg_start - std::chrono::milliseconds(1000 / d.fps);
+        std::lock_guard<std::mutex> lk(state.mtx);
+        d.toast_id = Impl::push_toast(state, "Recording", "REC  00:00", 0.f,
+                                      { {"PAUSE", set_action(VideoRequest::Pause)},
+                                        {"STOP",  set_action(VideoRequest::Stop)} });
+        state.video_recording = true;
+        state.video_paused    = false;
+    }
+    else if (req == VideoRequest::Pause && d.recording && !d.paused) {
+        d.drain();
+        d.close_writers();
+        d.accumulated_s += std::chrono::duration<double>(clock_t_::now() - d.seg_start).count();
+        d.paused = true;
+        std::lock_guard<std::mutex> lk(state.mtx);
+        state.notifs.dismiss(d.toast_id);
+        d.toast_id = Impl::push_toast(state, "Recording",
+                                      "PAUSED  " + fmt_mmss(d.elapsed()), 0.f,
+                                      { {"RESUME", set_action(VideoRequest::Resume)},
+                                        {"STOP",   set_action(VideoRequest::Stop)} });
+        state.video_paused = true;
+    }
+    else if (req == VideoRequest::Resume && d.recording && d.paused) {
+        ++d.segment;
+        if (!d.open_segment(xr)) {
+            std::lock_guard<std::mutex> lk(state.mtx);
+            Impl::push_toast(state, "Recording failed", "Could not reopen encoder", 6.f, {});
+            // fall through to a clean stop
+            d.recording = false; d.paused = false;
+            state.notifs.dismiss(d.toast_id); d.toast_id = 0;
+            state.video_recording = false; state.video_paused = false;
+            return;
+        }
+        d.paused    = false;
+        d.seg_start = clock_t_::now();
+        d.last_grab = d.seg_start - std::chrono::milliseconds(1000 / d.fps);
+        std::lock_guard<std::mutex> lk(state.mtx);
+        state.notifs.dismiss(d.toast_id);
+        d.toast_id = Impl::push_toast(state, "Recording", "REC  " + fmt_mmss(d.elapsed()), 0.f,
+                                      { {"PAUSE", set_action(VideoRequest::Pause)},
+                                        {"STOP",  set_action(VideoRequest::Stop)} });
+        state.video_paused = false;
+    }
+    else if (req == VideoRequest::Stop && d.recording) {
+        if (!d.paused)
+            d.accumulated_s += std::chrono::duration<double>(clock_t_::now() - d.seg_start).count();
+        d.recording = false;
+        d.paused    = false;
+        d.drain();
+        d.close_writers();
+
+        uintmax_t bytes = 0;
+        for (const auto& p : d.files) {
+            std::error_code ec; auto sz = fs::file_size(p, ec);
+            if (!ec) bytes += sz;
+        }
+        const double mb = static_cast<double>(bytes) / (1024.0 * 1024.0);
+        char body[96];
+        std::snprintf(body, sizeof(body), "%d seg \xc2\xb7 %s \xc2\xb7 %.1f MB",
+                      d.segment, fmt_mmss(d.accumulated_s).c_str(), mb);
+
+        std::lock_guard<std::mutex> lk(state.mtx);
+        state.notifs.dismiss(d.toast_id);
+        d.toast_id = 0;
+        Impl::push_toast(state, "Video saved", body, 6.f, {});
+        state.video_recording = false;
+        state.video_paused    = false;
+    }
+
+    if (!d.recording) return;
+
+    // 3. Grab frames at the configured rate (decoupled from render FPS).
+    if (!d.paused) {
+        auto now = clock_t_::now();
+        const auto interval = std::chrono::milliseconds(1000 / d.fps);
+        if (now - d.last_grab >= interval) {
+            d.last_grab = now;
+            int streams[2], n;
+            d.active_streams(streams, n);
+            for (int i = 0; i < n; ++i) {
+                int s = streams[i];
+                gl::Fbo& fbo = (s == 0) ? xr.eye_left() : xr.eye_right();
+                Impl::Frame f;
+                f.w = fbo.w; f.h = fbo.h; f.stream = s;
+                f.rgba = read_fbo_rgba(fbo);
+                d.enqueue(std::move(f));
+            }
+        }
+    }
+
+    // 4. Keep the live timer toast current.
+    {
+        std::lock_guard<std::mutex> lk(state.mtx);
+        for (auto& n : state.notifs.items) {
+            if (n.id != d.toast_id) continue;
+            n.body = (d.paused ? "PAUSED  " : "REC  ") + fmt_mmss(d.elapsed());
+            break;
+        }
+    }
+}

--- a/src/video_recorder.h
+++ b/src/video_recorder.h
@@ -1,0 +1,42 @@
+#pragma once
+#include <memory>
+#include <string>
+
+struct AppState;
+class  XRDisplay;
+
+// Encoder configuration, sourced from config.json (see "video" section).
+struct VideoConfig {
+    std::string dir;             // output directory (created if missing)
+    int         fps    = 30;     // capture/playback frame rate
+    std::string fourcc = "mp4v"; // 4-char OpenCV FOURCC (mp4v is widely available)
+};
+
+// ── VideoRecorder ─────────────────────────────────────────────────────────────
+// Records the camera eye FBOs (the same clean, HUD-free source the photo path
+// uses) to MP4. Driven entirely from the render thread via tick(); the actual
+// H.264/MPEG-4 encoding runs on a background worker so the render loop never
+// blocks on it.
+//
+// Control flow: input handlers / toast actions post a VideoRequest into
+// AppState; tick() consumes it. VideoRequest::Start toggles (start when idle,
+// stop when recording). Pause/Resume split the output into separate "segment"
+// files. Recording status is mirrored back into AppState for the menu/HUD, and a
+// live "REC mm:ss" toast (with Pause/Stop actions) is kept updated.
+class VideoRecorder {
+public:
+    VideoRecorder();
+    ~VideoRecorder();
+
+    VideoRecorder(const VideoRecorder&)            = delete;
+    VideoRecorder& operator=(const VideoRecorder&) = delete;
+
+    // Call once per frame on the render (GL) thread, after the eye FBOs are drawn.
+    void tick(XRDisplay& xr, AppState& state, const VideoConfig& cfg);
+
+    bool recording() const;
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
+};


### PR DESCRIPTION
## Summary
Adds video recording to ProtoHUD. Recording captures the **clean camera eye FBOs** — the same HUD-free source the photo path uses — and encodes to MP4 via OpenCV `VideoWriter` on a background worker thread, so the render loop never blocks on encoding. No new build dependencies (OpenCV `videoio` is already linked).

## Triggers
- **`v` key** — start/stop (toggle), next to the existing `C` photo key.
- **Double-tap the SmartKnob BACK button** — same toggle (requires the paired firmware change in Smart-Knob-Redux that emits `BTN_DOUBLE_TAP`).
- **Menu** — new `Record Video` submenu: `Record` toggle + `Camera` (Left / Right / Both).

## UX
- Live pinned toast shows `REC mm:ss` with **Pause** and **Stop** actions; pausing shows `PAUSED mm:ss` with **Resume** / **Stop**.
- **Pause/Resume** splits the output into separate segment files.
- On stop, a summary toast reports `N seg · mm:ss · X MB`.

## Files / output
- New module `src/video_recorder.{h,cpp}` (pimpl keeps OpenCV/threading out of the header).
- Output: `<video.dir>/video_YYYYMMDD_HHMMSS_{L,R}_segN.mp4`.
- New `video` config section: `dir`, `fps` (default 30), `fourcc` (default `mp4v`), `camera` (default `left`). Default dir `~/Videos/protohud`.
- Host protocol gains `KnobButtonEvent::DOUBLE_TAP = 3`.

## Not in this PR (deferred follow-ups)
- Multi-stage quality/camera **selection toast** at start (camera selection lives in the menu/config for now).
- Quality presets + display-rate **reconfigure** flow.
- **Hide-chrome / stealth** live-view modes — note the recording is already clean POV (HUD chrome is composited after the eye FBOs), so this only affects the live display.
- Audio capture; photo burst/timed modes.

## Test plan
- [ ] Builds on the CM5 target (OpenCV/libcamera/GLES present; cannot build in this x86 container).
- [ ] `v` starts a recording and a `REC mm:ss` toast appears; `v` again stops it and a summary toast shows.
- [ ] Double-tap BACK starts/stops recording (with firmware change flashed).
- [ ] Pause → Resume produces multiple `_segN.mp4` files; all play back.
- [ ] Left / Right / Both each produce the expected file(s).
- [ ] Output plays in a standard player; `mp4v` fourcc available (fall back / set `avc1` in config if H.264 desired).
- [ ] Confirm no render-loop hitching while recording (encode is off-thread; frames drop rather than block if the encoder lags).

https://claude.ai/code/session_01JZP4JBGR21kMZk2arR9hJV

---
_Generated by [Claude Code](https://claude.ai/code/session_01JZP4JBGR21kMZk2arR9hJV)_