### PR TITLE
Add Ctrl+# / Alt+# keybindings for faces and GIFs

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,8 @@ Keyboard shortcuts while running:
 | `↑` / `↓` | Navigate menu items |
 | `Enter` | Select menu item |
 | `Backspace` | Go back one menu level |
+| `Ctrl+1`…`Ctrl+9`, `Ctrl+0` | Switch face / expression on the active backend (1→first … 0→tenth) |
+| `Alt+1`…`Alt+9`, `Alt+0` | Play GIF on the active backend (auto-releases to the face after 5 s; restarts on each press) |
 | `Esc` | Quit |
 | `Ctrl+Q` / `Ctrl+K` | Force-kill the process immediately |
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3969,6 +3969,23 @@ int main(int argc, char* argv[]) {
             else if (menu.is_open())     menu.back();
         }
 
+        // Ctrl+1..9/0 — switch face (expression);  Alt+1..9/0 — play a GIF.
+        // Number maps to a 0-based index: 1→0 … 9→8, 0→9. Routed through the
+        // FaceProxy so it follows whichever backend (Protoface/Teensy) is active.
+        // Gated to menu-closed so the bare number keys keep driving the camera
+        // PiPs below; the camera block also ignores keys while Ctrl/Alt is held.
+        if (!menu.is_open() && (ImGui::GetIO().KeyCtrl || ImGui::GetIO().KeyAlt)) {
+            static const ImGuiKey kNumKeys[10] = {
+                ImGuiKey_1, ImGuiKey_2, ImGuiKey_3, ImGuiKey_4, ImGuiKey_5,
+                ImGuiKey_6, ImGuiKey_7, ImGuiKey_8, ImGuiKey_9, ImGuiKey_0,
+            };
+            for (int i = 0; i < 10; ++i) {
+                if (!key_pressed(kNumKeys[i])) continue;
+                if (ImGui::GetIO().KeyCtrl) face_proxy.set_face(static_cast<uint8_t>(i));
+                else                        face_proxy.play_gif(static_cast<uint8_t>(i));
+            }
+        }
+
         // ── Wireless controller pip state ─────────────────────────────────────
         bool wc_pip_left  = wireless_enabled && wireless.pip_left_active();
         bool wc_pip_right = wireless_enabled && wireless.pip_right_active();
@@ -4008,6 +4025,7 @@ int main(int argc, char* argv[]) {
         // 1/2/3     = toggle USB cam PiP 1/2/3   Shift+1/2/3 = autofocus that cam
         // 0         = toggle manual/auto focus    4 = autofocus both cameras
         // - / =     = focus near / far (step 20 of 0-1000)
+        // (Ctrl/Alt + number is reserved for face/GIF hotkeys handled above.)
         {
             GLFWwindow* win = static_cast<GLFWwindow*>(xr.glfw_window());
             auto edge = [&](int n, int glfw_key) -> bool {
@@ -4016,8 +4034,16 @@ int main(int argc, char* argv[]) {
                 prev_key[n] = now;
                 return fired;
             };
+            // Ctrl/Alt + number drives the face/GIF hotkeys above, so skip the
+            // camera number handlers while either is held (edge() still runs to
+            // keep prev_key state current and avoid a stale release-edge).
+            const bool face_mod =
+                (glfwGetKey(win, GLFW_KEY_LEFT_CONTROL) == GLFW_PRESS ||
+                 glfwGetKey(win, GLFW_KEY_RIGHT_CONTROL) == GLFW_PRESS ||
+                 glfwGetKey(win, GLFW_KEY_LEFT_ALT)  == GLFW_PRESS ||
+                 glfwGetKey(win, GLFW_KEY_RIGHT_ALT) == GLFW_PRESS);
             // 0: toggle manual/auto focus
-            if (edge(0, GLFW_KEY_0) && !menu.is_open()) {
+            if (edge(0, GLFW_KEY_0) && !menu.is_open() && !face_mod) {
                 bool go_manual = (state.focus_left.mode != CameraFocusState::Mode::MANUAL);
                 if (go_manual) {
                     if (cameras.owl_left())  cameras.owl_left()->stop_autofocus();
@@ -4034,7 +4060,7 @@ int main(int argc, char* argv[]) {
                 }
             }
             // 4: autofocus both cameras
-            if (edge(4, GLFW_KEY_4)) {
+            if (edge(4, GLFW_KEY_4) && !face_mod) {
                 if (cameras.owl_left())  cameras.owl_left()->start_autofocus();
                 if (cameras.owl_right()) cameras.owl_right()->start_autofocus();
                 std::lock_guard<std::mutex> lk(state.mtx);
@@ -4058,15 +4084,15 @@ int main(int argc, char* argv[]) {
                 bool shift = (glfwGetKey(win, GLFW_KEY_LEFT_SHIFT) == GLFW_PRESS ||
                               glfwGetKey(win, GLFW_KEY_RIGHT_SHIFT) == GLFW_PRESS);
                 if (!menu.is_open()) {
-                    if (edge(7, GLFW_KEY_1)) {
+                    if (edge(7, GLFW_KEY_1) && !face_mod) {
                         if (shift) cameras.set_usb1_ctrl(V4L2_CID_FOCUS_AUTO, 1);
                         else       pip_cam1_overlay_active = !pip_cam1_overlay_active;
                     }
-                    if (edge(8, GLFW_KEY_2)) {
+                    if (edge(8, GLFW_KEY_2) && !face_mod) {
                         if (shift) cameras.set_usb2_ctrl(V4L2_CID_FOCUS_AUTO, 1);
                         else       pip_cam2_overlay_active = !pip_cam2_overlay_active;
                     }
-                    if (edge(9, GLFW_KEY_3)) {
+                    if (edge(9, GLFW_KEY_3) && !face_mod) {
                         if (shift) cameras.set_usb3_ctrl(V4L2_CID_FOCUS_AUTO, 1);
                         else       pip_cam3_overlay_active = !pip_cam3_overlay_active;
                     }

--- a/src/serial/face_controller.h
+++ b/src/serial/face_controller.h
@@ -20,6 +20,8 @@ public:
 
     virtual void set_color(uint8_t r, uint8_t g, uint8_t b, uint8_t layer = 0) = 0;
     virtual void set_effect(uint8_t effect_id, uint8_t p1 = 0, uint8_t p2 = 0) = 0;
+    // Select a face/expression by 0-based index in the backend's face set.
+    virtual void set_face(uint8_t face_id) = 0;
     virtual void play_gif(uint8_t gif_id) = 0;
     virtual void set_brightness(uint8_t value) = 0;
     virtual void set_palette(uint8_t palette_id) = 0;
@@ -55,6 +57,7 @@ public:
     void set_effect(uint8_t effect_id, uint8_t p1 = 0, uint8_t p2 = 0) override {
         (*active_)->set_effect(effect_id, p1, p2);
     }
+    void set_face(uint8_t face_id)             override { (*active_)->set_face(face_id); }
     void play_gif(uint8_t gif_id)              override { (*active_)->play_gif(gif_id); }
     void set_brightness(uint8_t value)         override { (*active_)->set_brightness(value); }
     void set_palette(uint8_t palette_id)       override { (*active_)->set_palette(palette_id); }

--- a/src/serial/protoface_controller.cpp
+++ b/src/serial/protoface_controller.cpp
@@ -76,6 +76,12 @@ void ProtoFaceController::set_effect(uint8_t effect_id, uint8_t p1, uint8_t p2) 
     send(buf);
 }
 
+void ProtoFaceController::set_face(uint8_t face_id) {
+    char buf[64];
+    std::snprintf(buf, sizeof(buf), R"({"cmd":"set_face","face_id":%u})", face_id);
+    send(buf);
+}
+
 void ProtoFaceController::play_gif(uint8_t gif_id) {
     char buf[64];
     std::snprintf(buf, sizeof(buf), R"({"cmd":"play_gif","gif_id":%u})", gif_id);

--- a/src/serial/protoface_controller.h
+++ b/src/serial/protoface_controller.h
@@ -25,6 +25,7 @@ public:
 
     void set_color(uint8_t r, uint8_t g, uint8_t b, uint8_t layer = 0) override;
     void set_effect(uint8_t effect_id, uint8_t p1 = 0, uint8_t p2 = 0) override;
+    void set_face(uint8_t face_id)              override;
     void play_gif(uint8_t gif_id)               override;
     void set_brightness(uint8_t value)          override;
     void set_palette(uint8_t palette_id)        override;

--- a/src/serial/teensy_controller.cpp
+++ b/src/serial/teensy_controller.cpp
@@ -54,6 +54,12 @@ void TeensyController::set_effect(uint8_t effect_id, uint8_t p1, uint8_t p2) {
     state_.face.hud_control = true;
 }
 
+void TeensyController::set_face(uint8_t face_id) {
+    // ProtoTracer has no separate face command — expressions are effect slots
+    // (0=Idle, 1=Blink, 2=Angry, …), so a face select is an effect select.
+    set_effect(face_id);
+}
+
 void TeensyController::play_gif(uint8_t gif_id) {
     TeensyGifPayload p { gif_id };
     port_.send(TeensyCmd::PLAY_GIF,

--- a/src/serial/teensy_controller.h
+++ b/src/serial/teensy_controller.h
@@ -20,6 +20,7 @@ public:
     // Commands: CM5 → Teensy
     void set_color(uint8_t r, uint8_t g, uint8_t b, uint8_t layer = 0) override;
     void set_effect(uint8_t effect_id, uint8_t p1 = 0, uint8_t p2 = 0) override;
+    void set_face(uint8_t face_id)             override;
     void play_gif(uint8_t gif_id)              override;
     void set_brightness(uint8_t value)         override;
     void set_palette(uint8_t palette_id)       override;


### PR DESCRIPTION
## Summary
Adds keyboard shortcuts to drive the face display from ProtoHUD. Pairs with the ProtoFace PR (brooksthemaker/ProtoFace#1).

- **`Ctrl+1`…`Ctrl+9`, `Ctrl+0`** — switch face/expression (number → 0-based index: `1`→first … `0`→tenth).
- **`Alt+1`…`Alt+9`, `Alt+0`** — play a GIF (auto-releases back to the face after 5s in ProtoFace; restarts on each press).
- New `set_face(face_id)` on the `IFaceController` interface, so it works on whichever backend is active (routed through `FaceProxy`):
  - `ProtoFaceController` sends `{"cmd":"set_face","face_id":N}` over the Unix socket.
  - `TeensyController` maps it to its effect slots (ProtoTracer has no separate face command).
- Camera number-key handlers (`0/1/2/3/4`) now ignore presses while `Ctrl`/`Alt` is held so the new bindings don't collide; `edge()` still runs to keep key state current.
- README hotkey table updated.

## Test plan
- [x] All `IFaceController` implementers define `set_face` (FaceProxy, ProtoFaceController, TeensyController)
- [ ] Build on the CM5 toolchain (GLES/GLFW/ImGui unavailable in CI sandbox)
- [ ] On hardware: `Ctrl+#` changes face, `Alt+#` plays GIF then returns to the face after 5s, and bare number keys still toggle camera PiPs

https://claude.ai/code/session_01GWKuP2Sc1LqMcpBypjUJvj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GWKuP2Sc1LqMcpBypjUJvj)_