### PR TITLE
Stop Protoface when ProtoHUD exits (clears the panels on close)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4784,7 +4784,7 @@ int main(int argc, char* argv[]) {
     step("beast_cam");       beast_cam.stop();
     step("cameras");         cameras.shutdown();
     step("teensy");          teensy.stop();
-    step("protoface");       protoface_ctrl.stop();
+    step("protoface");       protoface_ctrl.shutdown_daemon(); protoface_ctrl.stop();
     step("lora");            lora.stop();
     step("knob");            knob.stop();
     step("textures");

--- a/src/serial/protoface_controller.cpp
+++ b/src/serial/protoface_controller.cpp
@@ -150,6 +150,10 @@ void ProtoFaceController::restart() {
     }).detach();
 }
 
+void ProtoFaceController::shutdown_daemon() {
+    send(R"({"cmd":"shutdown"})");
+}
+
 // ── Static helper ─────────────────────────────────────────────────────────────
 
 bool ProtoFaceController::socket_exists(const std::string& path) {

--- a/src/serial/protoface_controller.h
+++ b/src/serial/protoface_controller.h
@@ -35,6 +35,10 @@ public:
     void launch()                               override;
     void restart()                              override;
 
+    // Ask the running Protoface to exit cleanly (clears the panels). Called on
+    // ProtoHUD shutdown so closing the HUD also blanks the LED face.
+    void shutdown_daemon();
+
     // Path used to detect whether Protoface is available.
     static bool socket_exists(const std::string& path = "/tmp/protoface.sock");
 


### PR DESCRIPTION
Closing ProtoHUD previously only disconnected, leaving Protoface running and the panels lit (requiring a manual pkill). Now ProtoHUD sends {"cmd":"shutdown"} to Protoface during its shutdown step, so the LED face clears cleanly on close. No-op if Protoface isn't connected.