### PR TITLE
Preview: anchor across the whole screen + whole/left/right view toggle

### DIFF
--- a/src/hud/hud_renderer.cpp
+++ b/src/hud/hud_renderer.cpp
@@ -684,15 +684,19 @@ void HudRenderer::draw_android_overlay(unsigned int tex, int w, int h,
 
 void HudRenderer::draw_panel_preview(unsigned int tex, int screen_w, int screen_h,
                                      float anchor_x, float anchor_y,
-                                     float pan_x, float pan_y, float size_frac) {
+                                     float pan_x, float pan_y, float size_frac,
+                                     int view) {
     if (tex == 0) return;
 
     ImGui::SetCurrentContext(ctx_);
 
-    // Image size: height is a fraction of the screen; width keeps the LED canvas
-    // aspect (ShmFrameReader::W / ::H).
-    const float aspect = static_cast<float>(ShmFrameReader::W) /
-                         static_cast<float>(ShmFrameReader::H);
+    // view: 0 = whole canvas, 1 = left half, 2 = right half. A half crops one
+    // panel (one face) via UVs; width and aspect halve to match.
+    const bool   half   = (view == 1 || view == 2);
+    const float  wpx    = static_cast<float>(ShmFrameReader::W) * (half ? 0.5f : 1.0f);
+    const float  aspect = wpx / static_cast<float>(ShmFrameReader::H);
+    const ImVec2 uv0 = (view == 2) ? ImVec2(0.5f, 0.f) : ImVec2(0.f, 0.f);
+    const ImVec2 uv1 = (view == 1) ? ImVec2(0.5f, 1.f) : ImVec2(1.f, 1.f);
     float ph = size_frac * static_cast<float>(screen_h);
     if (ph < 8.f) ph = 8.f;
     const float pw = ph * aspect;
@@ -729,7 +733,7 @@ void HudRenderer::draw_panel_preview(unsigned int tex, int screen_w, int screen_
     const ImVec2 img0 = {p.x + pad, p.y + pad};
     const ImVec2 img1 = {p.x + pad + pw, p.y + pad + ph};
     dl->AddImage(reinterpret_cast<ImTextureID>(static_cast<uintptr_t>(tex)),
-                 img0, img1);
+                 img0, img1, uv0, uv1);
 
     // Accent border
     dl->AddRect({p.x, p.y}, {p.x + win_w, p.y + win_h},

--- a/src/hud/hud_renderer.h
+++ b/src/hud/hud_renderer.h
@@ -144,9 +144,11 @@ public:
     // anchor_x/anchor_y are screen fractions (0=left/top .. 1=right/bottom),
     // pan_x/pan_y a pixel nudge, size_frac the image height as a fraction of the
     // screen height.
+    // view: 0 = whole face (both panels), 1 = left half, 2 = right half.
     void draw_panel_preview(unsigned int tex, int screen_w, int screen_h,
                             float anchor_x, float anchor_y,
-                            float pan_x, float pan_y, float size_frac);
+                            float pan_x, float pan_y, float size_frac,
+                            int view = 0);
 
     // Draw system status panel (ImGui pass).
     void draw_sys_panel(const AppState& snap, int w, int h, bool active);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -307,6 +307,8 @@ static std::vector<MenuItem> build_menu(
         bool*             panel_preview_pp = nullptr,
         // Panel preview placement (anchor/nudge/size, like the camera PiPs)
         OverlayConfig*    protoface_preview_cfg = nullptr,
+        // Panel preview view mode: 0=whole face, 1=left half, 2=right half
+        int*              protoface_preview_view_pp = nullptr,
         std::string       map_dir         = "/home/user/Pictures/protohud/maps",
         // Eye source selection (render-thread only, no mutex needed)
         EyeSource* left_eye_src  = nullptr,
@@ -1696,6 +1698,14 @@ static std::vector<MenuItem> build_menu(
             make_position_items(protoface_preview_cfg)));
         protoface_inner_menu.push_back(make_size_slider("Preview Size", protoface_preview_cfg));
     }
+    if (protoface_preview_view_pp) {
+        int* vp = protoface_preview_view_pp;
+        protoface_inner_menu.push_back(submenu("Preview View", std::vector<MenuItem>{
+            leaf_sel("Whole Face", [vp]{ *vp = 0; }, [vp]{ return *vp == 0; }),
+            leaf_sel("Left Half",  [vp]{ *vp = 1; }, [vp]{ return *vp == 1; }),
+            leaf_sel("Right Half", [vp]{ *vp = 2; }, [vp]{ return *vp == 2; }),
+        }));
+    }
 
     // ── Face Display root: Source picker (radios) + per-backend submenus ─────
     std::vector<MenuItem> face_display_menu;
@@ -3008,6 +3018,7 @@ int main(int argc, char* argv[]) {
     protoface_preview_cfg.anchor_x = 1.0f;              // default: top-right (prior behaviour)
     protoface_preview_cfg.anchor_y = 0.0f;
     protoface_preview_cfg.size     = 0.15f;
+    int protoface_preview_view = 0;                     // 0=whole face, 1=left, 2=right
 
     if (cfg.contains("pip")) {
         auto& jpip = cfg["pip"];
@@ -3572,6 +3583,7 @@ int main(int argc, char* argv[]) {
                                static_cast<IFaceController*>(&protoface_ctrl),
                                &panel_preview_enabled,
                                &protoface_preview_cfg,
+                               &protoface_preview_view,
                                cfg_map_dir,
                                &left_eye_src, &right_eye_src));
     menu_ptr = &menu;
@@ -4532,10 +4544,10 @@ int main(int argc, char* argv[]) {
         if (panel_preview_enabled) {
             GLuint panel_tex = 0;
             protoface_ctrl.get_frame_texture(panel_tex);
-            hud.draw_panel_preview(panel_tex, xr.eye_width(), xr.eye_height(),
+            hud.draw_panel_preview(panel_tex, xr.display_width(), xr.display_height(),
                                    protoface_preview_cfg.anchor_x, protoface_preview_cfg.anchor_y,
                                    protoface_preview_cfg.pan_x,    protoface_preview_cfg.pan_y,
-                                   protoface_preview_cfg.size);
+                                   protoface_preview_cfg.size,     protoface_preview_view);
         }
 
         // System status panel (CPU/RAM/WiFi/ping/BT/SSH/perf/serial).


### PR DESCRIPTION
- Anchor against the full display (display_width/height) like the camera PiPs, instead of one eye half — so the preview can be placed anywhere on screen.
- New "Preview View" menu (Whole Face / Left Half / Right Half): draw_panel_preview takes a view mode and crops the shm texture via UVs (a half shows one panel / one face, with the aspect halved).