### PR TITLE
Add "Restart Protoface" — clean shutdown over IPC, then relaunch

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1681,12 +1681,18 @@ static std::vector<MenuItem> build_menu(
     };
     // "Start Protoface" first: launch the daemon (if not running) and make it the
     // active source. Targets the Protoface backend directly (not the proxy).
-    if (fp_option)
+    if (fp_option) {
         protoface_inner_menu.insert(protoface_inner_menu.begin(),
             leaf("Start Protoface", [fp_option, active_face_pp]{
                 fp_option->launch();
                 if (active_face_pp) *active_face_pp = fp_option;
             }));
+        protoface_inner_menu.insert(protoface_inner_menu.begin() + 1,
+            leaf("Restart Protoface", [fp_option, active_face_pp]{
+                fp_option->restart();
+                if (active_face_pp) *active_face_pp = fp_option;
+            }));
+    }
     if (panel_preview_pp)
         protoface_inner_menu.push_back(toggle("Panel Preview",
             [panel_preview_pp]{ return *panel_preview_pp; },

--- a/src/serial/face_controller.h
+++ b/src/serial/face_controller.h
@@ -34,6 +34,10 @@ public:
     // Start the backend's program/daemon if it isn't already running.
     // Default no-op (e.g. the Teensy is always-on hardware).
     virtual void launch() {}
+
+    // Restart the backend's program (stop the running one, then launch fresh).
+    // Default no-op.
+    virtual void restart() {}
 };
 
 /**
@@ -63,6 +67,7 @@ public:
     void release_control()                     override { (*active_)->release_control(); }
     void save_config()                         override { (*active_)->save_config(); }
     void launch()                              override { (*active_)->launch(); }
+    void restart()                             override { (*active_)->restart(); }
 
     IFaceController* backend() const { return *active_; }
 

--- a/src/serial/protoface_controller.cpp
+++ b/src/serial/protoface_controller.cpp
@@ -139,6 +139,17 @@ void ProtoFaceController::launch() {
         "nohup python3 run.py >/tmp/protoface.log 2>&1 &");
 }
 
+void ProtoFaceController::restart() {
+    // Ask the running instance to exit cleanly over the socket (it unlinks the
+    // socket and releases its single-instance lock), then launch a fresh one.
+    // Done on a detached thread so the HUD doesn't freeze during the wait.
+    send(R"({"cmd":"shutdown"})");
+    std::thread([this]{
+        std::this_thread::sleep_for(std::chrono::milliseconds(1200));
+        launch();
+    }).detach();
+}
+
 // ── Static helper ─────────────────────────────────────────────────────────────
 
 bool ProtoFaceController::socket_exists(const std::string& path) {

--- a/src/serial/protoface_controller.h
+++ b/src/serial/protoface_controller.h
@@ -33,6 +33,7 @@ public:
     void release_control()                      override;
     void save_config()                          override;
     void launch()                               override;
+    void restart()                              override;
 
     // Path used to detect whether Protoface is available.
     static bool socket_exists(const std::string& path = "/tmp/protoface.sock");


### PR DESCRIPTION
IFaceController gains restart() (default no-op). ProtoFaceController::restart() sends {"cmd":"shutdown"} so the running Protoface exits cleanly (unlinks socket, releases its lock), then launches a fresh one on a detached thread (no HUD freeze). New "Restart Protoface" menu item next to "Start Protoface".