### PR TITLE
serial: make reader thread interruptible to fix hang on close

### DIFF
--- a/src/serial/serial_port.cpp
+++ b/src/serial/serial_port.cpp
@@ -46,8 +46,12 @@ bool SerialPort::open() {
     tty.c_lflag &= ~(ICANON | ECHO | ECHOE | ISIG);
     tty.c_oflag &= ~OPOST;
 
-    tty.c_cc[VMIN]  = 1;
-    tty.c_cc[VTIME] = 1;  // 100ms timeout
+    // VMIN=0, VTIME=1: read() returns after at most 100ms even when no data
+    // arrives, so reader_thread() can observe running_=false and exit promptly
+    // on close().  With VMIN=1, read() blocks until a byte arrives — if the
+    // device goes silent, close()'s thread join() would hang forever.
+    tty.c_cc[VMIN]  = 0;
+    tty.c_cc[VTIME] = 1;  // 100ms read timeout
 
     tcsetattr(fd_, TCSANOW, &tty);
     tcflush(fd_, TCIOFLUSH);


### PR DESCRIPTION
The shutdown log pinpointed teensy.stop() hanging during cleanup.  Root cause: SerialPort opened the tty with VMIN=1/VTIME=1, where read() blocks until at least one byte arrives (VTIME is only an inter-byte timer once the first byte is in).  When a connected device goes silent, the reader thread is stuck in read() forever, so close()'s thread.join() never returns and the program freezes on exit.  Earlier runs avoided it only because the serial port failed to open, so the reader never started.

Set VMIN=0 so read() returns after the 100ms VTIME even with no data; reader_thread() then sees running_=false and exits within 100ms, letting close()/stop() complete.  Fixes teensy/smartknob/lora teardown (all use SerialPort).  The 8s cleanup force-exit added earlier remains as a backstop.