### PR TITLE
Native face renderer: Phase 1-2 core (port of Protoface render pipeline)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,6 +260,30 @@ set_target_properties(protohud PROPERTIES
 
 # ── Assets & Config ────────────────────────────────────────���──────────────────
 
+# ── Native face renderer (Protoface C++ port, work in progress) ───────────────
+# Built as a separate static library, EXCLUDE_FROM_ALL so it NEVER affects the
+# default `protohud` build while the port is incomplete and uncompiled-on-CM5.
+# Compile-check it in isolation with:
+#     cmake --build build --target protoface_native
+# A later PR links this into protohud and wires NativeFaceController into main.cpp.
+add_library(protoface_native STATIC EXCLUDE_FROM_ALL
+    src/face/face_state.cpp
+    src/face/materials.cpp
+    src/face/renderer.cpp
+    src/face/face_loader.cpp
+    src/face/shm_pusher_output.cpp
+    src/face/native_face_controller.cpp
+)
+target_include_directories(protoface_native PRIVATE
+    src/
+    ${OpenCV_INCLUDE_DIRS}
+)
+target_link_libraries(protoface_native PRIVATE
+    ${OpenCV_LIBS}
+    nlohmann_json::nlohmann_json
+    Threads::Threads
+)
+
 configure_file(config/config.example.json ${CMAKE_BINARY_DIR}/config.json COPYONLY)
 
 # Copy shaders to build directory.

--- a/scripts/panel_driver.py
+++ b/scripts/panel_driver.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""
+Minimal HUB75 frame-pusher for ProtoHUD's native face renderer.
+
+ProtoHUD renders the LED face in C++ and writes the canvas to a shared-memory
+segment (ShmPusherOutput). This shim only reads that segment and pushes each new
+frame to the panels via Adafruit Piomatter — the proven driver path — so no
+Python rendering daemon is needed. ProtoHUD launches this when its panel output
+mode is "shm".
+
+Shared-memory format (matches src/serial/shm_frame_reader.h / ShmPusherOutput):
+    byte 0      uint8 sequence counter (wraps at 256)
+    bytes 1..N  W*H RGB, row-major (R G B ...)
+
+Usage: panel_driver.py [--canvas-w 128] [--canvas-h 32]
+                       [--panel-w 64] [--panel-h 32] [--chain 2] [--parallel 1]
+                       [--shm /dev/shm/protoface_frame]
+"""
+
+import argparse
+import mmap
+import os
+import signal
+import time
+
+import numpy as np
+
+import adafruit_blinka_raspberry_pi5_piomatter as piomatter
+from adafruit_blinka_raspberry_pi5_piomatter.pixelmappers import simple_multilane_mapper
+
+
+def addr_lines(panel_h: int) -> int:
+    return (panel_h // 2).bit_length() - 1
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--canvas-w', type=int, default=128)
+    ap.add_argument('--canvas-h', type=int, default=32)
+    ap.add_argument('--panel-w', type=int, default=64)
+    ap.add_argument('--panel-h', type=int, default=32)
+    ap.add_argument('--chain', type=int, default=2)
+    ap.add_argument('--parallel', type=int, default=1)
+    ap.add_argument('--shm', default='/dev/shm/protoface_frame')
+    ap.add_argument('--fps', type=float, default=60.0, help='poll rate cap')
+    args = ap.parse_args()
+
+    W, H = args.canvas_w, args.canvas_h
+    size = 1 + W * H * 3
+
+    # Piomatter geometry — identical to Protoface's hub75.py.
+    n_addr  = addr_lines(args.panel_h)
+    n_lanes = 2 * args.parallel
+    width   = args.panel_w * args.chain
+    height  = n_lanes << n_addr
+    pixelmap = simple_multilane_mapper(width, height, n_addr, n_lanes)
+    geometry = piomatter.Geometry(width=width, height=height, n_addr_lines=n_addr,
+                                  n_planes=10, n_temporal_planes=4,
+                                  map=pixelmap, n_lanes=n_lanes)
+    fb = np.zeros((height, width, 3), dtype=np.uint8)
+    matrix = piomatter.PioMatter(colorspace=piomatter.Colorspace.RGB888Packed,
+                                 pinout=piomatter.Pinout.Active3,
+                                 framebuffer=fb, geometry=geometry)
+
+    # Wait for ProtoHUD to create the shm segment.
+    while not os.path.exists(args.shm):
+        time.sleep(0.2)
+    fd = os.open(args.shm, os.O_RDONLY)
+    mm = mmap.mmap(fd, size, mmap.MAP_SHARED, mmap.PROT_READ)
+
+    running = {'go': True}
+
+    def stop(*_):
+        running['go'] = False
+    signal.signal(signal.SIGINT, stop)
+    signal.signal(signal.SIGTERM, stop)
+
+    last_seq = -1
+    period = 1.0 / max(1.0, args.fps)
+    try:
+        while running['go']:
+            seq = mm[0]
+            if seq != last_seq:
+                last_seq = seq
+                buf = np.frombuffer(mm, dtype=np.uint8, count=W * H * 3, offset=1)
+                frame = buf.reshape((H, W, 3))
+                # Panels display R->G->B rotated; resend as (G,B,R) to correct.
+                fb[:] = frame[:, :, [1, 2, 0]]
+                matrix.show()
+            time.sleep(period)
+    finally:
+        fb[:] = 0           # blank on exit
+        matrix.show()
+        time.sleep(0.1)
+        mm.close()
+        os.close(fd)
+        print("panel_driver stopped.")
+
+
+if __name__ == '__main__':
+    main()

--- a/src/face/face_config.h
+++ b/src/face/face_config.h
@@ -1,0 +1,62 @@
+#pragma once
+// ── face_config.h ──────────────────────────────────────────────────────────────
+// Plain config structs for the native face renderer (a C++ port of the
+// Protoface Python daemon). main.cpp builds these from config.json's
+// "protoface" section; the renderer library itself is config-format agnostic.
+
+#include <array>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace face {
+
+struct WiggleCfg {
+    double speed       = 0.3;   // oscillation rate (Hz-ish)
+    double amplitude_x = 2.0;   // px
+    double amplitude_y = 1.0;   // px
+};
+
+struct BlinkCfg {
+    double interval_min = 3.0;  // s between blinks (min)
+    double interval_max = 7.0;  // s between blinks (max)
+    double duration     = 0.15; // s for a full close+open
+};
+
+struct FaceCfg {
+    std::string active          = "main";  // faces/<active>/ folder
+    WiggleCfg   wiggle;
+    BlinkCfg    blink;
+    double      expression_fade = 0.3;     // crossfade seconds
+    double      mouth_sensitivity = 0.5;
+};
+
+struct MaterialCfg {
+    std::string active   = "teal";  // "teal" | "solid:r,g,b" | "zone:a|b"
+    double      scroll_x = 0.0;     // px/s
+    double      scroll_y = 0.0;
+};
+
+// One physical panel region inside the logical canvas.
+struct PanelCfg {
+    std::string name;
+    int         x = 0, y = 0, w = 64, h = 32;   // region in canvas pixels
+    std::string mirror_of;                       // empty = renders its own face
+    FaceCfg     face;
+    MaterialCfg material;
+    std::string particles = "none";              // effect/preset shorthand (Phase 3)
+};
+
+// Top-level renderer config (mirror of Protoface config.yaml panel/display).
+struct RenderConfig {
+    int                  canvas_w   = 128;
+    int                  canvas_h   = 32;
+    int                  fps        = 30;
+    std::array<uint8_t,3> background = {0, 0, 0};   // RGB
+    std::string          faces_dir     = "faces";
+    std::string          materials_dir = "materials";
+    std::string          gifs_dir      = "gifs";
+    std::vector<PanelCfg> panels;
+};
+
+} // namespace face

--- a/src/face/face_image.h
+++ b/src/face/face_image.h
@@ -1,0 +1,64 @@
+#pragma once
+// ── face_image.h ───────────────────────────────────────────────────────────────
+// Small OpenCV image helpers for the native face renderer.
+//
+// Channel convention: all cv::Mat buffers in the face renderer are RGB / RGBA
+// ordered (channel 0 = R), matching the Protoface numpy code — NOT OpenCV's
+// native BGR. PNGs loaded via cv::imread (BGR/BGRA) are converted on load. The
+// final canvas is therefore RGB, which is what the shm preview format and the
+// (later) Piomatter output expect.
+
+#include <string>
+#include <opencv2/core.hpp>
+#include <opencv2/imgproc.hpp>
+#include <opencv2/imgcodecs.hpp>
+
+namespace face {
+
+// Load a PNG as an (h, w) RGBA cv::Mat (CV_8UC4), NEAREST-resized to panel size.
+// Returns an empty Mat if the file can't be read.
+inline cv::Mat load_png_rgba(const std::string& path, int w, int h) {
+    cv::Mat raw = cv::imread(path, cv::IMREAD_UNCHANGED);
+    if (raw.empty()) return cv::Mat();
+    cv::Mat rgba;
+    if (raw.channels() == 4)      cv::cvtColor(raw, rgba, cv::COLOR_BGRA2RGBA);
+    else if (raw.channels() == 3) cv::cvtColor(raw, rgba, cv::COLOR_BGR2RGBA);
+    else if (raw.channels() == 1) cv::cvtColor(raw, rgba, cv::COLOR_GRAY2RGBA);
+    else                          return cv::Mat();
+    cv::Mat out;
+    cv::resize(rgba, out, cv::Size(w, h), 0, 0, cv::INTER_NEAREST);
+    return out;
+}
+
+// Load a PNG as an (h, w) RGB cv::Mat (CV_8UC3) at native size (no resize).
+inline cv::Mat load_png_rgb_native(const std::string& path) {
+    cv::Mat raw = cv::imread(path, cv::IMREAD_COLOR);   // always 3-channel BGR
+    if (raw.empty()) return cv::Mat();
+    cv::Mat rgb;
+    cv::cvtColor(raw, rgb, cv::COLOR_BGR2RGB);
+    return rgb;
+}
+
+// Equivalent of np.roll on a 2D image: shift columns by dx and rows by dy with
+// wrap-around. Positive dx shifts content to the right.
+inline cv::Mat roll(const cv::Mat& m, int dx, int dy) {
+    const int w = m.cols, h = m.rows;
+    cv::Mat out = m;
+    if (w > 0 && (dx % w) != 0) {
+        int s = ((dx % w) + w) % w;
+        cv::Mat tmp(h, w, m.type());
+        out.colRange(w - s, w).copyTo(tmp.colRange(0, s));
+        out.colRange(0, w - s).copyTo(tmp.colRange(s, w));
+        out = tmp;
+    }
+    if (h > 0 && (dy % h) != 0) {
+        int s = ((dy % h) + h) % h;
+        cv::Mat tmp(h, w, m.type());
+        out.rowRange(h - s, h).copyTo(tmp.rowRange(0, s));
+        out.rowRange(0, h - s).copyTo(tmp.rowRange(s, h));
+        out = tmp;
+    }
+    return out;
+}
+
+} // namespace face

--- a/src/face/face_loader.cpp
+++ b/src/face/face_loader.cpp
@@ -1,0 +1,159 @@
+#include "face_loader.h"
+
+#include <algorithm>
+#include <cmath>
+#include <filesystem>
+#include <fstream>
+
+#include <opencv2/imgproc.hpp>
+#include <nlohmann/json.hpp>
+
+#include "face_image.h"
+#include "face_state.h"
+
+namespace fs = std::filesystem;
+using json = nlohmann::json;
+
+namespace face {
+
+FaceLoader::FaceLoader(const std::string& folder, int width, int height)
+    : folder_(folder), w_(width), h_(height) {
+    load();
+}
+
+void FaceLoader::load() {
+    json cfg = json::object();
+    fs::path cfg_path = fs::path(folder_) / "config.json";
+    if (fs::exists(cfg_path)) {
+        std::ifstream f(cfg_path);
+        try { f >> cfg; } catch (...) { cfg = json::object(); }
+    }
+
+    // Expression map: name → filename (or scan folder for PNGs).
+    std::vector<std::pair<std::string, std::string>> expr_map;
+    if (cfg.contains("expressions") && cfg["expressions"].is_object()) {
+        for (auto& [name, fn] : cfg["expressions"].items())
+            expr_map.emplace_back(name, fn.get<std::string>());
+    } else {
+        std::vector<std::string> pngs;
+        for (auto& e : fs::directory_iterator(folder_))
+            if (e.path().extension() == ".png") pngs.push_back(e.path().filename().string());
+        std::sort(pngs.begin(), pngs.end());
+        for (auto& p : pngs) {
+            std::string stem = fs::path(p).stem().string();
+            std::transform(stem.begin(), stem.end(), stem.begin(), ::tolower);
+            if (stem != "blink" && stem != "mouth_open") expr_map.emplace_back(stem, p);
+        }
+    }
+
+    for (auto& [name, filename] : expr_map) {
+        cv::Mat img = load_png_rgba((fs::path(folder_) / filename).string(), w_, h_);
+        if (!img.empty()) {
+            expressions_[name] = img;
+            expr_order_.push_back(name);
+        }
+    }
+
+    // Fallback neutral (alias to the first expression).
+    if (!expressions_.empty() && expressions_.find("neutral") == expressions_.end()) {
+        expressions_["neutral"] = expressions_[expr_order_.front()];
+    }
+
+    // Blink image.
+    std::string blink_file = cfg.value("blink", std::string("blink.png"));
+    blink_ = load_png_rgba((fs::path(folder_) / blink_file).string(), w_, h_);
+
+    // Optional mouth-open image.
+    fs::path mo = fs::path(folder_) / "mouth_open.png";
+    if (fs::exists(mo)) mouth_open_ = load_png_rgba(mo.string(), w_, h_);
+
+    // Region scaling: boxes may be authored at draw_size and scaled to panel px.
+    double sx = 1.0, sy = 1.0;
+    if (cfg.contains("draw_size") && cfg["draw_size"].is_array() &&
+        cfg["draw_size"].size() == 2) {
+        double dw = cfg["draw_size"][0].get<double>();
+        double dh = cfg["draw_size"][1].get<double>();
+        if (dw > 0 && dh > 0) { sx = w_ / dw; sy = h_ / dh; }
+    }
+    auto parse_region = [&](const json& d) {
+        Region r;
+        r.x = static_cast<int>(std::lround(d.value("x", 0) * sx));
+        r.y = static_cast<int>(std::lround(d.value("y", 0) * sy));
+        r.w = std::max(1, static_cast<int>(std::lround(d.value("w", 1) * sx)));
+        r.h = std::max(1, static_cast<int>(std::lround(d.value("h", 1) * sy)));
+        r.set = true;
+        return r;
+    };
+    if (cfg.contains("eye_left"))  eye_left_  = parse_region(cfg["eye_left"]);
+    if (cfg.contains("eye_right")) eye_right_ = parse_region(cfg["eye_right"]);
+    if (cfg.contains("mouth"))     mouth_     = parse_region(cfg["mouth"]);
+}
+
+cv::Mat FaceLoader::blend_region(const cv::Mat& base, const cv::Mat& overlay,
+                                 const Region& region, double t) const {
+    cv::Mat out = base.clone();
+    int x  = region.x, y = region.y;
+    int x2 = std::min(x + region.w, w_), y2 = std::min(y + region.h, h_);
+    x = std::max(0, x); y = std::max(0, y);
+    if (x2 <= x || y2 <= y) return out;
+    cv::Rect roi(x, y, x2 - x, y2 - y);
+    cv::addWeighted(base(roi), 1.0 - t, overlay(roi), t, 0.0, out(roi));
+    return out;
+}
+
+cv::Mat FaceLoader::get_frame(const FaceState& state) {
+    if (expressions_.empty())
+        return cv::Mat::zeros(h_, w_, CV_8UC4);
+
+    auto get_expr = [&](const std::string& name) -> const cv::Mat& {
+        auto it = expressions_.find(name);
+        if (it != expressions_.end()) return it->second;
+        return expressions_.at("neutral");
+    };
+
+    const cv::Mat& cur  = get_expr(state.expression());
+    const cv::Mat& prev = get_expr(state.prev_expression());
+
+    // 1. Expression crossfade.
+    double t = std::clamp(state.transition_t(), 0.0, 1.0);
+    cv::Mat frame;
+    if (t >= 1.0 || state.expression() == state.prev_expression())
+        frame = cur.clone();
+    else
+        cv::addWeighted(prev, 1.0 - t, cur, t, 0.0, frame);
+
+    // 2. Blink.
+    double bw = std::clamp(state.blink_weight(), 0.0, 1.0);
+    if (bw > 0.0 && !blink_.empty()) {
+        if (eye_left_.set || eye_right_.set) {
+            if (eye_left_.set)  frame = blend_region(frame, blink_, eye_left_,  bw);
+            if (eye_right_.set) frame = blend_region(frame, blink_, eye_right_, bw);
+        } else {
+            cv::addWeighted(frame, 1.0 - bw, blink_, bw, 0.0, frame);
+        }
+    }
+
+    // 3. Mouth open.
+    double mo = std::clamp(state.mouth_open(), 0.0, 1.0);
+    if (mo > 0.0 && mouth_.set && !mouth_open_.empty())
+        frame = blend_region(frame, mouth_open_, mouth_, mo);
+
+    // 4. Wiggle + gyro sub-pixel shift (edge-clamped, no wrap).
+    const WiggleCfg& wc = state.wiggle();
+    double tsec = state.time();
+    double dx = wc.amplitude_x * std::sin(2.0 * M_PI * wc.speed * tsec);
+    double dy = wc.amplitude_y * std::sin(2.0 * M_PI * wc.speed * tsec * 1.3);
+    double shift_x = dx + state.gyro_dx();
+    double shift_y = dy + state.gyro_dy();
+    if (std::abs(shift_x) > 0.01 || std::abs(shift_y) > 0.01) {
+        cv::Mat M = (cv::Mat_<double>(2, 3) << 1, 0, shift_x, 0, 1, shift_y);
+        cv::Mat shifted;
+        cv::warpAffine(frame, shifted, M, frame.size(),
+                       cv::INTER_LINEAR, cv::BORDER_REPLICATE);
+        frame = shifted;
+    }
+
+    return frame;
+}
+
+} // namespace face

--- a/src/face/face_loader.h
+++ b/src/face/face_loader.h
@@ -1,0 +1,42 @@
+#pragma once
+// ── face_loader.h ──────────────────────────────────────────────────────────────
+// C++ port of protoface/face.py. Loads a face folder (PNGs + config.json) and
+// composites the current frame each tick: expression crossfade, blink (per-eye
+// region or whole-face), mouth-open swap, and idle wiggle + gyro sub-pixel shift.
+// Output is an (h, w) RGBA cv::Mat (CV_8UC4, channel 0 = R).
+
+#include <map>
+#include <string>
+#include <vector>
+#include <opencv2/core.hpp>
+
+namespace face {
+
+class FaceState;   // fwd
+
+class FaceLoader {
+public:
+    FaceLoader(const std::string& folder, int width, int height);
+
+    cv::Mat get_frame(const FaceState& state);   // CV_8UC4
+    const std::vector<std::string>& expression_names() const { return expr_order_; }
+    bool valid() const { return !expressions_.empty(); }
+
+private:
+    struct Region { int x = 0, y = 0, w = 0, h = 0; bool set = false; };
+
+    void load();
+    cv::Mat blend_region(const cv::Mat& base, const cv::Mat& overlay,
+                         const Region& region, double t) const;
+
+    std::string folder_;
+    int w_, h_;
+
+    std::map<std::string, cv::Mat> expressions_;   // name → RGBA (h,w)
+    std::vector<std::string>       expr_order_;     // stable insertion order
+    cv::Mat  blink_;            // may be empty
+    cv::Mat  mouth_open_;       // may be empty
+    Region   eye_left_, eye_right_, mouth_;
+};
+
+} // namespace face

--- a/src/face/face_state.cpp
+++ b/src/face/face_state.cpp
@@ -1,0 +1,118 @@
+#include "face_state.h"
+
+#include <algorithm>
+#include <chrono>
+
+namespace face {
+
+FaceState::FaceState(const FaceCfg& cfg, std::vector<std::string> expression_names)
+    : expressions_(std::move(expression_names)),
+      rng_(static_cast<uint32_t>(
+          std::chrono::steady_clock::now().time_since_epoch().count())) {
+    expression_      = expressions_.empty() ? "neutral" : expressions_.front();
+    prev_expression_ = expression_;
+    transition_t_    = 1.0;
+
+    fade_speed_      = 1.0 / std::max(0.01, cfg.expression_fade);
+
+    blink_duration_  = cfg.blink.duration;
+    blink_min_       = cfg.blink.interval_min;
+    blink_max_       = cfg.blink.interval_max;
+    next_blink_      = rand_uniform(blink_min_, blink_max_);
+
+    wiggle_          = cfg.wiggle;
+}
+
+double FaceState::rand_uniform(double lo, double hi) {
+    std::uniform_real_distribution<double> d(lo, hi);
+    return d(rng_);
+}
+
+// ── Expression control ──────────────────────────────────────────────────────
+
+void FaceState::set_expression(const std::string& name) {
+    if (name == expression_) return;
+    prev_expression_ = expression_;
+    expression_      = name;
+    transition_t_    = 0.0;
+}
+
+void FaceState::set_expression_by_index(int idx) {
+    if (idx >= 0 && idx < static_cast<int>(expressions_.size())) {
+        expr_idx_ = idx;
+        set_expression(expressions_[idx]);
+    }
+}
+
+void FaceState::next_expression() {
+    if (expressions_.empty()) return;
+    expr_idx_ = (expr_idx_ + 1) % static_cast<int>(expressions_.size());
+    set_expression(expressions_[expr_idx_]);
+}
+
+void FaceState::prev_expression() {
+    if (expressions_.empty()) return;
+    int n = static_cast<int>(expressions_.size());
+    expr_idx_ = (expr_idx_ - 1 + n) % n;
+    set_expression(expressions_[expr_idx_]);
+}
+
+void FaceState::trigger_boop(const std::string& expression, double duration) {
+    if (boop_remaining_ <= 0.0) boop_prev_ = expression_;
+    boop_remaining_ = duration;
+    set_expression(expression);
+}
+
+void FaceState::trigger_blink() {
+    if (blink_phase_ == BlinkPhase::Open) {
+        blink_phase_ = BlinkPhase::Closing;
+        blink_t_     = 0.0;
+    }
+}
+
+// ── Per-frame update ─────────────────────────────────────────────────────────
+
+void FaceState::update(double dt) {
+    time_ += dt;
+
+    if (transition_t_ < 1.0)
+        transition_t_ = std::min(1.0, transition_t_ + dt * fade_speed_);
+
+    if (boop_remaining_ > 0.0) {
+        boop_remaining_ -= dt;
+        if (boop_remaining_ <= 0.0) set_expression(boop_prev_);
+    }
+
+    update_blink(dt);
+}
+
+void FaceState::update_blink(double dt) {
+    const double half = blink_duration_ / 2.0;
+
+    switch (blink_phase_) {
+    case BlinkPhase::Open:
+        next_blink_ -= dt;
+        if (next_blink_ <= 0.0) { blink_phase_ = BlinkPhase::Closing; blink_t_ = 0.0; }
+        break;
+    case BlinkPhase::Closing:
+        blink_t_ += dt;
+        blink_weight_ = std::min(1.0, blink_t_ / half);
+        if (blink_t_ >= half) { blink_phase_ = BlinkPhase::Closed; blink_t_ = 0.0; }
+        break;
+    case BlinkPhase::Closed:
+        blink_t_ += dt;
+        if (blink_t_ >= 0.04) { blink_phase_ = BlinkPhase::Opening; blink_t_ = 0.0; }
+        break;
+    case BlinkPhase::Opening:
+        blink_t_ += dt;
+        blink_weight_ = std::max(0.0, 1.0 - blink_t_ / half);
+        if (blink_t_ >= half) {
+            blink_weight_ = 0.0;
+            blink_phase_  = BlinkPhase::Open;
+            next_blink_   = rand_uniform(blink_min_, blink_max_);
+        }
+        break;
+    }
+}
+
+} // namespace face

--- a/src/face/face_state.h
+++ b/src/face/face_state.h
@@ -1,0 +1,91 @@
+#pragma once
+// ── face_state.h ───────────────────────────────────────────────────────────────
+// C++ port of protoface/state.py — the per-panel animation state passed to the
+// face compositor each tick. Owns expression crossfade, the blink state machine,
+// the boop override, and the inputs (audio mouth-open, gyro offset, brightness).
+//
+// Threading: NativeFaceController serializes all access under its own mutex, so
+// FaceState carries no internal locking.
+
+#include <random>
+#include <string>
+#include <vector>
+
+#include "face_config.h"
+
+namespace face {
+
+class FaceState {
+public:
+    FaceState(const FaceCfg& cfg, std::vector<std::string> expression_names);
+
+    // ── Expression control ──────────────────────────────────────────────────
+    void set_expression(const std::string& name);
+    void set_expression_by_index(int idx);   // out-of-range = no-op
+    void next_expression();
+    void prev_expression();
+    void trigger_boop(const std::string& expression, double duration);
+    void trigger_blink();
+
+    // ── Per-frame update ─────────────────────────────────────────────────────
+    void update(double dt);
+
+    // ── Inputs (set by the controller before render) ─────────────────────────
+    void set_audio(double volume, double mouth_open) { audio_volume_ = volume; mouth_open_ = mouth_open; }
+    void set_gyro(double dx, double dy)              { gyro_dx_ = dx; gyro_dy_ = dy; }
+    void set_brightness(int b)                       { brightness_ = b < 0 ? 0 : (b > 255 ? 255 : b); }
+
+    // ── Read accessors for the compositor (mirror face.py's state fields) ─────
+    const std::string& expression()      const { return expression_; }
+    const std::string& prev_expression() const { return prev_expression_; }
+    double transition_t() const { return transition_t_; }
+    double blink_weight() const { return blink_weight_; }
+    double mouth_open()   const { return mouth_open_; }
+    double gyro_dx()      const { return gyro_dx_; }
+    double gyro_dy()      const { return gyro_dy_; }
+    double time()         const { return time_; }
+    int    brightness()   const { return brightness_; }
+    const WiggleCfg& wiggle() const { return wiggle_; }
+    const std::vector<std::string>& expression_names() const { return expressions_; }
+
+private:
+    void update_blink(double dt);
+    double rand_uniform(double lo, double hi);
+
+    std::vector<std::string> expressions_;
+    int    expr_idx_ = 0;
+
+    std::string expression_;
+    std::string prev_expression_;
+    double transition_t_ = 1.0;
+    double fade_speed_   = 1.0 / 0.3;
+
+    // Boop override
+    double      boop_remaining_ = 0.0;
+    std::string boop_prev_      = "neutral";
+
+    // Blink state machine
+    enum class BlinkPhase { Open, Closing, Closed, Opening };
+    BlinkPhase blink_phase_ = BlinkPhase::Open;
+    double blink_weight_   = 0.0;
+    double blink_t_        = 0.0;
+    double blink_duration_ = 0.15;
+    double blink_min_      = 3.0;
+    double blink_max_      = 7.0;
+    double next_blink_     = 3.0;
+
+    WiggleCfg wiggle_;
+
+    // Inputs
+    double audio_volume_ = 0.0;
+    double mouth_open_   = 0.0;
+    double gyro_dx_      = 0.0;
+    double gyro_dy_      = 0.0;
+
+    double time_       = 0.0;
+    int    brightness_ = 255;
+
+    std::mt19937 rng_;
+};
+
+} // namespace face

--- a/src/face/materials.cpp
+++ b/src/face/materials.cpp
@@ -1,0 +1,113 @@
+#include "materials.h"
+
+#include <cstdio>
+#include <sys/stat.h>
+
+#include "face_image.h"
+
+namespace face {
+
+static bool file_exists(const std::string& p) {
+    struct stat st{};
+    return ::stat(p.c_str(), &st) == 0;
+}
+
+// ── Solid ────────────────────────────────────────────────────────────────────
+
+SolidMaterial::SolidMaterial(int r, int g, int b, int width, int height) {
+    // RGB channel order (channel 0 = R), matching the renderer convention.
+    frame_ = cv::Mat(height, width, CV_8UC3,
+                     cv::Scalar(static_cast<double>(r),
+                                static_cast<double>(g),
+                                static_cast<double>(b)));
+}
+
+// ── Texture ──────────────────────────────────────────────────────────────────
+
+TextureMaterial::TextureMaterial(const std::string& path, int width, int height,
+                                 double scroll_x, double scroll_y)
+    : w_(width), h_(height), scroll_x_(scroll_x), scroll_y_(scroll_y) {
+    cv::Mat img = load_png_rgb_native(path);
+    if (img.empty()) return;
+
+    // Tile to >= panel size so a scroll roll wraps cleanly, then crop.
+    int tw = std::max(width,  img.cols);
+    int th = std::max(height, img.rows);
+    cv::Mat tiled(th, tw, CV_8UC3, cv::Scalar(0, 0, 0));
+    for (int y = 0; y < th; y += img.rows)
+        for (int x = 0; x < tw; x += img.cols) {
+            int cw = std::min(img.cols, tw - x);
+            int ch = std::min(img.rows, th - y);
+            img(cv::Rect(0, 0, cw, ch)).copyTo(tiled(cv::Rect(x, y, cw, ch)));
+        }
+    base_ = tiled(cv::Rect(0, 0, width, height)).clone();
+}
+
+cv::Mat TextureMaterial::get_frame() {
+    if (base_.empty()) return cv::Mat(h_, w_, CV_8UC3, cv::Scalar(0, 220, 180));
+    int sx = w_ > 0 ? (static_cast<int>(scroll_x_ * t_) % w_) : 0;
+    int sy = h_ > 0 ? (static_cast<int>(scroll_y_ * t_) % h_) : 0;
+    if (sx == 0 && sy == 0) return base_;
+    return roll(base_, sx, sy);
+}
+
+// ── Zoned ────────────────────────────────────────────────────────────────────
+
+ZonedMaterial::ZonedMaterial(std::shared_ptr<BaseMaterial> a,
+                             std::shared_ptr<BaseMaterial> b,
+                             int width, int height, double boundary)
+    : a_(std::move(a)), b_(std::move(b)), w_(width), h_(height),
+      split_(static_cast<int>(width * boundary)) {}
+
+cv::Mat ZonedMaterial::get_frame() {
+    cv::Mat a = a_->get_frame();
+    cv::Mat b = b_->get_frame();
+    cv::Mat frame(h_, w_, CV_8UC3);
+    if (split_ > 0)        a(cv::Rect(0, 0, split_, h_)).copyTo(frame(cv::Rect(0, 0, split_, h_)));
+    if (split_ < w_)       b(cv::Rect(split_, 0, w_ - split_, h_))
+                               .copyTo(frame(cv::Rect(split_, 0, w_ - split_, h_)));
+    return frame;
+}
+
+// ── Factory ──────────────────────────────────────────────────────────────────
+
+std::shared_ptr<BaseMaterial> load_material(
+    const std::string& name, int width, int height,
+    double scroll_x, double scroll_y, const std::string& materials_dir) {
+
+    if (name.rfind("solid:", 0) == 0) {
+        int r = 0, g = 0, b = 0;
+        std::sscanf(name.c_str() + 6, "%d,%d,%d", &r, &g, &b);
+        return std::make_shared<SolidMaterial>(r, g, b, width, height);
+    }
+
+    if (name.rfind("zone:", 0) == 0) {
+        std::string rest = name.substr(5);
+        auto bar = rest.find('|');
+        std::string an = bar == std::string::npos ? rest : rest.substr(0, bar);
+        std::string bn = bar == std::string::npos ? rest : rest.substr(bar + 1);
+        auto trim = [](std::string s) {
+            size_t a = s.find_first_not_of(" \t");
+            size_t b = s.find_last_not_of(" \t");
+            return a == std::string::npos ? std::string() : s.substr(a, b - a + 1);
+        };
+        auto a = load_material(trim(an), width, height, scroll_x, scroll_y, materials_dir);
+        auto b = load_material(trim(bn), width, height, scroll_x, scroll_y, materials_dir);
+        return std::make_shared<ZonedMaterial>(a, b, width, height);
+    }
+
+    for (const std::string& cand : {materials_dir + "/" + name + ".png",
+                                    materials_dir + "/" + name}) {
+        if (file_exists(cand)) {
+            auto tex = std::make_shared<TextureMaterial>(cand, width, height,
+                                                         scroll_x, scroll_y);
+            if (tex->valid()) return tex;
+        }
+    }
+
+    std::fprintf(stderr, "[material] '%s' not found — falling back to solid teal\n",
+                 name.c_str());
+    return std::make_shared<SolidMaterial>(0, 220, 180, width, height);
+}
+
+} // namespace face

--- a/src/face/materials.h
+++ b/src/face/materials.h
@@ -1,0 +1,62 @@
+#pragma once
+// ── materials.h ────────────────────────────────────────────────────────────────
+// C++ port of protoface/material.py. A material is the colour/pattern painted
+// onto the face pixels. get_frame() returns an (h, w) RGB cv::Mat (CV_8UC3).
+
+#include <memory>
+#include <string>
+#include <opencv2/core.hpp>
+
+namespace face {
+
+class BaseMaterial {
+public:
+    virtual ~BaseMaterial() = default;
+    virtual void update(double /*dt*/) {}
+    virtual cv::Mat get_frame() = 0;   // (h, w) CV_8UC3 RGB
+};
+
+// Flat colour.
+class SolidMaterial : public BaseMaterial {
+public:
+    SolidMaterial(int r, int g, int b, int width, int height);
+    cv::Mat get_frame() override { return frame_; }
+private:
+    cv::Mat frame_;
+};
+
+// PNG tiled to panel size, optionally scrolling.
+class TextureMaterial : public BaseMaterial {
+public:
+    TextureMaterial(const std::string& path, int width, int height,
+                    double scroll_x = 0.0, double scroll_y = 0.0);
+    void update(double dt) override { t_ += dt; }
+    cv::Mat get_frame() override;
+    bool valid() const { return !base_.empty(); }
+private:
+    int    w_, h_;
+    double scroll_x_, scroll_y_, t_ = 0.0;
+    cv::Mat base_;   // (h, w) CV_8UC3 RGB, already cropped to panel size
+};
+
+// Horizontal split: left of boundary uses mat_a, right uses mat_b.
+class ZonedMaterial : public BaseMaterial {
+public:
+    ZonedMaterial(std::shared_ptr<BaseMaterial> a, std::shared_ptr<BaseMaterial> b,
+                  int width, int height, double boundary = 0.5);
+    void update(double dt) override { a_->update(dt); b_->update(dt); }
+    cv::Mat get_frame() override;
+private:
+    std::shared_ptr<BaseMaterial> a_, b_;
+    int w_, h_, split_;
+};
+
+// Factory mirroring material.py load_material():
+//   "solid:r,g,b" | "zone:a|b" | "<name>" → materials/<name>.png
+// Falls back to solid teal if a PNG can't be found.
+std::shared_ptr<BaseMaterial> load_material(
+    const std::string& name, int width, int height,
+    double scroll_x = 0.0, double scroll_y = 0.0,
+    const std::string& materials_dir = "materials");
+
+} // namespace face

--- a/src/face/native_face_controller.cpp
+++ b/src/face/native_face_controller.cpp
@@ -1,0 +1,217 @@
+#include "native_face_controller.h"
+
+#include <algorithm>
+#include <chrono>
+#include <thread>
+
+#include <opencv2/imgproc.hpp>
+
+#include "face_state.h"
+#include "face_loader.h"
+#include "materials.h"
+#include "renderer.h"
+#include "panel_output.h"
+
+namespace face {
+
+NativeFaceController::NativeFaceController(RenderConfig cfg,
+                                          std::unique_ptr<PanelOutput> output)
+    : cfg_(std::move(cfg)), output_(std::move(output)) {
+    build_panels();
+}
+
+NativeFaceController::~NativeFaceController() { stop(); }
+
+void NativeFaceController::build_panels() {
+    panels_.clear();
+    for (const PanelCfg& pc : cfg_.panels) {
+        Panel pn;
+        pn.cfg = pc;
+        if (pc.mirror_of.empty()) {
+            pn.loader = std::make_unique<FaceLoader>(
+                cfg_.faces_dir + "/" + pc.face.active, pc.w, pc.h);
+            pn.state = std::make_unique<FaceState>(
+                pc.face, pn.loader->expression_names());
+            pn.material = load_material(pc.material.active, pc.w, pc.h,
+                                        pc.material.scroll_x, pc.material.scroll_y,
+                                        cfg_.materials_dir);
+        } else {
+            pn.is_mirror = true;
+        }
+        panels_.push_back(std::move(pn));
+    }
+    // Resolve mirror sources by panel name.
+    for (auto& pn : panels_) {
+        if (!pn.is_mirror) continue;
+        for (size_t i = 0; i < panels_.size(); ++i)
+            if (panels_[i].cfg.name == pn.cfg.mirror_of) { pn.src_index = static_cast<int>(i); break; }
+    }
+}
+
+bool NativeFaceController::start() {
+    if (running_.load()) return true;
+    if (output_) output_->open();
+    running_.store(true);
+    thread_ = std::thread(&NativeFaceController::render_thread, this);
+    return true;
+}
+
+void NativeFaceController::stop() {
+    if (!running_.exchange(false)) return;
+    if (thread_.joinable()) thread_.join();
+    if (output_) output_->close();   // blank the panels on shutdown
+}
+
+void NativeFaceController::render_thread() {
+    using clock = std::chrono::steady_clock;
+    const double target_dt = 1.0 / std::max(1, cfg_.fps);
+    auto prev = clock::now();
+
+    while (running_.load()) {
+        auto now = clock::now();
+        double dt = std::chrono::duration<double>(now - prev).count();
+        prev = now;
+        dt = std::min(dt, 0.1);
+
+        cv::Mat canvas(cfg_.canvas_h, cfg_.canvas_w, CV_8UC3,
+                       cv::Scalar(cfg_.background[0], cfg_.background[1],
+                                  cfg_.background[2]));
+        {
+            std::lock_guard<std::mutex> lk(state_mtx_);
+
+            // Render each self-rendering panel into its region.
+            for (auto& pn : panels_) {
+                if (pn.is_mirror || !pn.state) continue;
+                if (!pn.loader || !pn.loader->valid()) continue;
+                const PanelCfg& pc = pn.cfg;
+
+                pn.state->update(dt);
+                pn.material->update(dt);
+
+                cv::Mat bg  = solid_layer(cfg_.background[0], cfg_.background[1],
+                                          cfg_.background[2], pc.w, pc.h);
+                cv::Mat mat = pn.material->get_frame();
+                cv::Mat face_rgba  = pn.loader->get_frame(*pn.state);
+                cv::Mat face_layer = apply_material(face_rgba, mat);
+
+                std::vector<Layer> layers{ Layer{face_layer, Blend::Normal} };
+                // TODO(Phase 3): append particle + GIF layers here.
+
+                cv::Mat frame = composite(bg, layers);
+                frame = scale_brightness(frame, pn.state->brightness());
+
+                cv::Rect roi(pc.x, pc.y, pc.w, pc.h);
+                if ((roi & cv::Rect(0, 0, canvas.cols, canvas.rows)) == roi)
+                    frame.copyTo(canvas(roi));
+            }
+
+            // Mirror panels copy a horizontally-flipped source region.
+            for (auto& pn : panels_) {
+                if (!pn.is_mirror || pn.src_index < 0) continue;
+                const PanelCfg& src = panels_[pn.src_index].cfg;
+                const PanelCfg& dst = pn.cfg;
+                cv::Rect sroi(src.x, src.y, src.w, src.h);
+                cv::Rect droi(dst.x, dst.y, dst.w, dst.h);
+                cv::Rect bounds(0, 0, canvas.cols, canvas.rows);
+                if ((sroi & bounds) != sroi || (droi & bounds) != droi) continue;
+                if (sroi.size() != droi.size()) continue;
+                cv::Mat flipped;
+                cv::flip(canvas(sroi), flipped, 1);
+                flipped.copyTo(canvas(droi));
+            }
+        }
+
+        {
+            std::lock_guard<std::mutex> lk(frame_mtx_);
+            canvas.copyTo(latest_);
+            have_frame_ = true;
+        }
+        if (output_) output_->show(canvas);
+
+        double elapsed = std::chrono::duration<double>(clock::now() - now).count();
+        double sleep_s = target_dt - elapsed;
+        if (sleep_s > 0)
+            std::this_thread::sleep_for(std::chrono::duration<double>(sleep_s));
+    }
+}
+
+bool NativeFaceController::latest_frame(cv::Mat& out) const {
+    std::lock_guard<std::mutex> lk(frame_mtx_);
+    if (!have_frame_) return false;
+    latest_.copyTo(out);
+    return true;
+}
+
+// ── Commands (mutate state under state_mtx_) ─────────────────────────────────
+
+void NativeFaceController::set_color(uint8_t r, uint8_t g, uint8_t b, uint8_t) {
+    std::lock_guard<std::mutex> lk(state_mtx_);
+    for (auto& pn : panels_)
+        if (!pn.is_mirror)
+            pn.material = std::make_shared<SolidMaterial>(r, g, b, pn.cfg.w, pn.cfg.h);
+}
+
+void NativeFaceController::set_effect(uint8_t /*effect_id*/, uint8_t, uint8_t) {
+    // TODO(Phase 3): map effect_id → ParticleSystem layers per panel.
+}
+
+void NativeFaceController::set_face(uint8_t face_id) {
+    std::lock_guard<std::mutex> lk(state_mtx_);
+    for (auto& pn : panels_)
+        if (pn.state) pn.state->set_expression_by_index(face_id);
+}
+
+void NativeFaceController::play_gif(uint8_t /*gif_id*/) {
+    // TODO(Phase 3): GIF playback (decode + per-panel override).
+}
+
+void NativeFaceController::set_brightness(uint8_t value) {
+    std::lock_guard<std::mutex> lk(state_mtx_);
+    for (auto& pn : panels_)
+        if (pn.state) pn.state->set_brightness(value);
+}
+
+void NativeFaceController::set_palette(uint8_t palette_id) {
+    std::lock_guard<std::mutex> lk(state_mtx_);
+    apply_material_all(preset_material(palette_id));
+}
+
+void NativeFaceController::set_menu_item(uint8_t menu_index, uint8_t value) {
+    if (menu_index != 8) return;   // 8 = material colour preset (matches Protoface)
+    std::lock_guard<std::mutex> lk(state_mtx_);
+    apply_material_all(preset_material(value));
+}
+
+void NativeFaceController::release_control() {
+    // TODO(Phase 3): stop any active GIF and revert to the face.
+}
+
+void NativeFaceController::apply_material_all(const std::string& name) {
+    for (auto& pn : panels_)
+        if (!pn.is_mirror)
+            pn.material = load_material(name, pn.cfg.w, pn.cfg.h,
+                                        pn.cfg.material.scroll_x,
+                                        pn.cfg.material.scroll_y,
+                                        cfg_.materials_dir);
+}
+
+std::string NativeFaceController::preset_material(int idx) {
+    // Mirrors Protoface ipc.py _MATERIAL_COLOR_MAP / ProtoHUD pf_palette order.
+    switch (idx) {
+        case 0:  return "teal";
+        case 1:  return "solid:255,220,0";
+        case 2:  return "solid:255,140,0";
+        case 3:  return "solid:255,255,255";
+        case 4:  return "solid:30,220,60";
+        case 5:  return "solid:180,30,220";
+        case 6:  return "solid:220,30,30";
+        case 7:  return "solid:30,100,255";
+        case 8:  return "rainbow";
+        case 9:  return "cool";
+        case 10: return "warm";
+        case 11: return "solid:0,0,0";
+        default: return "teal";
+    }
+}
+
+} // namespace face

--- a/src/face/native_face_controller.h
+++ b/src/face/native_face_controller.h
@@ -1,0 +1,87 @@
+#pragma once
+// ── native_face_controller.h ───────────────────────────────────────────────────
+// Native C++ Protoface backend. Implements ProtoHUD's IFaceController so it drops
+// into the existing FaceProxy/menu seam, renders the LED face in-process on a
+// worker thread (no Python daemon, no control socket), exposes the latest canvas
+// for the in-HUD preview, and emits frames to a swappable PanelOutput.
+//
+// Scope note (Phase 1–2): face + materials + compositing are ported. Particles,
+// GIF playback, and the C++ Piomatter output are stubbed/TODO for later phases.
+
+#include <atomic>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <opencv2/core.hpp>
+
+#include "../serial/face_controller.h"
+#include "face_config.h"
+
+namespace face {
+
+class FaceState;
+class FaceLoader;
+class BaseMaterial;
+class PanelOutput;
+
+class NativeFaceController : public IFaceController {
+public:
+    NativeFaceController(RenderConfig cfg, std::unique_ptr<PanelOutput> output);
+    ~NativeFaceController() override;
+
+    // IFaceController
+    bool start() override;
+    void stop()  override;
+    bool connected() const override { return running_.load(); }
+
+    void set_color(uint8_t r, uint8_t g, uint8_t b, uint8_t layer = 0) override;
+    void set_effect(uint8_t effect_id, uint8_t p1 = 0, uint8_t p2 = 0) override;
+    void set_face(uint8_t face_id) override;
+    void play_gif(uint8_t gif_id) override;
+    void set_brightness(uint8_t value) override;
+    void set_palette(uint8_t palette_id) override;
+    void set_menu_item(uint8_t menu_index, uint8_t value) override;
+    void request_status() override {}
+    void release_control() override;
+    void save_config() override {}        // TODO: persist look to ProtoHUD config
+
+    // Copy the latest rendered RGB canvas (CV_8UC3) for the preview. Returns
+    // false until the first frame exists. Safe to call from the main/GL thread.
+    bool latest_frame(cv::Mat& out) const;
+
+    int canvas_width()  const { return cfg_.canvas_w; }
+    int canvas_height() const { return cfg_.canvas_h; }
+
+private:
+    struct Panel {
+        PanelCfg                      cfg;
+        std::unique_ptr<FaceState>    state;     // null for mirror panels
+        std::unique_ptr<FaceLoader>   loader;    // null for mirror panels
+        std::shared_ptr<BaseMaterial> material;  // null for mirror panels
+        bool is_mirror = false;
+        int  src_index = -1;
+    };
+
+    void build_panels();
+    void render_thread();
+    void apply_material_all(const std::string& name);   // caller holds state_mtx_
+    static std::string preset_material(int idx);
+
+    RenderConfig                 cfg_;
+    std::unique_ptr<PanelOutput> output_;
+    std::vector<Panel>           panels_;
+
+    mutable std::mutex state_mtx_;   // panels_ mutation + render reads
+    mutable std::mutex frame_mtx_;   // latest_
+    cv::Mat            latest_;
+    bool               have_frame_ = false;
+
+    std::thread        thread_;
+    std::atomic<bool>  running_{false};
+};
+
+} // namespace face

--- a/src/face/panel_output.h
+++ b/src/face/panel_output.h
@@ -1,0 +1,24 @@
+#pragma once
+// ── panel_output.h ─────────────────────────────────────────────────────────────
+// Swappable LED-panel sink for the native face renderer. The renderer produces a
+// canvas-sized RGB cv::Mat each frame and hands it to a PanelOutput. Two impls:
+//   • ShmPusherOutput  — writes the frame to /dev/shm; a tiny Python shim calls
+//                        Piomatter.show() (the safe, proven path).
+//   • PiomatterOutput  — (future) drives the panels directly via a vendored
+//                        Piomatter C++ core, no Python.
+
+#include <opencv2/core.hpp>
+
+namespace face {
+
+class PanelOutput {
+public:
+    virtual ~PanelOutput() = default;
+    virtual bool open() { return true; }
+    // Push an (h, w) CV_8UC3 RGB canvas to the panels.
+    virtual void show(const cv::Mat& rgb) = 0;
+    // Blank the panels (best effort) on shutdown.
+    virtual void close() {}
+};
+
+} // namespace face

--- a/src/face/renderer.cpp
+++ b/src/face/renderer.cpp
@@ -1,0 +1,84 @@
+#include "renderer.h"
+
+#include <opencv2/imgproc.hpp>
+
+namespace face {
+
+cv::Mat solid_layer(uint8_t r, uint8_t g, uint8_t b, int width, int height) {
+    return cv::Mat(height, width, CV_8UC3,
+                   cv::Scalar(static_cast<double>(r),
+                              static_cast<double>(g),
+                              static_cast<double>(b)));
+}
+
+cv::Mat apply_material(const cv::Mat& face_rgba, const cv::Mat& material_rgb) {
+    std::vector<cv::Mat> f;            // R,G,B,A (uint8)
+    cv::split(face_rgba, f);
+
+    cv::Mat r, g, b;
+    f[0].convertTo(r, CV_32F);
+    f[1].convertTo(g, CV_32F);
+    f[2].convertTo(b, CV_32F);
+    cv::Mat lum = (r + g + b) / 3.0f / 255.0f;   // (h,w) float, 0..1
+
+    std::vector<cv::Mat> m;            // material R,G,B (uint8)
+    cv::split(material_rgb, m);
+    cv::Mat mr, mg, mb;
+    m[0].convertTo(mr, CV_32F);
+    m[1].convertTo(mg, CV_32F);
+    m[2].convertTo(mb, CV_32F);
+
+    cv::Mat cr, cg, cb;               // colour × luminance, saturate to 0..255
+    mr.mul(lum).convertTo(cr, CV_8U);
+    mg.mul(lum).convertTo(cg, CV_8U);
+    mb.mul(lum).convertTo(cb, CV_8U);
+
+    std::vector<cv::Mat> out{cr, cg, cb, f[3]};
+    cv::Mat result;
+    cv::merge(out, result);
+    return result;                    // CV_8UC4 RGBA
+}
+
+cv::Mat composite(const cv::Mat& base_rgb, const std::vector<Layer>& layers) {
+    cv::Mat out;
+    base_rgb.convertTo(out, CV_32FC3);
+
+    for (const Layer& L : layers) {
+        if (L.rgba.empty()) continue;
+
+        std::vector<cv::Mat> ch;      // R,G,B,A (uint8)
+        cv::split(L.rgba, ch);
+
+        cv::Mat rgb;
+        cv::merge(std::vector<cv::Mat>{ch[0], ch[1], ch[2]}, rgb);
+        cv::Mat rgbf;
+        rgb.convertTo(rgbf, CV_32FC3);
+
+        cv::Mat af;
+        ch[3].convertTo(af, CV_32F, 1.0 / 255.0);          // (h,w) 0..1
+        cv::Mat a3;
+        cv::merge(std::vector<cv::Mat>{af, af, af}, a3);    // (h,w,3)
+
+        if (L.blend == Blend::Add) {
+            out = out + rgbf.mul(a3);
+        } else {
+            cv::Mat inv;
+            cv::subtract(cv::Scalar::all(1.0), a3, inv);
+            out = out.mul(inv) + rgbf.mul(a3);
+        }
+    }
+
+    cv::Mat res;
+    out.convertTo(res, CV_8UC3);      // saturating cast == np.clip(...).astype
+    return res;
+}
+
+cv::Mat scale_brightness(const cv::Mat& rgb, int value) {
+    if (value >= 255) return rgb;
+    if (value <= 0)   return cv::Mat::zeros(rgb.size(), rgb.type());
+    cv::Mat out;
+    rgb.convertTo(out, CV_8UC3, value / 255.0);
+    return out;
+}
+
+} // namespace face

--- a/src/face/renderer.h
+++ b/src/face/renderer.h
@@ -1,0 +1,33 @@
+#pragma once
+// ── renderer.h ─────────────────────────────────────────────────────────────────
+// C++ port of protoface/renderer.py. Stateless compositing helpers over RGB(A)
+// cv::Mat buffers (channel 0 = R). Sizes are derived from the Mats, so unlike the
+// Python Renderer there's no per-size object to cache.
+
+#include <vector>
+#include <cstdint>
+#include <opencv2/core.hpp>
+
+namespace face {
+
+enum class Blend { Normal, Add };
+
+struct Layer {
+    cv::Mat rgba;          // (h, w) CV_8UC4 RGBA; empty = skipped
+    Blend   blend = Blend::Normal;
+};
+
+// (h, w) CV_8UC3 filled with an RGB colour.
+cv::Mat solid_layer(uint8_t r, uint8_t g, uint8_t b, int width, int height);
+
+// Combine a face sprite (RGBA; RGB=shading, A=mask) with a material colour layer
+// (RGB): material × normalised face luminance, alpha preserved. Returns RGBA.
+cv::Mat apply_material(const cv::Mat& face_rgba, const cv::Mat& material_rgb);
+
+// Alpha-composite layers (bottom-to-top) over an RGB base. Returns RGB.
+cv::Mat composite(const cv::Mat& base_rgb, const std::vector<Layer>& layers);
+
+// Scale an RGB frame's brightness by value/255 in place-safe fashion.
+cv::Mat scale_brightness(const cv::Mat& rgb, int value /*0-255*/);
+
+} // namespace face

--- a/src/face/shm_pusher_output.cpp
+++ b/src/face/shm_pusher_output.cpp
@@ -1,0 +1,58 @@
+#include "shm_pusher_output.h"
+
+#include <cstring>
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <opencv2/imgproc.hpp>
+
+namespace face {
+
+ShmPusherOutput::ShmPusherOutput(int width, int height, std::string path)
+    : w_(width), h_(height), path_(std::move(path)) {
+    size_ = static_cast<size_t>(1) + static_cast<size_t>(w_) * h_ * 3;
+}
+
+ShmPusherOutput::~ShmPusherOutput() { close(); }
+
+bool ShmPusherOutput::open() {
+    fd_ = ::open(path_.c_str(), O_RDWR | O_CREAT, 0660);
+    if (fd_ < 0) return false;
+    if (::ftruncate(fd_, static_cast<off_t>(size_)) != 0) {
+        ::close(fd_); fd_ = -1; return false;
+    }
+    void* m = ::mmap(nullptr, size_, PROT_READ | PROT_WRITE, MAP_SHARED, fd_, 0);
+    if (m == MAP_FAILED) { ::close(fd_); fd_ = -1; return false; }
+    map_ = static_cast<uint8_t*>(m);
+    return true;
+}
+
+void ShmPusherOutput::show(const cv::Mat& rgb) {
+    if (!map_) return;
+
+    // Normalise to the expected (h_, w_) CV_8UC3 contiguous buffer.
+    cv::Mat canvas = rgb;
+    if (canvas.type() != CV_8UC3)
+        canvas.convertTo(canvas, CV_8UC3);
+    if (canvas.cols != w_ || canvas.rows != h_)
+        cv::resize(canvas, canvas, cv::Size(w_, h_), 0, 0, cv::INTER_NEAREST);
+    if (!canvas.isContinuous())
+        canvas = canvas.clone();
+
+    std::memcpy(map_ + 1, canvas.data, static_cast<size_t>(w_) * h_ * 3);
+    map_[0] = ++seq_;   // publish: bump the sequence counter last
+}
+
+void ShmPusherOutput::close() {
+    if (map_) {
+        std::memset(map_ + 1, 0, static_cast<size_t>(w_) * h_ * 3);   // blank
+        map_[0] = ++seq_;
+        ::munmap(map_, size_);
+        map_ = nullptr;
+    }
+    if (fd_ >= 0) { ::close(fd_); fd_ = -1; }
+}
+
+} // namespace face

--- a/src/face/shm_pusher_output.h
+++ b/src/face/shm_pusher_output.h
@@ -1,0 +1,36 @@
+#pragma once
+// ── shm_pusher_output.h ────────────────────────────────────────────────────────
+// PanelOutput that writes the rendered RGB canvas to a POSIX shared-memory
+// segment in the exact format ProtoHUD's ShmFrameReader already understands:
+//   byte 0        uint8 sequence counter (wraps at 256)
+//   bytes 1..N    W×H RGB, row-major (R G B ...)
+// A tiny companion Python script (scripts/panel_driver.py) reads this and calls
+// Piomatter.show(), keeping the proven driver while ProtoHUD owns the rendering.
+
+#include <cstdint>
+#include <string>
+
+#include "panel_output.h"
+
+namespace face {
+
+class ShmPusherOutput : public PanelOutput {
+public:
+    explicit ShmPusherOutput(int width = 128, int height = 32,
+                             std::string path = "/dev/shm/protoface_frame");
+    ~ShmPusherOutput() override;
+
+    bool open() override;
+    void show(const cv::Mat& rgb) override;
+    void close() override;
+
+private:
+    int         w_, h_;
+    std::string path_;
+    int         fd_   = -1;
+    uint8_t*    map_  = nullptr;
+    size_t      size_ = 0;
+    uint8_t     seq_  = 0;
+};
+
+} // namespace face


### PR DESCRIPTION
First step of folding Protoface into ProtoHUD so the LED face is rendered natively in C++ with one UI + config (see plan). This adds the renderer *core* as a self-contained static library; it is NOT yet wired into main.cpp.

New src/face/ (C++ ports of the Python pipeline, using OpenCV for image ops):
- face_state.{h,cpp}      port of protoface/state.py (crossfade, blink SM, boop)
- face_loader.{h,cpp}     port of face.py (PNG load, crossfade, blink/mouth
                          region blend, edge-clamped sub-pixel wiggle/gyro via
                          cv::warpAffine BORDER_REPLICATE)
- materials.{h,cpp}       port of material.py (solid / texture-scroll / zoned)
- renderer.{h,cpp}        port of renderer.py (apply_material, composite
                          normal/add, brightness, solid layer)
- native_face_controller.{h,cpp}  IFaceController backend: render thread,
                          per-panel state + mirror, latest-frame accessor for
                          the in-HUD preview, command mapping (color/face/
                          brightness/material preset). Particles, GIF, and the
                          C++ Piomatter output are stubbed/TODO (Phases 3+5).
- panel_output.h + shm_pusher_output.{h,cpp}  swappable LED sink; the shm
                          backend writes the existing 128x32 shm frame format.
- scripts/panel_driver.py  ~60-line shim that reads the shm canvas and pushes
                          to Piomatter (the safe driver path / "option 1").

Build: added a separate `protoface_native` STATIC target with EXCLUDE_FROM_ALL so it can NEVER break the default protohud build while the port is incomplete. Compile-check in isolation on the CM5 with:
    cmake --build build --target protoface_native

Not compiled here (no CM5/OpenCV toolchain on the dev box); next PRs port particles + GIF, wire NativeFaceController into main.cpp/menu/config, and add the vendored C++ Piomatter output.