### PR TITLE
Don't crash on SIGPIPE when a socket peer goes away

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2788,6 +2788,11 @@ static void render_eye_fbo(gl::Fbo& fbo,
 // ── Entry point ───────────────────────────────────────────────────────────────
 
 int main(int argc, char* argv[]) {
+    // Writing to a socket/pipe whose peer has gone away (Protoface restarted, a
+    // serial device unplugged, etc.) must not kill the whole HUD — ignore SIGPIPE
+    // and handle the -1/EPIPE return at each call site.
+    std::signal(SIGPIPE, SIG_IGN);
+
     // Resolve resource paths relative to the binary's own directory so the app
     // works from any working directory (e.g. run via symlink from project root).
     namespace fs = std::filesystem;

--- a/src/serial/protoface_controller.cpp
+++ b/src/serial/protoface_controller.cpp
@@ -204,7 +204,10 @@ bool ProtoFaceController::send(const std::string& json) {
     if (fd_ < 0) return false;
 
     std::string msg = json + "\n";
-    ssize_t sent = ::write(fd_, msg.c_str(), msg.size());
+    // MSG_NOSIGNAL: writing to a peer that has gone away returns -1/EPIPE
+    // instead of raising SIGPIPE (which would crash the whole HUD). This happens
+    // routinely when Protoface is restarted and our connection goes stale.
+    ssize_t sent = ::send(fd_, msg.c_str(), msg.size(), MSG_NOSIGNAL);
     if (sent < 0) {
         ::close(fd_);
         fd_ = -1;


### PR DESCRIPTION
Changing an effect (or any command) after Protoface restarted wrote to a stale socket, and ::write() raised SIGPIPE → the whole HUD crashed. Ignore SIGPIPE in main() and use send(MSG_NOSIGNAL) in ProtoFaceController so a dead peer returns -1/EPIPE (handled: drop the connection, reconnect loop recovers).