### PR TITLE
Protoface: persist preview placement, autostart on boot, reliable shu…

### DIFF
--- a/config/config.example.json
+++ b/config/config.example.json
@@ -155,6 +155,19 @@
     "cam2": { "size": 0.25, "anchor": "top_right" },
     "_anchor_values": "top_left | top_center | top_right | bottom_left | bottom_center | bottom_right"
   },
+  "protoface": {
+    "_about": "Protoface LED face daemon. autostart launches it on HUD boot (no-op if already running) and makes it the active face source. preview is the on-glasses panel-preview window placement (persisted on exit).",
+    "autostart": true,
+    "preview": {
+      "anchor_x": 1.0,
+      "anchor_y": 0.0,
+      "pan_x": 0.0,
+      "pan_y": 0.0,
+      "size": 0.15,
+      "view": 0,
+      "_view_values": "0 = whole face | 1 = left half | 2 = right half"
+    }
+  },
   "audio": {
     "_note": "Audio capture is handled by the RP2350 helmet audio processor (USB Audio UAC2). The CM5 receives pre-processed stereo and routes it to the chosen output. Run 'arecord -l' to verify the RP2350 card name after connecting via USB.",
     "enabled": true,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3031,6 +3031,23 @@ int main(int argc, char* argv[]) {
     protoface_preview_cfg.size     = 0.15f;
     int protoface_preview_view = 0;                     // 0=whole face, 1=left, 2=right
 
+    // Protoface options: auto-start the daemon on boot and a persisted preview
+    // window placement (anchor/nudge/size/view) so it survives a restart.
+    bool pf_autostart = true;
+    if (cfg.contains("protoface")) {
+        auto& jpf = cfg["protoface"];
+        pf_autostart = jval(jpf, "autostart", true);
+        if (jpf.contains("preview")) {
+            auto& jpv = jpf["preview"];
+            protoface_preview_cfg.anchor_x = jval(jpv, "anchor_x", protoface_preview_cfg.anchor_x);
+            protoface_preview_cfg.anchor_y = jval(jpv, "anchor_y", protoface_preview_cfg.anchor_y);
+            protoface_preview_cfg.pan_x    = jval(jpv, "pan_x",    protoface_preview_cfg.pan_x);
+            protoface_preview_cfg.pan_y    = jval(jpv, "pan_y",    protoface_preview_cfg.pan_y);
+            protoface_preview_cfg.size     = jval(jpv, "size",     protoface_preview_cfg.size);
+            protoface_preview_view         = jval(jpv, "view",     protoface_preview_view);
+        }
+    }
+
     if (cfg.contains("pip")) {
         auto& jpip = cfg["pip"];
         float def_size = jval(jpip, "size", 0.25f);
@@ -3484,6 +3501,9 @@ int main(int argc, char* argv[]) {
     WirelessController   wireless(wireless_port, baud);
 
     if (!teensy.start()) std::cerr << "[main] Teensy not available on " << teensy_port << "\n";
+    // Auto-start the Protoface daemon on boot (no-op if already running). The
+    // reconnect loop in start() then connects once its socket comes up.
+    if (pf_autostart) protoface_ctrl.launch();
     protoface_ctrl.start();   // connects async; no-op if socket absent
 
     // QR / barcode scanner — active when either scan toggle is enabled.
@@ -3535,8 +3555,10 @@ int main(int argc, char* argv[]) {
     if (!lora.start())   std::cerr << "[main] LoRa not available on "   << lora_port   << "\n";
     if (!knob.start())   std::cerr << "[main] SmartKnob not available on " << knob_port << "\n";
 
-    // Active face backend: prefer Protoface if its socket already exists at startup.
-    IFaceController* active_face = ProtoFaceController::socket_exists()
+    // Active face backend: prefer Protoface if its socket already exists, or if
+    // we just auto-launched it (the socket may not be up yet — the reconnect
+    // loop will connect shortly, and commands no-op until then).
+    IFaceController* active_face = (ProtoFaceController::socket_exists() || pf_autostart)
         ? static_cast<IFaceController*>(&protoface_ctrl)
         : static_cast<IFaceController*>(&teensy);
     FaceProxy face_proxy(&active_face);
@@ -4650,6 +4672,14 @@ int main(int argc, char* argv[]) {
         cfg["pip"]["cam2"]["pan_y"]     = pip_overlay_cfg2.pan_y;
         cfg["pip"]["cam2"]["size"]      = pip_overlay_cfg2.size;
         cfg["pip"]["cam2"]["rotation"]  = rotation_to_str(pip_overlay_cfg2.rotation);
+
+        cfg["protoface"]["autostart"]           = pf_autostart;
+        cfg["protoface"]["preview"]["anchor_x"] = protoface_preview_cfg.anchor_x;
+        cfg["protoface"]["preview"]["anchor_y"] = protoface_preview_cfg.anchor_y;
+        cfg["protoface"]["preview"]["pan_x"]    = protoface_preview_cfg.pan_x;
+        cfg["protoface"]["preview"]["pan_y"]    = protoface_preview_cfg.pan_y;
+        cfg["protoface"]["preview"]["size"]     = protoface_preview_cfg.size;
+        cfg["protoface"]["preview"]["view"]     = protoface_preview_view;
 
         auto& jpp = cfg["post_process"];
         jpp["edge_enabled"]       = state.pp_cfg.edge_enabled;

--- a/src/serial/protoface_controller.cpp
+++ b/src/serial/protoface_controller.cpp
@@ -157,7 +157,15 @@ void ProtoFaceController::restart() {
 }
 
 void ProtoFaceController::shutdown_daemon() {
-    send(R"({"cmd":"shutdown"})");
+    // Deliver the shutdown even if our persistent connection has dropped: try
+    // the live socket first, then fall back to a fresh one-shot connection.
+    // Without the fallback, a stale/closed fd_ silently swallows the command and
+    // the LED panels stay lit after the HUD exits (the reported symptom).
+    if (!send(R"({"cmd":"shutdown"})"))
+        send_oneshot(R"({"cmd":"shutdown"})");
+    // Give Protoface a beat to read the line and blank the panels (it clears +
+    // unlinks on SIGINT) before the HUD process tears the connection down.
+    std::this_thread::sleep_for(std::chrono::milliseconds(250));
 }
 
 // ── Static helper ─────────────────────────────────────────────────────────────
@@ -236,4 +244,21 @@ bool ProtoFaceController::send(const std::string& json) {
         return false;
     }
     return true;
+}
+
+bool ProtoFaceController::send_oneshot(const std::string& json) {
+    int fd = ::socket(AF_UNIX, SOCK_STREAM, 0);
+    if (fd < 0) return false;
+
+    sockaddr_un addr{};
+    addr.sun_family = AF_UNIX;
+    std::strncpy(addr.sun_path, socket_path_.c_str(), sizeof(addr.sun_path) - 1);
+
+    bool ok = false;
+    if (::connect(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) == 0) {
+        std::string msg = json + "\n";
+        ok = ::send(fd, msg.c_str(), msg.size(), MSG_NOSIGNAL) >= 0;
+    }
+    ::close(fd);
+    return ok;
 }

--- a/src/serial/protoface_controller.h
+++ b/src/serial/protoface_controller.h
@@ -56,6 +56,10 @@ private:
     void reconnect_loop();
     bool try_connect();
     bool send(const std::string& json);
+    // Open a fresh one-shot connection, send one message, close. Used by
+    // shutdown_daemon() so the command still lands when the persistent
+    // connection has dropped (otherwise the panels stay lit after exit).
+    bool send_oneshot(const std::string& json);
 
     std::string          socket_path_;
     int                  fd_  { -1 };


### PR DESCRIPTION
…tdown

Three Protoface lifecycle/UX improvements:

- Preview window placement (anchor/nudge/size + whole/left/right view) now loads from and saves to config.json under "protoface.preview", so it survives a restart instead of resetting to top-right each launch.

- Auto-start on boot: when "protoface.autostart" is true (default), the HUD launches the daemon at startup (no-op if already running) and selects Protoface as the active face source; the existing reconnect loop connects once its socket comes up. Teensy-only users can set autostart=false.

- Reliable panel clearing on exit: shutdown_daemon() now falls back to a fresh one-shot socket connection if the persistent one has dropped, and waits briefly so Protoface receives the line and blanks the panels before the HUD tears down. Previously a stale fd silently swallowed the shutdown, leaving the LED face lit (requiring a manual pkill).

config.example.json documents the new "protoface" section.