### PR TITLE
Debug window (IMU + CPU/GPU) and on-board scheduler/reminders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,13 @@ overlays/*.dtbo
 # Runtime config — written by the app on exit with live settings.
 # config/config.example.json is the tracked defaults reference.
 config/config.json
+
+# Scheduler daemon — secrets and runtime artifacts (never commit OAuth creds).
+scheduler_daemon/client_secret.json
+scheduler_daemon/token.json
+scheduler_daemon/config.json
+scheduler_daemon/__pycache__/
+scheduler_daemon/*.events.json
+scheduler_daemon/events.json
+scheduler_daemon/scheduler_status.json
+scheduler_daemon/manual_events.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,6 +184,7 @@ set(SOURCES
     src/post_process.cpp
     src/sensor/mpu9250.cpp
     src/sys/system_monitor.cpp
+    src/sys/scheduler_monitor.cpp
     src/net/wifi_monitor.cpp
     src/net/ping_monitor.cpp
     src/net/bt_monitor.cpp
@@ -314,6 +315,12 @@ add_custom_command(TARGET protohud POST_BUILD
 
 install(TARGETS protohud RUNTIME DESTINATION bin)
 install(FILES config/config.example.json DESTINATION etc/protohud RENAME config.json)
+# Companion scheduler daemon (Python; owns the web form + Google Calendar sync).
+# Exclude any real OAuth secrets/tokens so they never get packaged.
+install(DIRECTORY scheduler_daemon DESTINATION share/protohud
+        PATTERN "token.json"          EXCLUDE
+        PATTERN "client_secret*.json" EXCLUDE
+        PATTERN "__pycache__"         EXCLUDE)
 install(FILES "${VITURE_LIB_DIR}/libglasses.so"
               "${VITURE_LIB_DIR}/libcarina_vio.so"
         DESTINATION lib)

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -168,6 +168,17 @@
       "_view_values": "0 = whole face | 1 = left half | 2 = right half"
     }
   },
+  "scheduler": {
+    "_about": "On-board scheduler/reminders. Networking (phone web form + Google Calendar) lives in the scheduler_daemon Python companion, which writes events.json + scheduler_status.json. ProtoHUD reads those by file poll and fires reminders via the toast system. The daemon reads this same block for its web_port / paths / all_day_reminder_hour.",
+    "enabled": true,
+    "autostart": false,
+    "events_path": "/home/user/.local/share/protohud-scheduler/events.json",
+    "status_path": "/home/user/.local/share/protohud-scheduler/scheduler_status.json",
+    "poll_interval_s": 20,
+    "lead_minutes": 10,
+    "all_day_reminder_hour": 8,
+    "web_port": 8770
+  },
   "audio": {
     "_note": "Audio capture is handled by the RP2350 helmet audio processor (USB Audio UAC2). The CM5 receives pre-processed stereo and routes it to the chosen output. Run 'arecord -l' to verify the RP2350 card name after connecting via USB.",
     "enabled": true,

--- a/scheduler_daemon/README.md
+++ b/scheduler_daemon/README.md
@@ -1,0 +1,60 @@
+# ProtoHUD Scheduler Daemon
+
+Companion service that feeds the on-glasses scheduler/reminder system. It owns all
+networking so the real-time C++ HUD never does HTTP or OAuth.
+
+```
+phone browser ──► web form (this daemon) ─┐
+                                          ├─► events.json ──► ProtoHUD (file poll) ──► toast reminders
+Google Calendar ──► (later) sync ─────────┘    scheduler_status.json
+```
+
+## What it does today
+
+- Serves a phone-friendly **web form** on `http://<device-ip>:<web_port>` (default
+  `8770`) to add/delete calendar events (title, date, start/end or all-day, location).
+- Merges all sources and **atomically** writes:
+  - `events.json` — the merged event list the HUD reads.
+  - `scheduler_status.json` — web URL, Google auth state, event count (the HUD shows
+    these in the Scheduler menu).
+- A heartbeat rewrites those files periodically so the HUD can tell the daemon is alive.
+
+Google Calendar sync is stubbed (`load_google_events()` / `google_state()` return
+empty/"disconnected") and lands in a later pass; `requests` will be added then.
+
+## Run it
+
+```bash
+cd scheduler_daemon
+python3 run.py
+```
+
+No dependencies (Python 3 standard library only). Config is read from the shared
+ProtoHUD `config.json` `"scheduler"` block if found (searched: `$SCHEDULER_CONFIG`,
+`./config.json`, `../config/config.json`, `/home/user/ProtoHUD/config/config.json`,
+`/etc/protohud/config.json`); otherwise built-in defaults are used.
+
+ProtoHUD can auto-launch it on boot when `scheduler.autostart` is `true` in config
+(mirrors the Protoface daemon). Otherwise start it manually or via systemd.
+
+## Files & data
+
+- Output (HUD-facing): `events.json`, `scheduler_status.json` — paths from config,
+  default `~/.local/share/protohud-scheduler/`.
+- Private store: `manual_events.json` in the same data dir.
+
+## Security
+
+No authentication — intended for a personal device on a trusted LAN, same model as the
+rest of ProtoHUD. User-entered text is HTML-escaped before display. Do not expose the
+port to the public internet.
+
+## Google sync setup (for the later pass)
+
+1. In Google Cloud Console create an OAuth client of type **TV and Limited Input
+   devices**.
+2. Copy `client_secret.example.json` → `client_secret.json` and fill in your client id/
+   secret. **Never commit** `client_secret.json` or `token.json` (both gitignored).
+3. The daemon will run the device flow: the glasses show a short URL + code, you
+   authorize on your phone, and the refresh token is stored at
+   `~/.config/protohud-scheduler/token.json`.

--- a/scheduler_daemon/client_secret.example.json
+++ b/scheduler_daemon/client_secret.example.json
@@ -1,0 +1,11 @@
+{
+  "_about": "Template for Google Calendar sync (a later pass). Create an OAuth client of type 'TV and Limited Input devices' in Google Cloud Console, then copy this file to client_secret.json and fill in the values. client_secret.json and token.json are gitignored and must never be committed.",
+  "installed": {
+    "client_id": "YOUR_CLIENT_ID.apps.googleusercontent.com",
+    "client_secret": "YOUR_CLIENT_SECRET",
+    "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+    "token_uri": "https://oauth2.googleapis.com/token",
+    "device_auth_uri": "https://oauth2.googleapis.com/device/code",
+    "scopes": ["https://www.googleapis.com/auth/calendar.readonly"]
+  }
+}

--- a/scheduler_daemon/requirements.txt
+++ b/scheduler_daemon/requirements.txt
@@ -1,0 +1,6 @@
+# The web-form daemon uses only the Python 3 standard library — nothing to install.
+#
+# Google Calendar sync (a later pass) will add:
+#   requests>=2.31
+# (OAuth 2.0 device flow + Calendar v3 REST are simple enough to drive with requests;
+#  swap in google-api-python-client if you prefer the official client.)

--- a/scheduler_daemon/run.py
+++ b/scheduler_daemon/run.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""ProtoHUD scheduler companion daemon.
+
+Owns all scheduler networking so the C++ HUD never does HTTP/OAuth:
+  * Serves a phone-friendly web form for manual calendar events.
+  * (Future) syncs Google Calendar via OAuth device flow — see load_google_events().
+
+It merges every source and atomically writes two files that the HUD's
+SchedulerMonitor polls:
+  * events.json          — {"version":1,"generated_utc":N,"events":[...]}
+  * scheduler_status.json — {"web_url","gcal_state","event_count",...}
+
+Event JSON shape (epoch UTC; the daemon does all timezone math):
+  {"uid","title","location","start_utc","end_utc","all_day",
+   "source":"manual"|"google"}
+
+No external dependencies — Python 3 standard library only (Google support will
+add libs to requirements.txt later). Runs on the same LAN as the phone; there is
+no auth, matching a personal-device threat model. User text is HTML-escaped when
+rendered to avoid stored XSS.
+"""
+
+import html
+import json
+import os
+import socket
+import sys
+import threading
+import time
+import uuid
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import parse_qs, urlparse
+
+# ── Config resolution ──────────────────────────────────────────────────────────
+
+DEFAULTS = {
+    "web_port": 8770,
+    "events_path": os.path.expanduser(
+        "~/.local/share/protohud-scheduler/events.json"),
+    "status_path": os.path.expanduser(
+        "~/.local/share/protohud-scheduler/scheduler_status.json"),
+    "all_day_reminder_hour": 8,
+    "heartbeat_s": 60,
+}
+
+
+def find_config():
+    candidates = [
+        os.environ.get("SCHEDULER_CONFIG"),
+        os.path.join(os.path.dirname(__file__), "config.json"),
+        os.path.join(os.path.dirname(__file__), "..", "config", "config.json"),
+        "/home/user/ProtoHUD/config/config.json",
+        "/etc/protohud/config.json",
+    ]
+    for p in candidates:
+        if p and os.path.isfile(p):
+            return p
+    return None
+
+
+def load_config():
+    cfg = dict(DEFAULTS)
+    path = find_config()
+    if path:
+        try:
+            with open(path) as f:
+                block = json.load(f).get("scheduler", {})
+            for k in DEFAULTS:
+                if k in block:
+                    cfg[k] = block[k]
+            print(f"[scheduler] config from {path}")
+        except Exception as e:  # noqa: BLE001 — best-effort; fall back to defaults
+            print(f"[scheduler] config read failed ({e}); using defaults")
+    else:
+        print("[scheduler] no config found; using defaults")
+    return cfg
+
+
+# ── Atomic JSON I/O ─────────────────────────────────────────────────────────────
+
+def atomic_write_json(path, obj):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    tmp = path + ".tmp"
+    with open(tmp, "w") as f:
+        json.dump(obj, f, indent=2)
+        f.flush()
+        os.fsync(f.fileno())
+    os.replace(tmp, path)  # POSIX-atomic; HUD sees whole-old or whole-new file
+
+
+def read_json(path, default):
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except Exception:  # noqa: BLE001 — missing/corrupt → default
+        return default
+
+
+def detect_ip():
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        s.connect(("8.8.8.8", 80))   # no packets sent; just picks the egress iface
+        return s.getsockname()[0]
+    except Exception:  # noqa: BLE001
+        return "127.0.0.1"
+    finally:
+        s.close()
+
+
+# ── Scheduler store ──────────────────────────────────────────────────────────────
+
+class Store:
+    """Owns manual events and publishes the merged events.json + status."""
+
+    def __init__(self, cfg):
+        self.cfg = cfg
+        self.lock = threading.Lock()
+        data_dir = os.path.dirname(cfg["events_path"])
+        os.makedirs(data_dir, exist_ok=True)
+        self.manual_path = os.path.join(data_dir, "manual_events.json")
+        self.manual = read_json(self.manual_path, {"events": []}).get("events", [])
+
+    # --- manual event mutations (call under self.lock via public methods) ---
+    def add_manual(self, ev):
+        with self.lock:
+            self.manual.append(ev)
+            self._save_manual()
+        self.publish()
+
+    def delete_manual(self, uid):
+        with self.lock:
+            self.manual = [e for e in self.manual if e.get("uid") != uid]
+            self._save_manual()
+        self.publish()
+
+    def list_events(self):
+        with self.lock:
+            return sorted(self._merged(), key=lambda e: e["start_utc"])
+
+    def _save_manual(self):
+        atomic_write_json(self.manual_path, {"events": self.manual})
+
+    def _merged(self):
+        # Manual + Google (Google returns [] until that pass lands).
+        return list(self.manual) + load_google_events(self.cfg)
+
+    # --- publish to the HUD-facing files ---
+    def publish(self):
+        with self.lock:
+            events = sorted(self._merged(), key=lambda e: e["start_utc"])
+        atomic_write_json(self.cfg["events_path"],
+                          {"version": 1,
+                           "generated_utc": int(time.time()),
+                           "events": events})
+        atomic_write_json(self.cfg["status_path"], {
+            "web_url": f"http://{detect_ip()}:{self.cfg['web_port']}",
+            "gcal_state": google_state(self.cfg),
+            "gcal_user_code": "",
+            "gcal_verify_url": "",
+            "last_sync_utc": int(time.time()),
+            "event_count": len(events),
+        })
+
+
+# ── Google Calendar seam (implemented in a later pass) ───────────────────────────
+
+def google_state(cfg):
+    return "disconnected"
+
+
+def load_google_events(cfg):
+    return []
+
+
+# ── Time helpers ─────────────────────────────────────────────────────────────────
+
+def local_to_epoch(date_str, time_str):
+    """'YYYY-MM-DD' + 'HH:MM' (local time) → epoch UTC, or None."""
+    try:
+        tm = time.strptime(f"{date_str} {time_str}", "%Y-%m-%d %H:%M")
+        return int(time.mktime(tm))  # mktime interprets the tuple as local time
+    except (ValueError, TypeError):
+        return None
+
+
+def make_event_from_form(form, all_day_hour):
+    title = (form.get("title", [""])[0] or "").strip() or "(untitled)"
+    location = (form.get("location", [""])[0] or "").strip()
+    date = form.get("date", [""])[0]
+    all_day = form.get("all_day", [""])[0] in ("on", "1", "true")
+
+    if all_day:
+        start = local_to_epoch(date, f"{int(all_day_hour):02d}:00")
+        end = local_to_epoch(date, "23:59")
+    else:
+        start = local_to_epoch(date, form.get("start_time", [""])[0])
+        end = local_to_epoch(date, form.get("end_time", [""])[0]) or start
+    if start is None:
+        return None
+    return {
+        "uid": uuid.uuid4().hex,
+        "title": title,
+        "location": location,
+        "start_utc": start,
+        "end_utc": end or start,
+        "all_day": all_day,
+        "source": "manual",
+    }
+
+
+# ── Web UI ───────────────────────────────────────────────────────────────────────
+
+PAGE = """<!doctype html><html><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>ProtoHUD Scheduler</title><style>
+body{{font-family:system-ui,sans-serif;margin:0;background:#0b0f14;color:#e6f0ee}}
+.wrap{{max-width:520px;margin:0 auto;padding:16px}}
+h1{{font-size:1.3rem;color:#00dcb4}} h2{{font-size:1rem;color:#9bb;margin-top:24px}}
+label{{display:block;margin:10px 0 4px;font-size:.85rem;color:#9bb}}
+input[type=text],input[type=date],input[type=time]{{width:100%;padding:12px;
+ font-size:1rem;border:1px solid #244;border-radius:8px;background:#101820;color:#e6f0ee}}
+.row{{display:flex;gap:10px}} .row>div{{flex:1}}
+.chk{{display:flex;align-items:center;gap:8px;margin:12px 0}}
+button{{margin-top:16px;width:100%;padding:14px;font-size:1rem;border:0;border-radius:8px;
+ background:#00b894;color:#012;font-weight:600}}
+ul{{list-style:none;padding:0}} li{{background:#101820;border:1px solid #1d2a30;
+ border-radius:8px;padding:10px 12px;margin:8px 0;display:flex;justify-content:space-between;align-items:center}}
+.when{{color:#00dcb4;font-size:.8rem}} .del{{width:auto;margin:0;padding:8px 12px;background:#933;color:#fee}}
+</style></head><body><div class="wrap">
+<h1>ProtoHUD Scheduler</h1>
+<form method="POST" action="/add">
+<label>Title</label><input type="text" name="title" required>
+<label>Location</label><input type="text" name="location">
+<label>Date</label><input type="date" name="date" required>
+<div class="chk"><input type="checkbox" name="all_day" id="ad"><label for="ad" style="margin:0">All day</label></div>
+<div class="row"><div><label>Start</label><input type="time" name="start_time"></div>
+<div><label>End</label><input type="time" name="end_time"></div></div>
+<button type="submit">Add event</button>
+</form>
+<h2>Upcoming</h2><ul>{rows}</ul>
+</div></body></html>"""
+
+
+def render_rows(events):
+    now = int(time.time())
+    rows = []
+    for e in events:
+        if e["end_utc"] and e["end_utc"] < now:
+            continue
+        tm = time.localtime(e["start_utc"])
+        when = (time.strftime("%a %b %d (all day)", tm) if e["all_day"]
+                else time.strftime("%a %b %d %H:%M", tm))
+        title = html.escape(e["title"])
+        loc = (" · " + html.escape(e["location"])) if e["location"] else ""
+        src = "" if e["source"] == "manual" else " [gcal]"
+        delete = "" if e["source"] != "manual" else (
+            f'<form method="POST" action="/delete">'
+            f'<input type="hidden" name="uid" value="{html.escape(e["uid"])}">'
+            f'<button class="del" type="submit">x</button></form>')
+        rows.append(f'<li><div><div class="when">{when}{src}</div>'
+                    f'{title}{loc}</div>{delete}</li>')
+    return "".join(rows) or '<li><div>(no upcoming events)</div></li>'
+
+
+def make_handler(store):
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, *_):  # quieter logs
+            pass
+
+        def _send(self, code, body, ctype="text/html; charset=utf-8"):
+            data = body.encode("utf-8")
+            self.send_response(code)
+            self.send_header("Content-Type", ctype)
+            self.send_header("Content-Length", str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+
+        def _redirect(self):
+            self.send_response(303)
+            self.send_header("Location", "/")
+            self.end_headers()
+
+        def do_GET(self):
+            if urlparse(self.path).path != "/":
+                self._send(404, "not found")
+                return
+            self._send(200, PAGE.format(rows=render_rows(store.list_events())))
+
+        def do_POST(self):
+            length = int(self.headers.get("Content-Length", 0))
+            form = parse_qs(self.rfile.read(length).decode("utf-8"))
+            path = urlparse(self.path).path
+            if path == "/add":
+                ev = make_event_from_form(form, store.cfg["all_day_reminder_hour"])
+                if ev:
+                    store.add_manual(ev)
+                self._redirect()
+            elif path == "/delete":
+                uid = form.get("uid", [""])[0]
+                if uid:
+                    store.delete_manual(uid)
+                self._redirect()
+            else:
+                self._send(404, "not found")
+
+    return Handler
+
+
+# ── Heartbeat: keep events.json mtime fresh so the HUD sees the daemon as online ──
+
+def heartbeat(store, period_s):
+    while True:
+        time.sleep(period_s)
+        try:
+            store.publish()
+        except Exception as e:  # noqa: BLE001
+            print(f"[scheduler] heartbeat publish failed: {e}")
+
+
+def main():
+    cfg = load_config()
+    store = Store(cfg)
+    store.publish()  # write initial events.json + status
+
+    threading.Thread(target=heartbeat,
+                     args=(store, int(cfg["heartbeat_s"])),
+                     daemon=True).start()
+
+    httpd = ThreadingHTTPServer(("0.0.0.0", int(cfg["web_port"])),
+                                make_handler(store))
+    url = f"http://{detect_ip()}:{cfg['web_port']}"
+    print(f"[scheduler] web form at {url}")
+    print(f"[scheduler] events -> {cfg['events_path']}")
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        print("\n[scheduler] shutting down")
+        httpd.shutdown()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/app_state.h
+++ b/src/app_state.h
@@ -273,6 +273,39 @@ struct TimerAlarmState {
     int    custom_timer_sec = 0;      // custom timer seconds (0–59)
 };
 
+// ── Scheduler / reminders ───────────────────────────────────────────────────────
+// Full calendar events fed from a Python companion daemon (scheduler_daemon/) that
+// owns all networking: it serves a phone web form and (later) syncs Google Calendar,
+// merges both, and writes events.json + scheduler_status.json atomically. ProtoHUD
+// reads those files via SchedulerMonitor (file poll) and fires reminders through the
+// existing NotificationQueue. The C++ side never does HTTP/OAuth.
+enum class EventSource : uint8_t { Manual = 0, Google = 1 };
+
+struct ScheduledEvent {
+    std::string uid;                  // stable dedupe key (gcal id, or daemon UUID)
+    std::string title;
+    std::string location;
+    time_t      start_utc = 0;        // epoch UTC; 0 = invalid. Daemon does all tz math.
+    time_t      end_utc   = 0;
+    bool        all_day   = false;
+    EventSource source    = EventSource::Manual;
+    // Render-thread-only fire bookkeeping — NOT serialized; carried across reloads
+    // by SchedulerMonitor's uid merge (reset only when start_utc changes).
+    bool        fired_lead  = false;  // lead-time reminder already raised
+    bool        fired_start = false;  // at-start reminder already raised
+    time_t      snooze_until = 0;     // if >0, re-raise the lead reminder at this time
+};
+
+struct SchedulerStatus {
+    bool        daemon_ok      = false;  // files parsed and fresh (mtime recent)
+    std::string web_url;                 // e.g. "http://192.168.1.42:8770"
+    std::string gcal_state     = "disconnected"; // disconnected|pending|connected|error
+    std::string gcal_user_code;          // device-flow code to type on phone
+    std::string gcal_verify_url;         // device-flow verification URL
+    time_t      last_sync_utc  = 0;
+    int         event_count    = 0;
+};
+
 // ── System metrics ────────────────────────────────────────────────────────────
 static constexpr int kSysHistLen  = 60;
 static constexpr int kPingHistLen = 30;
@@ -483,6 +516,13 @@ struct AppState {
 
     // Timer / alarm state (managed on render thread; no mutex needed for reads)
     TimerAlarmState      timer_alarm;
+
+    // Scheduler / reminders. scheduler_events + scheduler_status are written by the
+    // SchedulerMonitor thread under mtx and read on the render thread; lead_min is
+    // render-thread-only (menu slider + fire loop).
+    std::vector<ScheduledEvent> scheduler_events;   // sorted by start_utc
+    SchedulerStatus             scheduler_status;
+    int                         scheduler_lead_min = 10;  // reminder lead time (minutes)
 
     // Notification queue — render-thread owned; push from main thread while holding mtx
     NotificationQueue    notifs;

--- a/src/app_state.h
+++ b/src/app_state.h
@@ -204,6 +204,30 @@ struct ImuPose {
     float yaw   = 0.0f;
 };
 
+// ── Full IMU debug readout ─────────────────────────────────────────────────────
+// Aggregates every value delivered by the two IMUs so the debug window can show
+// live readings for fault-finding:
+//   • VITURE XR glasses — fused Euler pose (roll/pitch/yaw), ~1 kHz.
+//   • MPU-9250          — raw accel (g), gyro (deg/s), mag (µT), die temp, heading.
+// Written by the IMU callbacks under AppState::mtx; read on the render thread.
+struct ImuData {
+    // VITURE XR glasses fused pose (degrees)
+    bool  xr_active  = false;   // IMU frames arrived within the freshness window
+    float xr_roll    = 0.f;
+    float xr_pitch   = 0.f;
+    float xr_yaw     = 0.f;
+    float xr_rate_hz = 0.f;     // measured callback rate (EMA)
+
+    // MPU-9250 raw 9-axis readout
+    bool  mpu_ok      = false;
+    float accel_g[3]  = {0.f, 0.f, 0.f};   // x, y, z (g)
+    float gyro_dps[3] = {0.f, 0.f, 0.f};   // x, y, z (deg/s)
+    float mag_ut[3]   = {0.f, 0.f, 0.f};   // x, y, z (µT, bias-corrected)
+    float temp_c      = 0.f;               // MPU die temperature
+    float mpu_heading = 0.f;               // fused compass heading (deg)
+    float mpu_rate_hz = 0.f;               // measured sample rate (EMA)
+};
+
 // ── Map overlay ───────────────────────────────────────────────────────────────
 
 struct MapOverlayConfig {
@@ -252,6 +276,7 @@ struct TimerAlarmState {
 // ── System metrics ────────────────────────────────────────────────────────────
 static constexpr int kSysHistLen  = 60;
 static constexpr int kPingHistLen = 30;
+static constexpr int kMaxCpuCores = 16;
 
 struct SysMetrics {
     uint64_t uptime_s     = 0;
@@ -261,12 +286,34 @@ struct SysMetrics {
     float    cpu_history [kSysHistLen]  = {};
     float    ram_history [kSysHistLen]  = {};
     int      history_head = 0;        // shared head for cpu/ram (updated by SystemMonitor)
+    // Per-core CPU breakdown (filled by SystemMonitor)
+    int      cpu_core_count = 0;
+    float    cpu_core_pct[kMaxCpuCores] = {};   // 0–100 per logical core
+    float    cpu_core_mhz[kMaxCpuCores] = {};   // current freq; 0 if unavailable
+    float    cpu_temp_c     = 0.f;              // package temperature (0 if unknown)
     // Frame-time metrics — updated by render thread each frame
     float    frame_time_ms  = 0.f;    // last frame duration in ms
     float    fps_avg        = 0.f;    // 1000 / frame_time_ms (instantaneous)
     float    fps_avg_smooth = 0.f;    // EMA-smoothed FPS over fps_avg_interval_s
     float    ft_history[kSysHistLen]  = {};
     int      ft_history_head = 0;
+};
+
+// ── GPU metrics ─────────────────────────────────────────────────────────────────
+// VideoCore (Raspberry Pi) per-domain clock breakdown + temperature, polled via
+// vcgencmd by SystemMonitor. The clock domains are the GPU's functional cores.
+static constexpr int kMaxGpuClocks = 6;
+
+struct GpuClock {
+    char  name[6] = {};   // "core","v3d","isp","h264","hevc"
+    float mhz     = 0.f;
+};
+
+struct GpuMetrics {
+    bool     available   = false;   // vcgencmd produced usable data
+    float    temp_c      = 0.f;
+    int      clock_count = 0;
+    GpuClock clocks[kMaxGpuClocks] = {};
 };
 
 struct SerialMetrics {
@@ -460,6 +507,8 @@ struct AppState {
 
     // System monitor / network / Bluetooth state
     SysMetrics             sys_metrics;
+    GpuMetrics             gpu;
+    ImuData                imu_data;
     WifiState              wifi;
     PingState              ping;
     SshState               ssh;

--- a/src/hud/hud_renderer.cpp
+++ b/src/hud/hud_renderer.cpp
@@ -2138,13 +2138,17 @@ void HudRenderer::draw_sys_panel(const AppState& snap, int w, int h, bool active
         ImGuiWindowFlags_NoSavedSettings);
     ImDrawList* dl = ImGui::GetWindowDrawList();
 
-    // Panel geometry — top-left, fixed size
-    constexpr float PW    = 340.f;
-    constexpr float PH    = 750.f;
+    // Panel geometry — top-left, two columns. The debug readout outgrew a single
+    // column once IMU + per-core CPU/GPU sections were added, so content flows
+    // into a second column when the first fills up.
+    constexpr float COLW  = 330.f;            // per-column content width
+    constexpr float GAP   = 12.f;             // gap between columns
+    constexpr float PW     = COLW * 2.f + GAP; // total panel width
     constexpr float PAD   = 10.f;
-    constexpr float MRG   = 14.f;   // left margin from screen edge
+    constexpr float MRG   = 14.f;             // left/top margin from screen edge
     const float px = MRG;
     const float py = MRG;
+    const float PH = std::min(sh - MRG * 2.f, 1040.f);
 
     // Background + border
     dl->AddRectFilled({px, py}, {px + PW, py + PH}, col_.panel_bg, 6.f);
@@ -2153,13 +2157,23 @@ void HudRenderer::draw_sys_panel(const AppState& snap, int w, int h, bool active
     if (font_mono_) ImGui::PushFont(font_mono_);
     const float lh = ImGui::GetTextLineHeight();
 
-    float cy = py + PAD;   // current y cursor
+    float cx = px;          // current column origin x
+    float cy = py + PAD;    // current y cursor
+
+    // Wrap into the second column once the first can't fit `need` more pixels.
+    auto wrap_col = [&](float need) {
+        if (cx <= px + 0.5f && cy + need > py + PH - PAD) {
+            cx = px + COLW + GAP;
+            cy = py + PAD;
+        }
+    };
 
     // Helper: draw a section header + separator
     auto section = [&](const char* title) {
-        hud_glow_text(dl, {px + PAD, cy}, title, true, col_.primary, col_.primary);
+        wrap_col(60.f);
+        hud_glow_text(dl, {cx + PAD, cy}, title, true, col_.primary, col_.primary);
         cy += lh + 2.f;
-        dl->AddLine({px + PAD, cy}, {px + PW - PAD, cy}, with_alpha(col_.primary, 80), 1.f);
+        dl->AddLine({cx + PAD, cy}, {cx + COLW - PAD, cy}, with_alpha(col_.primary, 80), 1.f);
         cy += 5.f;
     };
 
@@ -2194,7 +2208,7 @@ void HudRenderer::draw_sys_panel(const AppState& snap, int w, int h, bool active
         const uint32_t mm = static_cast<uint32_t>((s % 3600) / 60);
         char buf[48];
         snprintf(buf, sizeof(buf), "Up: %ud %02uh %02um", d, hh, mm);
-        hud_glow_text(dl, {px + PAD, cy}, buf, false, col_.glow_base, col_.text_fill);
+        hud_glow_text(dl, {cx + PAD, cy}, buf, false, col_.glow_base, col_.text_fill);
         cy += lh + 4.f;
     }
 
@@ -2202,10 +2216,10 @@ void HudRenderer::draw_sys_panel(const AppState& snap, int w, int h, bool active
     {
         char buf[32];
         snprintf(buf, sizeof(buf), "CPU  %3.0f%%", static_cast<double>(snap.sys_metrics.cpu_pct));
-        hud_glow_text(dl, {px + PAD, cy}, buf, false, col_.glow_base, col_.text_fill);
-        const float spw = PW - PAD * 2.f - 80.f;
+        hud_glow_text(dl, {cx + PAD, cy}, buf, false, col_.glow_base, col_.text_fill);
+        const float spw = COLW - PAD * 2.f - 80.f;
         sparkline(snap.sys_metrics.cpu_history, kSysHistLen, snap.sys_metrics.history_head,
-                  {px + PAD + 78.f, cy}, spw, lh,
+                  {cx + PAD + 78.f, cy}, spw, lh,
                   100.f, col_.accent);
         cy += lh + 6.f;
     }
@@ -2217,12 +2231,146 @@ void HudRenderer::draw_sys_panel(const AppState& snap, int w, int h, bool active
         char buf[40];
         snprintf(buf, sizeof(buf), "RAM  %.0f/%.0f", static_cast<double>(used),
                                                       static_cast<double>(total));
-        hud_glow_text(dl, {px + PAD, cy}, buf, false, col_.glow_base, col_.text_fill);
-        const float spw = PW - PAD * 2.f - 80.f;
+        hud_glow_text(dl, {cx + PAD, cy}, buf, false, col_.glow_base, col_.text_fill);
+        const float spw = COLW - PAD * 2.f - 80.f;
         sparkline(snap.sys_metrics.ram_history, kSysHistLen, snap.sys_metrics.history_head,
-                  {px + PAD + 78.f, cy}, spw, lh,
+                  {cx + PAD + 78.f, cy}, spw, lh,
                   total > 0.f ? total : 4096.f, col_.warn);
         cy += lh + 8.f;
+    }
+
+    // ── CPU CORES ───────────────────────────────────────────────────────────────
+    // Per-logical-core utilisation bar + current frequency.
+    section("CPU CORES");
+    {
+        const auto& m   = snap.sys_metrics;
+        const int   n   = std::clamp(m.cpu_core_count, 0, kMaxCpuCores);
+        if (m.cpu_temp_c > 0.f) {
+            char tb[32];
+            snprintf(tb, sizeof(tb), "Temp  %.1f C", static_cast<double>(m.cpu_temp_c));
+            const bool hot = m.cpu_temp_c >= 75.f;
+            hud_glow_text(dl, {cx + PAD, cy}, tb, hot,
+                          col_.glow_base, hot ? col_.warn : col_.text_fill);
+            cy += lh + 4.f;
+        }
+        const float bx = cx + PAD + 44.f;
+        const float bw = COLW - PAD * 2.f - 44.f - 56.f;  // room for label + MHz
+        for (int i = 0; i < n; ++i) {
+            char cb[16];
+            snprintf(cb, sizeof(cb), "C%-2d", i);
+            hud_glow_text(dl, {cx + PAD, cy}, cb, false, col_.glow_base, col_.text_fill);
+            const float frac = std::clamp(m.cpu_core_pct[i] / 100.f, 0.f, 1.f);
+            const ImU32 barc = (frac > 0.85f) ? col_.warn : col_.accent;
+            dl->AddRect      ({bx, cy + 2.f}, {bx + bw, cy + lh - 2.f},
+                              with_alpha(col_.accent, 60));
+            dl->AddRectFilled({bx, cy + 2.f}, {bx + bw * frac, cy + lh - 2.f}, barc);
+            char vb[24];
+            if (m.cpu_core_mhz[i] > 0.f)
+                snprintf(vb, sizeof(vb), "%3.0f%% %4.0f", static_cast<double>(m.cpu_core_pct[i]),
+                         static_cast<double>(m.cpu_core_mhz[i]));
+            else
+                snprintf(vb, sizeof(vb), "%3.0f%%", static_cast<double>(m.cpu_core_pct[i]));
+            hud_glow_text(dl, {bx + bw + 6.f, cy}, vb, false, col_.glow_base, col_.text_dim);
+            cy += lh + 3.f;
+        }
+        if (n == 0) {
+            hud_glow_text(dl, {cx + PAD, cy}, "--", false, col_.glow_base, col_.text_dim);
+            cy += lh + 4.f;
+        }
+        cy += 4.f;
+    }
+
+    // ── GPU ───────────────────────────────────────────────────────────────────
+    // VideoCore per-domain clock breakdown + temperature (via vcgencmd).
+    section("GPU");
+    {
+        const auto& g = snap.gpu;
+        if (!g.available) {
+            hud_glow_text(dl, {cx + PAD, cy}, "unavailable", false,
+                          col_.glow_base, col_.text_dim);
+            cy += lh + 4.f;
+        } else {
+            char gb[40];
+            if (g.temp_c > 0.f) {
+                const bool hot = g.temp_c >= 75.f;
+                snprintf(gb, sizeof(gb), "Temp  %.1f C", static_cast<double>(g.temp_c));
+                hud_glow_text(dl, {cx + PAD, cy}, gb, hot,
+                              col_.glow_base, hot ? col_.warn : col_.text_fill);
+                cy += lh + 4.f;
+            }
+            const int n = std::clamp(g.clock_count, 0, kMaxGpuClocks);
+            for (int i = 0; i < n; ++i) {
+                snprintf(gb, sizeof(gb), "  %-5s %4.0f MHz",
+                         g.clocks[i].name, static_cast<double>(g.clocks[i].mhz));
+                hud_glow_text(dl, {cx + PAD, cy}, gb, false, col_.glow_base, col_.text_fill);
+                cy += lh + 2.f;
+            }
+            cy += 4.f;
+        }
+    }
+
+    // ── IMU ───────────────────────────────────────────────────────────────────
+    // Every value delivered by both IMUs, for fault-finding.
+    section("IMU");
+    {
+        const auto& d = snap.imu_data;
+        char ib[56];
+
+        // VITURE XR glasses fused pose
+        dl->AddCircleFilled({cx + PAD + 5.f, cy + lh * 0.5f}, 4.f,
+                            d.xr_active ? col_.ind_good : col_.ind_inactive);
+        snprintf(ib, sizeof(ib), "  XR  %s", d.xr_active ? "live" : "no data");
+        hud_glow_text(dl, {cx + PAD + 4.f, cy}, ib, d.xr_active,
+                      col_.glow_base, col_.text_fill);
+        if (d.xr_active && d.xr_rate_hz > 0.f) {
+            char rb[16];
+            snprintf(rb, sizeof(rb), "%.0f Hz", static_cast<double>(d.xr_rate_hz));
+            hud_glow_text(dl, {cx + COLW - PAD - 52.f, cy}, rb, false,
+                          col_.glow_base, col_.text_dim);
+        }
+        cy += lh + 2.f;
+        snprintf(ib, sizeof(ib), " R%6.1f P%6.1f Y%6.1f",
+                 static_cast<double>(d.xr_roll), static_cast<double>(d.xr_pitch),
+                 static_cast<double>(d.xr_yaw));
+        hud_glow_text(dl, {cx + PAD, cy}, ib, false, col_.glow_base,
+                      d.xr_active ? col_.text_fill : col_.text_dim);
+        cy += lh + 6.f;
+
+        // MPU-9250 raw 9-axis
+        dl->AddCircleFilled({cx + PAD + 5.f, cy + lh * 0.5f}, 4.f,
+                            d.mpu_ok ? col_.ind_good : col_.ind_fail);
+        snprintf(ib, sizeof(ib), "  MPU-9250  %s", d.mpu_ok ? "ok" : "no data");
+        hud_glow_text(dl, {cx + PAD + 4.f, cy}, ib, d.mpu_ok,
+                      col_.glow_base, col_.text_fill);
+        if (d.mpu_ok && d.mpu_rate_hz > 0.f) {
+            char rb[16];
+            snprintf(rb, sizeof(rb), "%.0f Hz", static_cast<double>(d.mpu_rate_hz));
+            hud_glow_text(dl, {cx + COLW - PAD - 52.f, cy}, rb, false,
+                          col_.glow_base, col_.text_dim);
+        }
+        cy += lh + 2.f;
+        if (d.mpu_ok) {
+            snprintf(ib, sizeof(ib), " Acc %6.2f %6.2f %6.2f g",
+                     static_cast<double>(d.accel_g[0]), static_cast<double>(d.accel_g[1]),
+                     static_cast<double>(d.accel_g[2]));
+            hud_glow_text(dl, {cx + PAD, cy}, ib, false, col_.glow_base, col_.text_fill);
+            cy += lh + 2.f;
+            snprintf(ib, sizeof(ib), " Gyr %6.0f %6.0f %6.0f d/s",
+                     static_cast<double>(d.gyro_dps[0]), static_cast<double>(d.gyro_dps[1]),
+                     static_cast<double>(d.gyro_dps[2]));
+            hud_glow_text(dl, {cx + PAD, cy}, ib, false, col_.glow_base, col_.text_fill);
+            cy += lh + 2.f;
+            snprintf(ib, sizeof(ib), " Mag %6.0f %6.0f %6.0f uT",
+                     static_cast<double>(d.mag_ut[0]), static_cast<double>(d.mag_ut[1]),
+                     static_cast<double>(d.mag_ut[2]));
+            hud_glow_text(dl, {cx + PAD, cy}, ib, false, col_.glow_base, col_.text_fill);
+            cy += lh + 2.f;
+            snprintf(ib, sizeof(ib), " Hdg %5.1f deg    %4.1f C",
+                     static_cast<double>(d.mpu_heading), static_cast<double>(d.temp_c));
+            hud_glow_text(dl, {cx + PAD, cy}, ib, false, col_.glow_base, col_.text_fill);
+            cy += lh + 2.f;
+        }
+        cy += 6.f;
     }
 
     // ── NETWORK ───────────────────────────────────────────────────────────────
@@ -2236,7 +2384,7 @@ void HudRenderer::draw_sys_panel(const AppState& snap, int w, int h, bool active
         } else {
             snprintf(buf, sizeof(buf), "WiFi: --");
         }
-        hud_glow_text(dl, {px + PAD, cy}, buf, snap.wifi.connected,
+        hud_glow_text(dl, {cx + PAD, cy}, buf, snap.wifi.connected,
                       col_.glow_base, col_.text_fill);
         cy += lh + 2.f;
 
@@ -2245,9 +2393,9 @@ void HudRenderer::draw_sys_panel(const AppState& snap, int w, int h, bool active
             const int dbm   = snap.wifi.signal_dbm;
             const int bars  = (dbm >= -50) ? 4 : (dbm >= -65) ? 3 : (dbm >= -75) ? 2 : 1;
             snprintf(buf, sizeof(buf), "  %s  %d dBm", snap.wifi.ip.c_str(), dbm);
-            hud_glow_text(dl, {px + PAD, cy}, buf, false, col_.glow_base, col_.text_fill);
+            hud_glow_text(dl, {cx + PAD, cy}, buf, false, col_.glow_base, col_.text_fill);
             // Draw signal bars (4 rectangles of increasing height)
-            const float bx = px + PW - PAD - 28.f;
+            const float bx = cx + COLW - PAD - 28.f;
             const float by = cy + lh;
             for (int i = 0; i < 4; ++i) {
                 const float bh2  = (i + 1) * 4.f;
@@ -2270,12 +2418,12 @@ void HudRenderer::draw_sys_panel(const AppState& snap, int w, int h, bool active
         } else {
             snprintf(buf, sizeof(buf), "Ping  --  %s", snap.ping.host.c_str());
         }
-        hud_glow_text(dl, {px + PAD, cy}, buf, snap.ping.reachable,
+        hud_glow_text(dl, {cx + PAD, cy}, buf, snap.ping.reachable,
                       col_.glow_base, col_.text_fill);
-        const float spw = PW - PAD * 2.f - 80.f;
+        const float spw = COLW - PAD * 2.f - 80.f;
         // Scale: 500 ms max
         sparkline(snap.ping.history, kPingHistLen, snap.ping.history_head,
-                  {px + PAD + 78.f, cy}, spw, lh,
+                  {cx + PAD + 78.f, cy}, spw, lh,
                   500.f, snap.ping.reachable ? col_.primary : with_alpha(col_.primary, 80));
         cy += lh + 8.f;
     }
@@ -2284,7 +2432,7 @@ void HudRenderer::draw_sys_panel(const AppState& snap, int w, int h, bool active
     section("BLUETOOTH");
 
     if (snap.bt_devices.empty()) {
-        hud_glow_text(dl, {px + PAD, cy}, "No devices", false, col_.glow_base, col_.text_dim);
+        hud_glow_text(dl, {cx + PAD, cy}, "No devices", false, col_.glow_base, col_.text_dim);
         cy += lh + 4.f;
     } else {
         constexpr int MAX_BT = 4;
@@ -2292,10 +2440,10 @@ void HudRenderer::draw_sys_panel(const AppState& snap, int w, int h, bool active
         for (const auto& dev : snap.bt_devices) {
             if (shown >= MAX_BT) break;
             const ImU32 dot_col = dev.connected ? col_.ind_good : col_.ind_inactive;
-            dl->AddCircleFilled({px + PAD + 5.f, cy + lh * 0.5f}, 4.f, dot_col);
+            dl->AddCircleFilled({cx + PAD + 5.f, cy + lh * 0.5f}, 4.f, dot_col);
             char buf[64];
             snprintf(buf, sizeof(buf), "  %s", dev.name.c_str());
-            hud_glow_text(dl, {px + PAD + 4.f, cy}, buf, dev.connected,
+            hud_glow_text(dl, {cx + PAD + 4.f, cy}, buf, dev.connected,
                           col_.glow_base, col_.text_fill);
             cy += lh + 2.f;
             ++shown;
@@ -2317,25 +2465,25 @@ void HudRenderer::draw_sys_panel(const AppState& snap, int w, int h, bool active
             snprintf(buf, sizeof(buf), "FPS  %4.1f", static_cast<double>(fps_show));
         else
             snprintf(buf, sizeof(buf), "FPS  --");
-        hud_glow_text(dl, {px + PAD, cy}, buf, fps_show > 0.f, col_.glow_base, col_.text_fill);
-        const float spw = PW - PAD * 2.f - 80.f;
+        hud_glow_text(dl, {cx + PAD, cy}, buf, fps_show > 0.f, col_.glow_base, col_.text_fill);
+        const float spw = COLW - PAD * 2.f - 80.f;
         // Sparkline: frame time in ms, capped at 50ms (20 FPS floor)
         sparkline(snap.sys_metrics.ft_history, kSysHistLen, snap.sys_metrics.ft_history_head,
-                  {px + PAD + 78.f, cy}, spw, lh, 50.f, col_.primary);
+                  {cx + PAD + 78.f, cy}, spw, lh, 50.f, col_.primary);
         cy += lh + 4.f;
 
         if (fps_r > 0.f && fps_s > 0.f)
             snprintf(buf, sizeof(buf), "Inst  %4.1f", static_cast<double>(fps_r));
         else
             snprintf(buf, sizeof(buf), "Inst  --");
-        hud_glow_text(dl, {px + PAD, cy}, buf, false, col_.glow_base, col_.text_dim);
+        hud_glow_text(dl, {cx + PAD, cy}, buf, false, col_.glow_base, col_.text_dim);
         cy += lh + 2.f;
 
         if (ft > 0.f)
             snprintf(buf, sizeof(buf), "Frame  %.1fms", static_cast<double>(ft));
         else
             snprintf(buf, sizeof(buf), "Frame  --");
-        hud_glow_text(dl, {px + PAD, cy}, buf, false, col_.glow_base, col_.text_dim);
+        hud_glow_text(dl, {cx + PAD, cy}, buf, false, col_.glow_base, col_.text_dim);
         cy += lh + 8.f;
     }
 
@@ -2351,9 +2499,9 @@ void HudRenderer::draw_sys_panel(const AppState& snap, int w, int h, bool active
             snprintf(buf, sizeof(buf), "  Teensy   %.0fms", static_cast<double>(rtt));
         else
             snprintf(buf, sizeof(buf), "  Teensy   --");
-        dl->AddCircleFilled({px + PAD + 5.f, cy + lh * 0.5f}, 4.f,
+        dl->AddCircleFilled({cx + PAD + 5.f, cy + lh * 0.5f}, 4.f,
                             ok ? col_.ind_good : col_.ind_fail);
-        hud_glow_text(dl, {px + PAD + 4.f, cy}, buf, ok, col_.glow_base, col_.text_fill);
+        hud_glow_text(dl, {cx + PAD + 4.f, cy}, buf, ok, col_.glow_base, col_.text_fill);
         cy += lh + 4.f;
     }
 
@@ -2366,9 +2514,9 @@ void HudRenderer::draw_sys_panel(const AppState& snap, int w, int h, bool active
             snprintf(buf, sizeof(buf), "  Knob   <%.0fms ago", static_cast<double>(age));
         else
             snprintf(buf, sizeof(buf), "  Knob   --");
-        dl->AddCircleFilled({px + PAD + 5.f, cy + lh * 0.5f}, 4.f,
+        dl->AddCircleFilled({cx + PAD + 5.f, cy + lh * 0.5f}, 4.f,
                             ok ? col_.ind_good : col_.ind_inactive);
-        hud_glow_text(dl, {px + PAD + 4.f, cy}, buf, ok, col_.glow_base, col_.text_fill);
+        hud_glow_text(dl, {cx + PAD + 4.f, cy}, buf, ok, col_.glow_base, col_.text_fill);
         cy += lh + 4.f;
     }
 
@@ -2382,26 +2530,28 @@ void HudRenderer::draw_sys_panel(const AppState& snap, int w, int h, bool active
                      static_cast<double>(snap.serial_metrics.lora_snr));
         else
             snprintf(buf, sizeof(buf), "  LoRa   --");
-        dl->AddCircleFilled({px + PAD + 5.f, cy + lh * 0.5f}, 4.f,
+        dl->AddCircleFilled({cx + PAD + 5.f, cy + lh * 0.5f}, 4.f,
                             ok ? col_.ind_good : col_.ind_inactive);
-        hud_glow_text(dl, {px + PAD + 4.f, cy}, buf, ok, col_.glow_base, col_.text_fill);
+        hud_glow_text(dl, {cx + PAD + 4.f, cy}, buf, ok, col_.glow_base, col_.text_fill);
         cy += lh + 8.f;
     }
 
     // ── SSH ───────────────────────────────────────────────────────────────────
     {
-        dl->AddLine({px + PAD, cy}, {px + PW - PAD, cy}, with_alpha(col_.primary, 80), 1.f);
+        wrap_col(2.f * lh + 10.f);
+        dl->AddLine({cx + PAD, cy}, {cx + COLW - PAD, cy}, with_alpha(col_.primary, 80), 1.f);
         cy += 5.f;
         char buf[32];
         if (snap.ssh.active) {
             snprintf(buf, sizeof(buf), "SSH  Active :%d", snap.ssh.port);
-            dl->AddCircleFilled({px + PAD + 5.f, cy + lh * 0.5f}, 4.f, col_.ind_good);
+            dl->AddCircleFilled({cx + PAD + 5.f, cy + lh * 0.5f}, 4.f, col_.ind_good);
         } else {
             snprintf(buf, sizeof(buf), "SSH  Inactive");
-            dl->AddCircleFilled({px + PAD + 5.f, cy + lh * 0.5f}, 4.f, col_.ind_fail);
+            dl->AddCircleFilled({cx + PAD + 5.f, cy + lh * 0.5f}, 4.f, col_.ind_fail);
         }
-        hud_glow_text(dl, {px + PAD + 4.f, cy}, buf, snap.ssh.active,
+        hud_glow_text(dl, {cx + PAD + 4.f, cy}, buf, snap.ssh.active,
                       col_.glow_base, col_.text_fill);
+        cy += lh + 8.f;
     }
 
     // ── I2C ───────────────────────────────────────────────────────────────────
@@ -2409,22 +2559,22 @@ void HudRenderer::draw_sys_panel(const AppState& snap, int w, int h, bool active
     {
         char buf[64];
         if (snap.i2c_scan_busy) {
-            hud_glow_text(dl, {px + PAD, cy}, "Scanning...", true, col_.glow_base, col_.warn);
+            hud_glow_text(dl, {cx + PAD, cy}, "Scanning...", true, col_.glow_base, col_.warn);
             cy += lh + 4.f;
         } else if (snap.i2c_scan_results.empty()) {
             snprintf(buf, sizeof(buf), "%s  no scan", snap.i2c_scan_bus.c_str());
-            hud_glow_text(dl, {px + PAD, cy}, buf, false, col_.glow_base, col_.text_dim);
+            hud_glow_text(dl, {cx + PAD, cy}, buf, false, col_.glow_base, col_.text_dim);
             cy += lh + 4.f;
         } else {
             snprintf(buf, sizeof(buf), "Bus: %s", snap.i2c_scan_bus.c_str());
-            hud_glow_text(dl, {px + PAD, cy}, buf, false, col_.glow_base, col_.text_dim);
+            hud_glow_text(dl, {cx + PAD, cy}, buf, false, col_.glow_base, col_.text_dim);
             cy += lh + 2.f;
             constexpr int kCols = 6;
             int col_idx = 0;
-            const float cell_w = (PW - PAD * 2.f) / kCols;
+            const float cell_w = (COLW - PAD * 2.f) / kCols;
             for (uint8_t addr : snap.i2c_scan_results) {
                 snprintf(buf, sizeof(buf), "0x%02X", static_cast<int>(addr));
-                const float ax = px + PAD + col_idx * cell_w;
+                const float ax = cx + PAD + col_idx * cell_w;
                 dl->AddRectFilled({ax, cy}, {ax + cell_w - 2.f, cy + lh},
                                   with_alpha(col_.primary, 30), 2.f);
                 hud_glow_text(dl, {ax + 2.f, cy}, buf, true, col_.glow_base, col_.text_fill);
@@ -2445,8 +2595,8 @@ void HudRenderer::draw_sys_panel(const AppState& snap, int w, int h, bool active
             const ImU32 vc = na ? col_.ind_inactive : (hi ? col_.ind_good : col_.text_dim);
             snprintf(buf, sizeof(buf), "  GPIO%-3d  %s", ps.pin,
                      na ? "N/A" : (hi ? "HI" : "LO"));
-            dl->AddCircleFilled({px + PAD + 5.f, cy + lh * 0.5f}, 4.f, vc);
-            hud_glow_text(dl, {px + PAD + 4.f, cy}, buf, !na, col_.glow_base, vc);
+            dl->AddCircleFilled({cx + PAD + 5.f, cy + lh * 0.5f}, 4.f, vc);
+            hud_glow_text(dl, {cx + PAD + 4.f, cy}, buf, !na, col_.glow_base, vc);
             cy += lh + 3.f;
         }
         cy += 2.f;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -36,6 +36,7 @@
 #include "post_process.h"
 #include "sensor/mpu9250.h"
 #include "sys/system_monitor.h"
+#include "sys/scheduler_monitor.h"
 #include "net/wifi_monitor.h"
 #include "net/ping_monitor.h"
 #include "net/bt_monitor.h"
@@ -1991,6 +1992,15 @@ static std::vector<MenuItem> build_menu(
         leaf("Dismiss Alarm", [&state]{ state.timer_alarm.alarm_triggered = false; }),
     };
 
+    // Scheduler — events are entered from a phone (web form served by the
+    // scheduler_daemon) or, later, synced from Google Calendar. On-device the
+    // user can only tune the reminder lead time and view upcoming events.
+    std::vector<MenuItem> scheduler_menu = {
+        slider("Reminder Lead", 0.f, 60.f, 5.f, "min",
+            [&state]{ return static_cast<float>(state.scheduler_lead_min); },
+            [&state](float v){ state.scheduler_lead_min = static_cast<int>(v); }),
+    };
+
     // ── Color Options ─────────────────────────────────────────────────────────
 
     // HUD > Borders & Lines
@@ -2740,6 +2750,58 @@ static std::vector<MenuItem> build_menu(
                                : IM_COL32(220, 160, 90, 220));
             }),
         submenu("Timers and Alarm", std::move(timers_alarm_menu)),
+        with_panel(
+            submenu("Scheduler", std::move(scheduler_menu)),
+            "Scheduler",
+            [state_ptr](ImDrawList* dl, ImVec2 o, ImVec2 sz) {
+                (void)sz;
+                if (!state_ptr) return;
+                const float lh = 18.f;
+                ImVec2 p = o;
+                auto line = [&](const std::string& s, ImU32 c) {
+                    dl->AddText({ p.x, p.y }, c, s.c_str());
+                    p.y += lh;
+                };
+                SchedulerStatus st;
+                std::vector<ScheduledEvent> evs;
+                {
+                    std::lock_guard<std::mutex> lk(state_ptr->mtx);
+                    st  = state_ptr->scheduler_status;
+                    evs = state_ptr->scheduler_events;
+                }
+                const ImU32 dim = IM_COL32(180, 180, 180, 200);
+                const ImU32 ok  = IM_COL32(160, 220, 160, 220);
+                const ImU32 bad = IM_COL32(220, 160,  90, 220);
+                const ImU32 wht = IM_COL32(230, 230, 230, 230);
+
+                line(std::string("Daemon: ") + (st.daemon_ok ? "online" : "offline"),
+                     st.daemon_ok ? ok : bad);
+                line(std::string("Web: ") +
+                         (st.web_url.empty() ? "(starting...)" : st.web_url),
+                     st.web_url.empty() ? dim : wht);
+                line("Open that URL on your phone", dim);
+                line(std::string("Google: ") + st.gcal_state,
+                     st.gcal_state == "connected" ? ok : dim);
+                if (st.gcal_state == "pending" && !st.gcal_user_code.empty()) {
+                    line(std::string("  code: ") + st.gcal_user_code, wht);
+                    line(std::string("  at: ")   + st.gcal_verify_url, dim);
+                }
+                p.y += lh * 0.5f;
+                line("Upcoming:", dim);
+                if (evs.empty()) line("  (none)", dim);
+                int shown = 0;
+                for (const auto& e : evs) {
+                    if (shown >= 6) break;
+                    char when[24] = "--:--";
+                    if (e.start_utc) {
+                        struct tm tm{}; localtime_r(&e.start_utc, &tm);
+                        strftime(when, sizeof(when),
+                                 e.all_day ? "%b %d all-day" : "%b %d %H:%M", &tm);
+                    }
+                    line(std::string("  ") + when + "  " + e.title, wht);
+                    ++shown;
+                }
+            }),
         toggle("System Panel",
             [sys_panel_active]{ return sys_panel_active && *sys_panel_active; },
             [sys_panel_active](bool v){ if (sys_panel_active) *sys_panel_active = v; }),
@@ -3049,6 +3111,25 @@ int main(int argc, char* argv[]) {
             protoface_preview_cfg.size     = jval(jpv, "size",     protoface_preview_cfg.size);
             protoface_preview_view         = jval(jpv, "view",     protoface_preview_view);
         }
+    }
+
+    // Scheduler / reminders. Networking lives in the scheduler_daemon companion;
+    // ProtoHUD only reads the merged events.json + scheduler_status.json it writes.
+    bool        sched_enabled    = true;
+    bool        sched_autostart  = false;
+    int         sched_poll_s     = 20;
+    std::string sched_events_path =
+        "/home/user/.local/share/protohud-scheduler/events.json";
+    std::string sched_status_path =
+        "/home/user/.local/share/protohud-scheduler/scheduler_status.json";
+    if (cfg.contains("scheduler")) {
+        auto& jsc = cfg["scheduler"];
+        sched_enabled     = jval(jsc, "enabled",         sched_enabled);
+        sched_autostart   = jval(jsc, "autostart",       sched_autostart);
+        sched_poll_s      = jval(jsc, "poll_interval_s", sched_poll_s);
+        sched_events_path = jval(jsc, "events_path",     sched_events_path);
+        sched_status_path = jval(jsc, "status_path",     sched_status_path);
+        state.scheduler_lead_min = jval(jsc, "lead_minutes", state.scheduler_lead_min);
     }
 
     if (cfg.contains("pip")) {
@@ -3378,15 +3459,25 @@ int main(int argc, char* argv[]) {
 
     // ── Dev/debug monitors ────────────────────────────────────────────────────
 
-    SystemMonitor sys_mon;
-    WifiMonitor   wifi_mon;
-    PingMonitor   ping_mon;
-    BtMonitor     bt_mon;
+    SystemMonitor    sys_mon;
+    WifiMonitor      wifi_mon;
+    PingMonitor      ping_mon;
+    BtMonitor        bt_mon;
+    SchedulerMonitor sched_mon;
 
     sys_mon.start(&state);
     wifi_mon.start(&state, cfg_wifi_iface);
     ping_mon.start(&state, cfg_ping_host);
     bt_mon.start(&state);
+    if (sched_enabled) {
+        if (sched_autostart) {
+            // Best-effort launch of the companion daemon (mirrors protoface autostart).
+            // No-op if already running; file poll means the HUD never blocks on it.
+            std::system("cd \"$HOME/protohud/scheduler_daemon\" && "
+                        "nohup python3 run.py >/tmp/protohud-scheduler.log 2>&1 &");
+        }
+        sched_mon.start(&state, sched_events_path, sched_status_path, sched_poll_s);
+    }
     CrashReporter::install(&state, cfg_crash_dir, GIT_HASH);
 
     // ── Async Timewarp ────────────────────────────────────────────────────────
@@ -4211,6 +4302,67 @@ int main(int argc, char* argv[]) {
             }
         }
 
+        // ── Scheduler reminders ───────────────────────────────────────────────
+        // Raise a lead-time reminder and an at-start reminder for each event.
+        // Locked because SchedulerMonitor mutates scheduler_events concurrently.
+        {
+            std::lock_guard<std::mutex> lk(state.mtx);
+            const time_t now_t  = time(nullptr);
+            const time_t lead_s = static_cast<time_t>(state.scheduler_lead_min) * 60;
+            auto local_hm = [](time_t t) {
+                struct tm tm{}; localtime_r(&t, &tm);
+                char b[8]; strftime(b, sizeof(b), "%H:%M", &tm);
+                return std::string(b);
+            };
+            auto body_for = [&](const ScheduledEvent& ev) {
+                std::string b = ev.all_day ? "All day" : local_hm(ev.start_utc);
+                if (!ev.location.empty()) b += "  @ " + ev.location;
+                return b;
+            };
+            for (auto& e : state.scheduler_events) {
+                if (e.start_utc == 0) continue;
+
+                // Lead reminder (skipped for all-day; they only fire the at-start path).
+                const time_t lead_at = e.start_utc - lead_s;
+                const bool snoozed_due = e.snooze_until > 0 && now_t >= e.snooze_until
+                                         && now_t < e.start_utc;
+                if (!e.all_day &&
+                    ((!e.fired_lead && now_t >= lead_at && now_t < e.start_utc) || snoozed_due)) {
+                    e.fired_lead   = true;
+                    e.snooze_until = 0;
+                    long mins = static_cast<long>((e.start_utc - now_t + 59) / 60);
+                    if (mins < 0) mins = 0;
+                    Notification n;
+                    n.type           = NotifType::App;
+                    n.title          = "In " + std::to_string(mins) + " min: " + e.title;
+                    n.body           = body_for(e);
+                    n.timestamp      = static_cast<int64_t>(now_t);
+                    n.auto_dismiss_s = 0.f;
+                    const std::string uid = e.uid;
+                    n.actions.push_back({"DISMISS", [](AppState&){}});
+                    n.actions.push_back({"SNOOZE 5", [uid](AppState& s){
+                        std::lock_guard<std::mutex> g(s.mtx);
+                        for (auto& ev : s.scheduler_events)
+                            if (ev.uid == uid) { ev.snooze_until = time(nullptr) + 300; break; }
+                    }});
+                    state.notifs.push(std::move(n));
+                }
+
+                // At-start reminder.
+                if (!e.fired_start && now_t >= e.start_utc) {
+                    e.fired_start = true;
+                    Notification n;
+                    n.type           = NotifType::App;
+                    n.title          = (e.all_day ? "Today: " : "Now: ") + e.title;
+                    n.body           = body_for(e);
+                    n.timestamp      = static_cast<int64_t>(now_t);
+                    n.auto_dismiss_s = 0.f;
+                    n.actions.push_back({"DISMISS", [](AppState&){}});
+                    state.notifs.push(std::move(n));
+                }
+            }
+        }
+
         // ── Update AF / focus state from cameras (atomics, no mutex needed) ─────
         if (cameras.owl_left()) {
             state.focus_left.af_locked = cameras.owl_left()->is_af_locked();
@@ -4266,6 +4418,9 @@ int main(int argc, char* argv[]) {
             snap.clock_cfg          = state.clock_cfg;
             snap.pp_cfg             = state.pp_cfg;
             snap.timer_alarm        = state.timer_alarm;
+            snap.scheduler_events   = state.scheduler_events;
+            snap.scheduler_status   = state.scheduler_status;
+            snap.scheduler_lead_min = state.scheduler_lead_min;
             snap.effects_cfg        = state.effects_cfg;
             snap.map_overlay        = state.map_overlay;
             snap.sys_metrics        = state.sys_metrics;
@@ -4727,6 +4882,8 @@ int main(int argc, char* argv[]) {
         cfg["protoface"]["preview"]["size"]     = protoface_preview_cfg.size;
         cfg["protoface"]["preview"]["view"]     = protoface_preview_view;
 
+        cfg["scheduler"]["lead_minutes"]        = state.scheduler_lead_min;
+
         auto& jpp = cfg["post_process"];
         jpp["edge_enabled"]       = state.pp_cfg.edge_enabled;
         jpp["edge_strength"]      = state.pp_cfg.edge_strength;
@@ -4890,6 +5047,7 @@ int main(int argc, char* argv[]) {
     step("bt_mon");          bt_mon.stop();
     step("ping_mon");        ping_mon.stop();
     step("wifi_mon");        wifi_mon.stop();
+    step("sched_mon");       sched_mon.stop();
     step("sys_mon");         sys_mon.stop();
     step("mpu9250");         mpu9250.stop();
     step("audio");           audio.stop();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3297,10 +3297,24 @@ int main(int argc, char* argv[]) {
     std::atomic<int64_t> last_xr_imu_us { 0 };
 
     xr.on_imu_pose([&state, &last_xr_imu_us](float roll, float pitch, float yaw) {
-        last_xr_imu_us = std::chrono::duration_cast<std::chrono::microseconds>(
+        int64_t now_us = std::chrono::duration_cast<std::chrono::microseconds>(
             std::chrono::steady_clock::now().time_since_epoch()).count();
+        last_xr_imu_us = now_us;
         std::lock_guard<std::mutex> lk(state.mtx);
         state.imu_pose = { roll, pitch, yaw };
+
+        // Mirror into the debug-window IMU readout + estimate the callback rate.
+        auto& d = state.imu_data;
+        d.xr_roll = roll; d.xr_pitch = pitch; d.xr_yaw = yaw;
+        static int64_t prev_us = 0;
+        if (prev_us) {
+            float dms = (now_us - prev_us) / 1000.f;
+            if (dms > 0.f) {
+                float hz = 1000.f / dms;
+                d.xr_rate_hz = (d.xr_rate_hz > 0.f) ? d.xr_rate_hz * 0.98f + hz * 0.02f : hz;
+            }
+        }
+        prev_us = now_us;
     });
 
     xr.on_state_changed([](int id, int val) {
@@ -3331,6 +3345,32 @@ int main(int argc, char* argv[]) {
             if (filtered < 0.f) filtered += 360.f;
             state.compass_heading = filtered;
         }
+    });
+
+    // Full raw 9-axis sample → debug-window IMU readout (separate from the
+    // heading filter above so compass behaviour is unchanged).
+    mpu9250.set_sample_callback([&state](const Mpu9250::Sample& s) {
+        int64_t now_us = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::steady_clock::now().time_since_epoch()).count();
+        std::lock_guard<std::mutex> lk(state.mtx);
+        auto& d = state.imu_data;
+        d.mpu_ok = true;
+        for (int i = 0; i < 3; ++i) {
+            d.accel_g[i]  = s.accel_g[i];
+            d.gyro_dps[i] = s.gyro_dps[i];
+            d.mag_ut[i]   = s.mag_ut[i];
+        }
+        d.temp_c      = s.temp_c;
+        d.mpu_heading = s.heading_deg;
+        static int64_t prev_us = 0;
+        if (prev_us) {
+            float dms = (now_us - prev_us) / 1000.f;
+            if (dms > 0.f) {
+                float hz = 1000.f / dms;
+                d.mpu_rate_hz = (d.mpu_rate_hz > 0.f) ? d.mpu_rate_hz * 0.9f + hz * 0.1f : hz;
+            }
+        }
+        prev_us = now_us;
     });
 
     if (!mpu9250.start() && mpu_cfg.enabled)
@@ -4229,6 +4269,8 @@ int main(int argc, char* argv[]) {
             snap.effects_cfg        = state.effects_cfg;
             snap.map_overlay        = state.map_overlay;
             snap.sys_metrics        = state.sys_metrics;
+            snap.gpu                = state.gpu;
+            snap.imu_data           = state.imu_data;
             snap.wifi               = state.wifi;
             snap.ping               = state.ping;
             snap.ssh                = state.ssh;
@@ -4263,6 +4305,7 @@ int main(int argc, char* argv[]) {
                 std::chrono::duration_cast<std::chrono::microseconds>(
                     std::chrono::steady_clock::now().time_since_epoch()).count());
             bool xr_fresh = (now_us - last_xr_imu_us.load()) < 2'000'000ULL;
+            snap.imu_data.xr_active = xr_fresh;
             if (xr_fresh) {
                 const float vals[3] = {
                     snap.imu_pose.roll, snap.imu_pose.pitch, snap.imu_pose.yaw

--- a/src/sensor/mpu9250.cpp
+++ b/src/sensor/mpu9250.cpp
@@ -21,6 +21,8 @@ static constexpr uint8_t MPU_GYRO_CONFIG   = 0x1B;
 static constexpr uint8_t MPU_ACCEL_CONFIG  = 0x1C;
 static constexpr uint8_t MPU_INT_PIN_CFG   = 0x37; // bit1 = BYPASS_EN
 static constexpr uint8_t MPU_ACCEL_XOUT_H  = 0x3B;
+static constexpr uint8_t MPU_TEMP_OUT_H    = 0x41; // 2 bytes
+static constexpr uint8_t MPU_GYRO_XOUT_H   = 0x43; // 6 bytes
 static constexpr uint8_t MPU_PWR_MGMT_1    = 0x6B;
 static constexpr uint8_t MPU_WHO_AM_I      = 0x75; // expect 0x71 or 0x73
 
@@ -259,6 +261,42 @@ void Mpu9250::sensor_thread_fn() {
                     float heading = compute_heading(mx, my, mz, ax, ay, az);
 
                     if (cb_) cb_(heading);
+
+                    // ── Full sample for the debug window ──────────────────────
+                    if (sample_cb_) {
+                        Sample s;
+                        // Accel ±2 g → 16384 LSB/g
+                        s.accel_g[0] = ax / 16384.0f;
+                        s.accel_g[1] = ay / 16384.0f;
+                        s.accel_g[2] = az / 16384.0f;
+
+                        // Gyro ±250 °/s → 131 LSB/(°/s)
+                        uint8_t graw[6] = {};
+                        if (read_regs(i2c_fd_, cfg_.mpu_addr, MPU_GYRO_XOUT_H, graw, 6)) {
+                            int16_t gx = (int16_t)((graw[0] << 8) | graw[1]);
+                            int16_t gy = (int16_t)((graw[2] << 8) | graw[3]);
+                            int16_t gz = (int16_t)((graw[4] << 8) | graw[5]);
+                            s.gyro_dps[0] = gx / 131.0f;
+                            s.gyro_dps[1] = gy / 131.0f;
+                            s.gyro_dps[2] = gz / 131.0f;
+                        }
+
+                        // AK8963 16-bit mode → 0.15 µT/LSB (mx/my/mz are
+                        // sensitivity-adjusted, hard-iron-corrected counts)
+                        s.mag_ut[0] = mx * 0.15f;
+                        s.mag_ut[1] = my * 0.15f;
+                        s.mag_ut[2] = mz * 0.15f;
+
+                        // Die temperature: T(°C) = raw/333.87 + 21.0
+                        uint8_t traw[2] = {};
+                        if (read_regs(i2c_fd_, cfg_.mpu_addr, MPU_TEMP_OUT_H, traw, 2)) {
+                            int16_t t = (int16_t)((traw[0] << 8) | traw[1]);
+                            s.temp_c = t / 333.87f + 21.0f;
+                        }
+
+                        s.heading_deg = heading;
+                        sample_cb_(s);
+                    }
                 }
             }
         }

--- a/src/sensor/mpu9250.h
+++ b/src/sensor/mpu9250.h
@@ -53,6 +53,20 @@ public:
     // Register callback invoked on each new heading estimate (~50 Hz).
     void set_heading_callback(HeadingCallback cb) { cb_ = std::move(cb); }
 
+    // Full 9-axis sample, delivered alongside each heading update for the debug
+    // window. Magnetometer is sensitivity-adjusted and hard-iron corrected.
+    struct Sample {
+        float accel_g[3]  = {0.f, 0.f, 0.f};   // x, y, z (g)
+        float gyro_dps[3] = {0.f, 0.f, 0.f};   // x, y, z (deg/s)
+        float mag_ut[3]   = {0.f, 0.f, 0.f};   // x, y, z (µT)
+        float temp_c      = 0.f;               // die temperature
+        float heading_deg = 0.f;               // fused compass heading
+    };
+    using SampleCallback = std::function<void(const Sample&)>;
+
+    // Register callback invoked with the full raw sample on each update (~50 Hz).
+    void set_sample_callback(SampleCallback cb) { sample_cb_ = std::move(cb); }
+
     // Open I2C, initialise MPU-9250 and AK8963, start background thread.
     // Returns false if the device is not found or initialisation fails.
     bool start();
@@ -101,6 +115,7 @@ private:
 
     Config cfg_;
     HeadingCallback cb_;
+    SampleCallback  sample_cb_;
 
     int  i2c_fd_  = -1;
     // AK8963 factory sensitivity adjustment (read from fuse ROM at init)

--- a/src/sys/scheduler_monitor.cpp
+++ b/src/sys/scheduler_monitor.cpp
@@ -1,0 +1,133 @@
+#include "scheduler_monitor.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cstdio>
+#include <ctime>
+#include <fstream>
+#include <sys/stat.h>
+#include <thread>
+
+#include <nlohmann/json.hpp>
+
+using json = nlohmann::json;
+
+// Staleness window: if events.json hasn't been rewritten in this long, treat the
+// daemon as down (events still render from the last good read).
+static constexpr time_t kStaleAfterS = 300;
+
+static bool file_mtime(const std::string& path, time_t& out) {
+    struct stat st{};
+    if (stat(path.c_str(), &st) != 0) return false;
+    out = st.st_mtime;
+    return true;
+}
+
+// Parse a JSON file; returns discarded() json on missing/partial/invalid file so a
+// torn read mid-rename is handled gracefully (caller keeps last good state).
+static json parse_file(const std::string& path) {
+    std::ifstream f(path);
+    if (!f) return json::value_t::discarded;
+    return json::parse(f, nullptr, /*allow_exceptions=*/false);
+}
+
+void SchedulerMonitor::start(AppState* state, std::string events_path,
+                             std::string status_path, int poll_interval_s) {
+    state_           = state;
+    events_path_     = std::move(events_path);
+    status_path_     = std::move(status_path);
+    poll_interval_s_ = poll_interval_s > 0 ? poll_interval_s : 20;
+    first_load_      = true;
+    running_         = true;
+    thread_          = std::thread(&SchedulerMonitor::thread_fn, this);
+}
+
+void SchedulerMonitor::stop() {
+    running_ = false;
+    if (thread_.joinable()) thread_.join();
+}
+
+void SchedulerMonitor::thread_fn() {
+    while (running_) {
+        const time_t now = time(nullptr);
+
+        // ── events.json ────────────────────────────────────────────────────────
+        std::vector<ScheduledEvent> fresh;
+        bool events_ok = false;
+        json je = parse_file(events_path_);
+        if (!je.is_discarded()) {
+            const json* arr = je.is_array() ? &je
+                            : (je.contains("events") && je["events"].is_array()
+                                   ? &je["events"] : nullptr);
+            if (arr) {
+                events_ok = true;
+                for (const auto& e : *arr) {
+                    ScheduledEvent ev;
+                    ev.uid       = e.value("uid", std::string());
+                    ev.title     = e.value("title", std::string("(untitled)"));
+                    ev.location  = e.value("location", std::string());
+                    ev.start_utc = static_cast<time_t>(e.value("start_utc", (int64_t)0));
+                    ev.end_utc   = static_cast<time_t>(e.value("end_utc", (int64_t)0));
+                    ev.all_day   = e.value("all_day", false);
+                    ev.source    = (e.value("source", std::string("manual")) == "google")
+                                       ? EventSource::Google : EventSource::Manual;
+                    if (ev.uid.empty()) continue;  // uid is required for dedupe
+                    // Suppress reminders for events already past on first load.
+                    if (first_load_ && ev.start_utc != 0 && ev.start_utc < now) {
+                        ev.fired_lead = ev.fired_start = true;
+                    }
+                    fresh.push_back(std::move(ev));
+                }
+                std::sort(fresh.begin(), fresh.end(),
+                          [](const ScheduledEvent& a, const ScheduledEvent& b) {
+                              return a.start_utc < b.start_utc;
+                          });
+            }
+        }
+
+        // ── scheduler_status.json ────────────────────────────────────────────────
+        SchedulerStatus status;
+        json js = parse_file(status_path_);
+        if (!js.is_discarded() && js.is_object()) {
+            status.web_url         = js.value("web_url", std::string());
+            status.gcal_state      = js.value("gcal_state", std::string("disconnected"));
+            status.gcal_user_code  = js.value("gcal_user_code", std::string());
+            status.gcal_verify_url = js.value("gcal_verify_url", std::string());
+            status.last_sync_utc   = static_cast<time_t>(js.value("last_sync_utc", (int64_t)0));
+        }
+
+        // Daemon considered healthy only if events.json parsed and is fresh.
+        time_t mt = 0;
+        const bool fresh_file = file_mtime(events_path_, mt) && (now - mt) < kStaleAfterS;
+        status.daemon_ok   = events_ok && fresh_file;
+        status.event_count = static_cast<int>(fresh.size());
+
+        // ── Publish under the lock, carrying fire-state forward by uid ───────────
+        if (events_ok) {
+            std::lock_guard<std::mutex> lk(state_->mtx);
+            for (auto& nv : fresh) {
+                for (const auto& old : state_->scheduler_events) {
+                    if (old.uid != nv.uid) continue;
+                    // Re-arm reminders only when the event was rescheduled.
+                    if (old.start_utc == nv.start_utc) {
+                        nv.fired_lead   = old.fired_lead;
+                        nv.fired_start  = old.fired_start;
+                        nv.snooze_until = old.snooze_until;
+                    }
+                    break;
+                }
+            }
+            state_->scheduler_events = std::move(fresh);
+            state_->scheduler_status = std::move(status);
+            first_load_ = false;
+        } else {
+            // Keep last good event list; just refresh daemon health/status.
+            std::lock_guard<std::mutex> lk(state_->mtx);
+            state_->scheduler_status = std::move(status);
+        }
+
+        // Sleep in short slices so stop() is responsive.
+        for (int i = 0; i < poll_interval_s_ * 5 && running_; ++i)
+            std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    }
+}

--- a/src/sys/scheduler_monitor.h
+++ b/src/sys/scheduler_monitor.h
@@ -1,0 +1,36 @@
+#pragma once
+#include "../app_state.h"
+#include <atomic>
+#include <string>
+#include <thread>
+
+// Polls the scheduler daemon's atomically-written JSON files every poll_interval_s:
+//   events.json          — the merged calendar event list (manual + Google)
+//   scheduler_status.json — daemon web URL, Google auth state, last sync
+// Results are written to AppState::scheduler_events / scheduler_status under the
+// state mutex. The daemon owns all networking; this side only reads files.
+//
+// fired_lead / fired_start / snooze_until flags are preserved across reloads by
+// merging on event uid, so a poll never re-fires reminders already shown.
+
+class SchedulerMonitor {
+public:
+    SchedulerMonitor()  = default;
+    ~SchedulerMonitor() { stop(); }
+
+    void start(AppState* state, std::string events_path, std::string status_path,
+               int poll_interval_s);
+    void stop();
+    bool is_running() const { return running_.load(); }
+
+private:
+    void thread_fn();
+
+    AppState*         state_ = nullptr;
+    std::string       events_path_;
+    std::string       status_path_;
+    int               poll_interval_s_ = 20;
+    bool              first_load_ = true;   // suppress reminder backfill for past events
+    std::thread       thread_;
+    std::atomic<bool> running_ { false };
+};

--- a/src/sys/system_monitor.cpp
+++ b/src/sys/system_monitor.cpp
@@ -4,7 +4,9 @@
 #include <cerrno>
 #include <chrono>
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
+#include <string>
 #include <sys/sysinfo.h>
 #include <thread>
 
@@ -19,19 +21,91 @@ void SystemMonitor::stop() {
     if (thread_.joinable()) thread_.join();
 }
 
-// Read first "cpu" line of /proc/stat → (total_jiffies, idle_jiffies)
-static bool read_cpu_jiffies(uint64_t& total, uint64_t& idle) {
+// Parse /proc/stat: aggregate "cpu" line + per-core "cpuN" lines into
+// (total_jiffies, idle_jiffies). Returns the number of per-core entries filled.
+static int read_cpu_jiffies(uint64_t& agg_total, uint64_t& agg_idle,
+                            uint64_t core_total[], uint64_t core_idle[],
+                            int max_cores) {
     FILE* f = fopen("/proc/stat", "r");
-    if (!f) return false;
-    char label[8];
-    uint64_t user, nice, system, id, iowait, irq, softirq, steal;
-    int n = fscanf(f, "%7s %llu %llu %llu %llu %llu %llu %llu %llu",
-                   label, &user, &nice, &system, &id, &iowait, &irq, &softirq, &steal);
+    if (!f) return -1;
+    int cores = 0;
+    char line[256];
+    while (fgets(line, sizeof(line), f)) {
+        if (strncmp(line, "cpu", 3) != 0) break;  // cpu lines come first
+        uint64_t user, nice, system, id, iowait, irq, softirq, steal;
+        // Aggregate line: "cpu  …"; per-core: "cpuN …"
+        if (line[3] == ' ') {
+            if (sscanf(line + 3, "%llu %llu %llu %llu %llu %llu %llu %llu",
+                       &user, &nice, &system, &id, &iowait, &irq, &softirq, &steal) == 8) {
+                agg_idle  = id + iowait;
+                agg_total = user + nice + system + id + iowait + irq + softirq + steal;
+            }
+        } else {
+            int idx = -1;
+            if (sscanf(line, "cpu%d %llu %llu %llu %llu %llu %llu %llu %llu",
+                       &idx, &user, &nice, &system, &id, &iowait, &irq, &softirq, &steal) == 9
+                && idx >= 0 && idx < max_cores) {
+                core_idle [idx] = id + iowait;
+                core_total[idx] = user + nice + system + id + iowait + irq + softirq + steal;
+                if (idx + 1 > cores) cores = idx + 1;
+            }
+        }
+    }
     fclose(f);
-    if (n < 9) return false;
-    idle  = id + iowait;
-    total = user + nice + system + id + iowait + irq + softirq + steal;
-    return true;
+    return cores;
+}
+
+// CPU package temperature in °C from the thermal sysfs (0 if unavailable).
+static float read_cpu_temp_c() {
+    FILE* f = fopen("/sys/class/thermal/thermal_zone0/temp", "r");
+    if (!f) return 0.f;
+    long milli = 0;
+    int n = fscanf(f, "%ld", &milli);
+    fclose(f);
+    return (n == 1) ? static_cast<float>(milli) / 1000.f : 0.f;
+}
+
+// Current frequency (MHz) of logical core `idx` (0 if unavailable).
+static float read_core_mhz(int idx) {
+    char path[96];
+    snprintf(path, sizeof(path),
+             "/sys/devices/system/cpu/cpu%d/cpufreq/scaling_cur_freq", idx);
+    FILE* f = fopen(path, "r");
+    if (!f) return 0.f;
+    long khz = 0;
+    int n = fscanf(f, "%ld", &khz);
+    fclose(f);
+    return (n == 1) ? static_cast<float>(khz) / 1000.f : 0.f;
+}
+
+// ── GPU helpers (vcgencmd — VideoCore on Raspberry Pi) ────────────────────────
+
+// Run `vcgencmd <args>` and return the substring after the first '=' (or "").
+static std::string vcgen(const char* args) {
+    char cmd[96];
+    snprintf(cmd, sizeof(cmd), "vcgencmd %s 2>/dev/null", args);
+    FILE* fp = popen(cmd, "r");
+    if (!fp) return {};
+    char line[96] = {};
+    char* got = fgets(line, sizeof(line), fp);
+    pclose(fp);
+    if (!got) return {};
+    const char* eq = strchr(line, '=');
+    return eq ? std::string(eq + 1) : std::string();
+}
+
+static float vcgen_clock_mhz(const char* domain) {
+    char arg[48];
+    snprintf(arg, sizeof(arg), "measure_clock %s", domain);
+    std::string v = vcgen(arg);
+    if (v.empty()) return 0.f;
+    return static_cast<float>(std::strtod(v.c_str(), nullptr) / 1e6);  // Hz → MHz
+}
+
+static float vcgen_temp_c() {
+    std::string v = vcgen("measure_temp");   // "47.2'C"
+    if (v.empty()) return 0.f;
+    return static_cast<float>(std::strtod(v.c_str(), nullptr));
 }
 
 // Parse /proc/meminfo for MemTotal and MemAvailable (kB).
@@ -54,8 +128,11 @@ static bool read_meminfo(float& total_mb, float& used_mb) {
 }
 
 void SystemMonitor::thread_fn() {
-    // Prime the CPU delta baseline before the first report.
-    read_cpu_jiffies(prev_total_, prev_idle_);
+    // Prime the CPU delta baselines before the first report.
+    read_cpu_jiffies(prev_total_, prev_idle_,
+                     prev_core_total_, prev_core_idle_, kMaxCpuCores);
+
+    int gpu_tick = 0;
 
     while (running_) {
         std::this_thread::sleep_for(std::chrono::seconds(1));
@@ -65,19 +142,41 @@ void SystemMonitor::thread_fn() {
         struct sysinfo si {};
         uint64_t uptime_s = (sysinfo(&si) == 0) ? static_cast<uint64_t>(si.uptime) : 0;
 
-        // ── CPU % ─────────────────────────────────────────────────────────────
+        // ── CPU % (aggregate + per-core) ──────────────────────────────────────
         uint64_t cur_total = 0, cur_idle = 0;
+        uint64_t cur_core_total[kMaxCpuCores] = {};
+        uint64_t cur_core_idle [kMaxCpuCores] = {};
         float cpu_pct = 0.f;
-        if (read_cpu_jiffies(cur_total, cur_idle)) {
+        float core_pct[kMaxCpuCores] = {};
+        float core_mhz[kMaxCpuCores] = {};
+        int   core_count = 0;
+
+        int cores = read_cpu_jiffies(cur_total, cur_idle,
+                                     cur_core_total, cur_core_idle, kMaxCpuCores);
+        if (cores >= 0) {
             uint64_t dtotal = cur_total - prev_total_;
             uint64_t didle  = cur_idle  - prev_idle_;
             if (dtotal > 0)
                 cpu_pct = 100.f * (1.f - static_cast<float>(didle) /
                                          static_cast<float>(dtotal));
-            cpu_pct    = std::clamp(cpu_pct, 0.f, 100.f);
+            cpu_pct     = std::clamp(cpu_pct, 0.f, 100.f);
             prev_total_ = cur_total;
             prev_idle_  = cur_idle;
+
+            core_count = std::min(cores, kMaxCpuCores);
+            for (int i = 0; i < core_count; ++i) {
+                uint64_t dt = cur_core_total[i] - prev_core_total_[i];
+                uint64_t di = cur_core_idle [i] - prev_core_idle_[i];
+                float p = (dt > 0) ? 100.f * (1.f - static_cast<float>(di) /
+                                                    static_cast<float>(dt)) : 0.f;
+                core_pct[i] = std::clamp(p, 0.f, 100.f);
+                core_mhz[i] = read_core_mhz(i);
+                prev_core_total_[i] = cur_core_total[i];
+                prev_core_idle_[i]  = cur_core_idle[i];
+            }
         }
+
+        float cpu_temp = read_cpu_temp_c();
 
         // ── RAM ───────────────────────────────────────────────────────────────
         float total_mb = 0.f, used_mb = 0.f;
@@ -91,11 +190,46 @@ void SystemMonitor::thread_fn() {
             m.cpu_pct      = cpu_pct;
             m.ram_used_mb  = used_mb;
             m.ram_total_mb = total_mb;
+            m.cpu_core_count = core_count;
+            m.cpu_temp_c     = cpu_temp;
+            for (int i = 0; i < core_count; ++i) {
+                m.cpu_core_pct[i] = core_pct[i];
+                m.cpu_core_mhz[i] = core_mhz[i];
+            }
 
             int h = (m.history_head + 1) % kSysHistLen;
             m.cpu_history[h] = cpu_pct;
             m.ram_history[h] = (total_mb > 0.f) ? (used_mb / total_mb * 100.f) : 0.f;
             m.history_head   = h;
         }
+
+        // ── GPU (every 2 s — vcgencmd spawns a subprocess) ────────────────────
+        if (++gpu_tick >= 2) {
+            gpu_tick = 0;
+            poll_gpu();
+        }
+    }
+}
+
+void SystemMonitor::poll_gpu() {
+    // Functional clock domains exposed by the VideoCore. Only those reporting a
+    // non-zero frequency are kept (e.g. h264/hevc are absent on some SoCs).
+    static const char* kDomains[] = { "core", "v3d", "isp", "h264", "hevc" };
+
+    GpuMetrics g;
+    g.temp_c = vcgen_temp_c();
+    for (const char* d : kDomains) {
+        if (g.clock_count >= kMaxGpuClocks) break;
+        float mhz = vcgen_clock_mhz(d);
+        if (mhz <= 0.f) continue;
+        GpuClock& c = g.clocks[g.clock_count++];
+        snprintf(c.name, sizeof(c.name), "%s", d);
+        c.mhz = mhz;
+    }
+    g.available = (g.clock_count > 0) || (g.temp_c > 0.f);
+
+    {
+        std::lock_guard<std::mutex> lk(state_->mtx);
+        state_->gpu = g;
     }
 }

--- a/src/sys/system_monitor.h
+++ b/src/sys/system_monitor.h
@@ -3,8 +3,10 @@
 #include <atomic>
 #include <thread>
 
-// Polls /proc/stat (CPU), /proc/meminfo (RAM), and /proc/uptime every second.
-// Results are written to AppState::sys_metrics under the state mutex.
+// Polls /proc/stat (aggregate + per-core CPU), /proc/meminfo (RAM),
+// /proc/uptime, the thermal sysfs (CPU temp) every second, and the VideoCore
+// GPU clocks/temperature via vcgencmd every two seconds. Results are written to
+// AppState::sys_metrics and AppState::gpu under the state mutex.
 
 class SystemMonitor {
 public:
@@ -17,10 +19,14 @@ public:
 
 private:
     void thread_fn();
+    void poll_gpu();   // vcgencmd clocks + temp → AppState::gpu
 
     AppState*          state_    = nullptr;
     std::thread        thread_;
     std::atomic<bool>  running_  { false };
     uint64_t           prev_total_ = 0;
     uint64_t           prev_idle_  = 0;
+    // Per-core jiffy baselines (index 0 = cpu0, …)
+    uint64_t           prev_core_total_[kMaxCpuCores] = {};
+    uint64_t           prev_core_idle_ [kMaxCpuCores] = {};
 };


### PR DESCRIPTION
This branch contains two features.

---

# 1. Debug window: IMU readout + CPU/GPU core breakdowns

Three new sections in the `D`-key system debug panel (`draw_sys_panel`), which now flows into two columns.

- **IMU** — VITURE XR glasses fused pose (roll/pitch/yaw) with live/no-data dot + callback rate, and MPU-9250 raw 9-axis (accel g, gyro deg/s, mag µT, die temp, heading) + sample rate. The MPU thread now also reads the gyro/temp registers and emits a full `Sample` via a new callback (compass filter unchanged).
- **CPU CORES** — per-core utilisation bars + frequency (`/proc/stat` + `cpufreq`) and package temperature.
- **GPU** — VideoCore per-domain clocks (core/v3d/isp/h264/hevc) + temp via `vcgencmd`, polled every 2s; shows "unavailable" without vcgencmd.

---

# 2. On-board scheduler / reminders

A calendar scheduler that surfaces reminders through the existing notification/toast system. Data entry is via a **phone web form** today; **Google Calendar** sync is stubbed behind a seam for a later pass.

**Architecture** — all networking lives in a new Python companion daemon (`scheduler_daemon/`, mirroring the ProtoFace daemon pattern), so the real-time C++ render loop never does HTTP/OAuth:

```
phone browser ─► web form (daemon) ─┐
                                    ├─► events.json ─► ProtoHUD (file poll) ─► toast reminders
Google Calendar ─► (later) sync ────┘    scheduler_status.json
```

- **Daemon** (`scheduler_daemon/run.py`, stdlib-only): serves a phone-friendly form to add/delete events; merges sources; atomically writes `events.json` + `scheduler_status.json`; a heartbeat keeps them fresh. `load_google_events()`/`google_state()` are the Google seam.
- **C++ reader** (`src/sys/scheduler_monitor.*`, mirrors `SystemMonitor`): file-polls both JSONs into `AppState::scheduler_events`/`scheduler_status`, preserving per-event fire flags by `uid` so polls never re-fire reminders; suppresses backfill for past events on first load.
- **Firing** (`main.cpp`, beside the timer/alarm loop): lead-time + at-start reminders via `NotificationQueue` with DISMISS/SNOOZE actions and all-day handling (full event model: title/start/end/all-day/location, epoch-UTC).
- **Menu**: `System > Scheduler` shows the web URL, Google status, and upcoming events, and tunes the reminder lead time (persisted on exit).
- C++ needs **no new libraries** (`nlohmann_json` already linked).

Scope chosen for this pass: shared core + local web form. Google Calendar device-flow sync is a follow-up (`requests` added then; OAuth secrets gitignored).

---

## Test plan
- [ ] Build on the CM5 target — FetchContent deps (imgui/glfw/libcamera) are unavailable in the cloud sandbox, so the full C++ app was **not** compiled here. Validated standalone: `mpu9250.cpp` syntax, the `/proc/stat` per-core parser, `vcgencmd` parsing, and `app_state.h` additions.
- [ ] Debug panel: press `D`, confirm two-column layout and the IMU / CPU CORES / GPU sections populate (or degrade gracefully).
- [ ] Scheduler daemon (tested in sandbox): `python3 scheduler_daemon/run.py`, open the web URL on a phone, add timed + all-day events, confirm valid atomic `events.json`/`scheduler_status.json` with correct epoch times.
- [ ] On-glasses: `System > Scheduler` shows the live URL + upcoming events; adding an event from the phone fires a lead + at-start toast; SNOOZE/DISMISS work.
- [ ] Resilience: kill the daemon → menu shows "offline", stale events still render, no crash; restart → recovers with no duplicate reminders.

https://claude.ai/code/session_016Shy65EG8rEG8ttucJJXzW