### PR TITLE
install: add udev rule for VITURE glasses (35ca) device access

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -302,6 +302,13 @@ SUBSYSTEM=="tty", ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="7523", \
 # USB cameras — readable by video group
 SUBSYSTEM=="video4linux", MODE="0660", GROUP="video"
 
+# VITURE glasses (Beast/Luma) — control + IMU over USB HID / libusb (VID 0x35ca).
+# The SDK opens the device directly (hidraw and/or libusb), so the hidraw nodes
+# and the raw usb device must be accessible to the running user; without this
+# the glasses are recognized but every control command fails (no access).
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="35ca", MODE="0660", GROUP="plugdev", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="35ca", MODE="0660", GROUP="plugdev", TAG+="uaccess"
+
 # GPIO — readable by gpio group (libgpiod)
 SUBSYSTEM=="gpio", MODE="0660", GROUP="gpio"
 EOF


### PR DESCRIPTION
There was no udev rule for the Viture device, so the SDK-opened hidraw / usb nodes are root-only by default.  When the glasses are recognized but every control command fails for a non-root run, missing device access is a prime suspect.  Grant the running user access to VID 0x35ca hidraw and usb nodes (uaccess + plugdev), matching how the other peripherals are handled.