### PR TITLE
video_recorder: deterministic shutdown to fix crash on close

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4658,6 +4658,12 @@ int main(int argc, char* argv[]) {
     wd_stop.store(true);
     watchdog.join();
 
+    // Finalise video recording first: stops the encode worker and releases the
+    // OpenCV writers deterministically here, instead of in the recorder's
+    // destructor at return 0 (which runs after the GL context is gone and amid
+    // other destructors — an unordered teardown that crashes on close).
+    video_recorder.stop();
+
     bt_mon.stop();
     ping_mon.stop();
     wifi_mon.stop();

--- a/src/video_recorder.cpp
+++ b/src/video_recorder.cpp
@@ -102,12 +102,17 @@ struct VideoRecorder::Impl {
     Impl() {
         worker = std::thread([this] { worker_loop(); });
     }
-    ~Impl() {
+    ~Impl() { stop(); }
+
+    // Idempotent: stop the encode worker (draining queued frames) and finalise
+    // any open writers. Safe to call more than once and from the dtor.
+    void stop() {
+        bool was_running = false;
         {
             std::lock_guard<std::mutex> lk(qmtx);
-            stop_worker = true;
+            if (!stop_worker) { stop_worker = true; was_running = true; }
         }
-        qcv.notify_all();
+        if (was_running) qcv.notify_all();
         if (worker.joinable()) worker.join();
         close_writers();
     }
@@ -220,6 +225,7 @@ struct VideoRecorder::Impl {
 
 VideoRecorder::VideoRecorder()  : impl_(std::make_unique<Impl>()) {}
 VideoRecorder::~VideoRecorder() = default;
+void VideoRecorder::stop() { if (impl_) impl_->stop(); }
 bool VideoRecorder::recording() const { return impl_->recording; }
 
 void VideoRecorder::tick(XRDisplay& xr, AppState& state, const VideoConfig& cfg) {

--- a/src/video_recorder.h
+++ b/src/video_recorder.h
@@ -34,6 +34,11 @@ public:
     // Call once per frame on the render (GL) thread, after the eye FBOs are drawn.
     void tick(XRDisplay& xr, AppState& state, const VideoConfig& cfg);
 
+    // Stop the encode worker and finalise any open MP4 writers. Idempotent.
+    // Call during shutdown so teardown is deterministic and happens before the
+    // GL context is destroyed, rather than in the destructor at program exit.
+    void stop();
+
     bool recording() const;
 
 private:


### PR DESCRIPTION
The video recorder was the only subsystem with no explicit teardown in main()'s cleanup block — every other one (cameras, audio, knob, monitors) is stopped there.  It relied on its destructor running at `return 0`, which happens after xr.shutdown() tears down the GL context and amid the other local destructors.  Finalising the OpenCV VideoWriter that late, in an unordered teardown, crashes on program close.

Add an idempotent VideoRecorder::stop() (stop encode worker, drain queued frames, release writers) and call it at the top of the cleanup block, before the camera/GL teardown — matching the pattern of every other subsystem.  The destructor now just calls stop(), so exit is safe whether or not stop() was already invoked.