### PR TITLE
Scheduler: Google Calendar sync + persist enabled/autostart config

### DIFF
--- a/scheduler_daemon/README.md
+++ b/scheduler_daemon/README.md
@@ -9,18 +9,21 @@ phone browser ──► web form (this daemon) ─┐
 Google Calendar ──► (later) sync ─────────┘    scheduler_status.json
 ```
 
-## What it does today
+## What it does
 
 - Serves a phone-friendly **web form** on `http://<device-ip>:<web_port>` (default
   `8770`) to add/delete calendar events (title, date, start/end or all-day, location).
+- Syncs **Google Calendar** (`gcal.py`) via the OAuth 2.0 device flow — see setup
+  below. Active only when a `client_secret.json` is present; otherwise the state stays
+  `disconnected` and only the web form is used.
 - Merges all sources and **atomically** writes:
   - `events.json` — the merged event list the HUD reads.
-  - `scheduler_status.json` — web URL, Google auth state, event count (the HUD shows
-    these in the Scheduler menu).
+  - `scheduler_status.json` — web URL, Google auth state (incl. the device-flow
+    code/URL while pending), event count (the HUD shows these in the Scheduler menu).
 - A heartbeat rewrites those files periodically so the HUD can tell the daemon is alive.
 
-Google Calendar sync is stubbed (`load_google_events()` / `google_state()` return
-empty/"disconnected") and lands in a later pass; `requests` will be added then.
+No third-party dependencies — both the web form and Google sync use the Python
+standard library (`urllib`). HTTPS to Google needs system CA certificates.
 
 ## Run it
 
@@ -49,12 +52,17 @@ No authentication — intended for a personal device on a trusted LAN, same mode
 rest of ProtoHUD. User-entered text is HTML-escaped before display. Do not expose the
 port to the public internet.
 
-## Google sync setup (for the later pass)
+## Google sync setup
 
 1. In Google Cloud Console create an OAuth client of type **TV and Limited Input
-   devices**.
+   devices** and enable the Google Calendar API. Add yourself as a test user (or
+   publish the consent screen).
 2. Copy `client_secret.example.json` → `client_secret.json` and fill in your client id/
    secret. **Never commit** `client_secret.json` or `token.json` (both gitignored).
-3. The daemon will run the device flow: the glasses show a short URL + code, you
-   authorize on your phone, and the refresh token is stored at
-   `~/.config/protohud-scheduler/token.json`.
+3. Start the daemon. It runs the device flow automatically: the Scheduler menu on the
+   glasses (and the daemon log) shows a short URL + code — open the URL on your phone
+   and enter the code. The refresh token is then stored at
+   `~/.config/protohud-scheduler/token.json` and events sync every 5 minutes.
+
+Scope is `calendar.readonly` (events are pulled, never modified). Events are fetched
+30 days ahead from the user's primary calendar; recurring events are expanded.

--- a/scheduler_daemon/gcal.py
+++ b/scheduler_daemon/gcal.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""Google Calendar sync for the ProtoHUD scheduler daemon.
+
+Implements the OAuth 2.0 *device authorization flow* (for "TV and Limited Input
+devices") so the user authorizes on their phone — the glasses only display a
+short code + URL, never any typed input. Uses the Python standard library only
+(urllib); no third-party dependencies.
+
+Flow:
+  1. POST device/code  -> device_code + user_code + verification_url (shown on HUD)
+  2. Poll token        -> access_token + refresh_token once the user authorizes
+  3. Refresh as needed -> pull upcoming events from Calendar v3, normalize to the
+     scheduler event schema, and hand them to the daemon to merge/publish.
+
+State is exposed via snapshot() for scheduler_status.json:
+  state: "disconnected" (no client secret) | "pending" (awaiting authorization)
+       | "connected" | "error"
+"""
+
+import datetime
+import json
+import os
+import threading
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+DEVICE_CODE_URL = "https://oauth2.googleapis.com/device/code"
+TOKEN_URL       = "https://oauth2.googleapis.com/token"
+CAL_EVENTS_URL  = "https://www.googleapis.com/calendar/v3/calendars/primary/events"
+SCOPE           = "https://www.googleapis.com/auth/calendar.readonly"
+GRANT_DEVICE    = "urn:ietf:params:oauth:grant-type:device_code"
+
+TOKEN_PATH      = os.path.expanduser("~/.config/protohud-scheduler/token.json")
+SYNC_INTERVAL_S = 300          # pull cadence once connected
+HORIZON_DAYS    = 30           # how far ahead to fetch events
+HTTP_TIMEOUT_S  = 30
+
+
+def _http(req):
+    """Return (status, parsed_json). Never raises; error bodies are parsed too."""
+    try:
+        with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT_S) as r:
+            return r.status, json.load(r)
+    except urllib.error.HTTPError as e:
+        try:
+            return e.code, json.load(e)
+        except Exception:  # noqa: BLE001
+            return e.code, {}
+    except Exception as e:  # noqa: BLE001 — network/SSL/etc.
+        return 0, {"error": str(e)}
+
+
+def _post(url, data):
+    body = urllib.parse.urlencode(data).encode()
+    return _http(urllib.request.Request(url, data=body, method="POST"))
+
+
+def _get(url, token):
+    return _http(urllib.request.Request(
+        url, headers={"Authorization": "Bearer " + token}))
+
+
+def _rfc3339(epoch):
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(epoch))
+
+
+def _parse_dt(s):
+    """RFC3339 datetime string -> epoch seconds (UTC)."""
+    try:
+        return int(datetime.datetime.fromisoformat(
+            s.replace("Z", "+00:00")).timestamp())
+    except (ValueError, AttributeError):
+        return None
+
+
+def _date_to_epoch(d, hour):
+    """'YYYY-MM-DD' (local) at the given hour -> epoch seconds."""
+    try:
+        return int(datetime.datetime.strptime(d, "%Y-%m-%d")
+                   .replace(hour=hour).timestamp())
+    except (ValueError, TypeError):
+        return None
+
+
+class GoogleSync:
+    def __init__(self, cfg, on_change):
+        self.cfg = cfg
+        self.on_change = on_change          # called when state/events change
+        self.lock = threading.Lock()
+        self.state = "disconnected"
+        self.user_code = ""
+        self.verify_url = ""
+        self.events = []
+        self._client = self._load_client_secret()
+        self._refresh_token = self._load_refresh_token()
+        self._access_token = None
+        self._access_expiry = 0
+
+    # ── public ────────────────────────────────────────────────────────────────
+    def enabled(self):
+        return self._client is not None
+
+    def snapshot(self):
+        with self.lock:
+            return self.state, self.user_code, self.verify_url, list(self.events)
+
+    def start(self):
+        if not self.enabled():
+            print("[scheduler] Google: no client_secret.json — sync disabled")
+            return
+        threading.Thread(target=self._run, daemon=True).start()
+
+    # ── credential loading ──────────────────────────────────────────────────────
+    def _load_client_secret(self):
+        path = os.path.join(os.path.dirname(__file__), "client_secret.json")
+        if not os.path.isfile(path):
+            return None
+        try:
+            with open(path) as f:
+                blob = json.load(f)
+            node = blob.get("installed") or blob.get("web") or blob
+            if node.get("client_id") and node.get("client_secret"):
+                return {"client_id": node["client_id"],
+                        "client_secret": node["client_secret"]}
+        except Exception as e:  # noqa: BLE001
+            print(f"[scheduler] Google: bad client_secret.json ({e})")
+        return None
+
+    def _load_refresh_token(self):
+        try:
+            with open(TOKEN_PATH) as f:
+                return json.load(f).get("refresh_token")
+        except Exception:  # noqa: BLE001
+            return None
+
+    def _save_refresh_token(self, tok):
+        os.makedirs(os.path.dirname(TOKEN_PATH), exist_ok=True)
+        with open(TOKEN_PATH, "w") as f:
+            json.dump({"refresh_token": tok}, f)
+        try:
+            os.chmod(TOKEN_PATH, 0o600)
+        except OSError:
+            pass
+
+    def _set_state(self, state, user_code="", verify_url=""):
+        with self.lock:
+            self.state = state
+            self.user_code = user_code
+            self.verify_url = verify_url
+        if self.on_change:
+            self.on_change()
+
+    # ── main loop ───────────────────────────────────────────────────────────────
+    def _run(self):
+        while True:
+            try:
+                if not self._refresh_token and not self._device_flow():
+                    time.sleep(30)
+                    continue
+                if not self._ensure_access():
+                    self._set_state("error")
+                    self._refresh_token = None   # force re-auth on next pass
+                    time.sleep(60)
+                    continue
+                events = self._pull()
+                if events is None:
+                    self._set_state("error")
+                    time.sleep(60)
+                    continue
+                with self.lock:
+                    self.events = events
+                    self.state = "connected"
+                if self.on_change:
+                    self.on_change()
+            except Exception as e:  # noqa: BLE001 — keep the thread alive
+                print(f"[scheduler] Google sync error: {e}")
+                self._set_state("error")
+            time.sleep(SYNC_INTERVAL_S)
+
+    def _device_flow(self):
+        st, resp = _post(DEVICE_CODE_URL,
+                         {"client_id": self._client["client_id"], "scope": SCOPE})
+        if st != 200 or "device_code" not in resp:
+            self._set_state("error")
+            return False
+        device_code = resp["device_code"]
+        interval = resp.get("interval", 5)
+        verify = resp.get("verification_url") or resp.get("verification_uri", "")
+        self._set_state("pending", resp.get("user_code", ""), verify)
+        print(f"[scheduler] Google: visit {verify} and enter {resp.get('user_code')}")
+
+        deadline = time.time() + resp.get("expires_in", 1800)
+        while time.time() < deadline:
+            time.sleep(interval)
+            st, tok = _post(TOKEN_URL, {
+                "client_id": self._client["client_id"],
+                "client_secret": self._client["client_secret"],
+                "device_code": device_code,
+                "grant_type": GRANT_DEVICE,
+            })
+            if "access_token" in tok:
+                self._access_token = tok["access_token"]
+                self._access_expiry = time.time() + tok.get("expires_in", 3600)
+                if tok.get("refresh_token"):
+                    self._refresh_token = tok["refresh_token"]
+                    self._save_refresh_token(self._refresh_token)
+                return True
+            err = tok.get("error", "")
+            if err == "authorization_pending":
+                continue
+            if err == "slow_down":
+                interval += 5
+                continue
+            # access_denied / expired_token / other → abort this attempt
+            self._set_state("error")
+            return False
+        self._set_state("error")
+        return False
+
+    def _ensure_access(self):
+        if self._access_token and time.time() < self._access_expiry - 60:
+            return True
+        st, tok = _post(TOKEN_URL, {
+            "client_id": self._client["client_id"],
+            "client_secret": self._client["client_secret"],
+            "refresh_token": self._refresh_token,
+            "grant_type": "refresh_token",
+        })
+        if "access_token" in tok:
+            self._access_token = tok["access_token"]
+            self._access_expiry = time.time() + tok.get("expires_in", 3600)
+            return True
+        return False
+
+    def _pull(self):
+        now = int(time.time())
+        params = urllib.parse.urlencode({
+            "timeMin": _rfc3339(now),
+            "timeMax": _rfc3339(now + HORIZON_DAYS * 86400),
+            "singleEvents": "true",
+            "orderBy": "startTime",
+            "maxResults": "50",
+        })
+        st, data = _get(CAL_EVENTS_URL + "?" + params, self._access_token)
+        if st != 200:
+            return None
+        out = []
+        for item in data.get("items", []):
+            ev = self._normalize(item)
+            if ev:
+                out.append(ev)
+        return out
+
+    def _normalize(self, item):
+        eid = item.get("id")
+        if not eid:
+            return None
+        start, end = item.get("start", {}), item.get("end", {})
+        if "dateTime" in start:
+            s = _parse_dt(start["dateTime"])
+            e = _parse_dt(end.get("dateTime", "")) or s
+            all_day = False
+        elif "date" in start:
+            hour = int(self.cfg.get("all_day_reminder_hour", 8))
+            s = _date_to_epoch(start["date"], hour)
+            e = _date_to_epoch(end.get("date", start["date"]), 0)  # end date is exclusive
+            all_day = True
+        else:
+            return None
+        if s is None:
+            return None
+        return {
+            "uid": "g:" + eid,
+            "title": item.get("summary", "(no title)"),
+            "location": item.get("location", ""),
+            "start_utc": s,
+            "end_utc": e or s,
+            "all_day": all_day,
+            "source": "google",
+        }

--- a/scheduler_daemon/requirements.txt
+++ b/scheduler_daemon/requirements.txt
@@ -1,6 +1,5 @@
-# The web-form daemon uses only the Python 3 standard library — nothing to install.
+# No third-party dependencies — Python 3 standard library only.
 #
-# Google Calendar sync (a later pass) will add:
-#   requests>=2.31
-# (OAuth 2.0 device flow + Calendar v3 REST are simple enough to drive with requests;
-#  swap in google-api-python-client if you prefer the official client.)
+# Both the web form and Google Calendar sync (OAuth 2.0 device flow + Calendar v3)
+# are implemented with urllib, so nothing needs to be pip-installed. Requires
+# system CA certificates (the `ca-certificates` package) for HTTPS to Google.

--- a/scheduler_daemon/run.py
+++ b/scheduler_daemon/run.py
@@ -31,6 +31,8 @@ import uuid
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from urllib.parse import parse_qs, urlparse
 
+from gcal import GoogleSync
+
 # ── Config resolution ──────────────────────────────────────────────────────────
 
 DEFAULTS = {
@@ -115,10 +117,14 @@ class Store:
     def __init__(self, cfg):
         self.cfg = cfg
         self.lock = threading.Lock()
+        self.gsync = None  # GoogleSync, set after construction (events second source)
         data_dir = os.path.dirname(cfg["events_path"])
         os.makedirs(data_dir, exist_ok=True)
         self.manual_path = os.path.join(data_dir, "manual_events.json")
         self.manual = read_json(self.manual_path, {"events": []}).get("events", [])
+
+    def _google_events(self):
+        return self.gsync.snapshot()[3] if self.gsync else []
 
     # --- manual event mutations (call under self.lock via public methods) ---
     def add_manual(self, ev):
@@ -134,42 +140,34 @@ class Store:
         self.publish()
 
     def list_events(self):
+        gevents = self._google_events()
         with self.lock:
-            return sorted(self._merged(), key=lambda e: e["start_utc"])
+            return sorted(list(self.manual) + gevents, key=lambda e: e["start_utc"])
 
     def _save_manual(self):
         atomic_write_json(self.manual_path, {"events": self.manual})
 
-    def _merged(self):
-        # Manual + Google (Google returns [] until that pass lands).
-        return list(self.manual) + load_google_events(self.cfg)
-
     # --- publish to the HUD-facing files ---
     def publish(self):
+        gstate, gcode, gurl = "disconnected", "", ""
+        gevents = []
+        if self.gsync:
+            gstate, gcode, gurl, gevents = self.gsync.snapshot()
         with self.lock:
-            events = sorted(self._merged(), key=lambda e: e["start_utc"])
+            events = sorted(list(self.manual) + gevents,
+                            key=lambda e: e["start_utc"])
         atomic_write_json(self.cfg["events_path"],
                           {"version": 1,
                            "generated_utc": int(time.time()),
                            "events": events})
         atomic_write_json(self.cfg["status_path"], {
             "web_url": f"http://{detect_ip()}:{self.cfg['web_port']}",
-            "gcal_state": google_state(self.cfg),
-            "gcal_user_code": "",
-            "gcal_verify_url": "",
+            "gcal_state": gstate,
+            "gcal_user_code": gcode,
+            "gcal_verify_url": gurl,
             "last_sync_utc": int(time.time()),
             "event_count": len(events),
         })
-
-
-# ── Google Calendar seam (implemented in a later pass) ───────────────────────────
-
-def google_state(cfg):
-    return "disconnected"
-
-
-def load_google_events(cfg):
-    return []
 
 
 # ── Time helpers ─────────────────────────────────────────────────────────────────
@@ -320,6 +318,13 @@ def heartbeat(store, period_s):
 def main():
     cfg = load_config()
     store = Store(cfg)
+
+    # Google Calendar is the second event source. It runs only when a
+    # client_secret.json is present; otherwise state stays "disconnected".
+    gsync = GoogleSync(cfg, on_change=store.publish)
+    store.gsync = gsync
+    gsync.start()
+
     store.publish()  # write initial events.json + status
 
     threading.Thread(target=heartbeat,

--- a/src/face/renderer.cpp
+++ b/src/face/renderer.cpp
@@ -29,9 +29,10 @@ cv::Mat apply_material(const cv::Mat& face_rgba, const cv::Mat& material_rgb) {
     m[2].convertTo(mb, CV_32F);
 
     cv::Mat cr, cg, cb;               // colour × luminance, saturate to 0..255
-    mr.mul(lum).convertTo(cr, CV_8U);
-    mg.mul(lum).convertTo(cg, CV_8U);
-    mb.mul(lum).convertTo(cb, CV_8U);
+    // mul() yields a cv::MatExpr (no convertTo); materialize to a Mat first.
+    cv::Mat(mr.mul(lum)).convertTo(cr, CV_8U);
+    cv::Mat(mg.mul(lum)).convertTo(cg, CV_8U);
+    cv::Mat(mb.mul(lum)).convertTo(cb, CV_8U);
 
     std::vector<cv::Mat> out{cr, cg, cb, f[3]};
     cv::Mat result;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4882,6 +4882,8 @@ int main(int argc, char* argv[]) {
         cfg["protoface"]["preview"]["size"]     = protoface_preview_cfg.size;
         cfg["protoface"]["preview"]["view"]     = protoface_preview_view;
 
+        cfg["scheduler"]["enabled"]             = sched_enabled;
+        cfg["scheduler"]["autostart"]           = sched_autostart;
         cfg["scheduler"]["lead_minutes"]        = state.scheduler_lead_min;
 
         auto& jpp = cfg["post_process"];

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3118,6 +3118,7 @@ int main(int argc, char* argv[]) {
     bool        sched_enabled    = true;
     bool        sched_autostart  = false;
     int         sched_poll_s     = 20;
+    int         sched_lead_min   = 10;   // applied to state once it exists (below)
     std::string sched_events_path =
         "/home/user/.local/share/protohud-scheduler/events.json";
     std::string sched_status_path =
@@ -3129,7 +3130,7 @@ int main(int argc, char* argv[]) {
         sched_poll_s      = jval(jsc, "poll_interval_s", sched_poll_s);
         sched_events_path = jval(jsc, "events_path",     sched_events_path);
         sched_status_path = jval(jsc, "status_path",     sched_status_path);
-        state.scheduler_lead_min = jval(jsc, "lead_minutes", state.scheduler_lead_min);
+        sched_lead_min    = jval(jsc, "lead_minutes",    sched_lead_min);
     }
 
     if (cfg.contains("pip")) {
@@ -3182,6 +3183,7 @@ int main(int argc, char* argv[]) {
     AppState state;
     state.max_messages        = jval(jhud, "lora_message_history", 50);
     state.compass_bg_enabled  = jhud.value("compass_bg", true);
+    state.scheduler_lead_min  = sched_lead_min;
 
     if (jhud.contains("effects")) {
         auto& jfx = jhud["effects"];

--- a/src/sys/scheduler_monitor.cpp
+++ b/src/sys/scheduler_monitor.cpp
@@ -7,6 +7,7 @@
 #include <fstream>
 #include <sys/stat.h>
 #include <thread>
+#include <utility>
 
 #include <nlohmann/json.hpp>
 


### PR DESCRIPTION
Two scheduler follow-ups to #185.

## 1. Google Calendar sync (daemon)

Adds Google Calendar as the second event source (the local web form shipped in #185). Daemon-only — the C++ HUD already reads the merged events + Google auth status the daemon publishes.

- **`scheduler_daemon/gcal.py`** — OAuth 2.0 **device authorization flow** ("TV and Limited Input devices"): the glasses show a short URL + code, the user authorizes on their phone (no on-device typing).
- Device-code request, token polling/refresh, and Calendar v3 event pull are all done with the Python **standard library (`urllib`)** — no third-party dependencies.
- Pulls the primary calendar 30 days ahead (`singleEvents=true`, `calendar.readonly`), normalizes timed and all-day events to the scheduler schema (`uid` = `g:<event-id>`), and merges them with manual web-form events into `events.json`.
- Auth state + device code/URL are written to `scheduler_status.json`, surfaced by the existing **System > Scheduler** menu (no C++ change for this part).
- Active only when `client_secret.json` is present; otherwise stays `disconnected` and only the web form is used. Refresh token stored at `~/.config/protohud-scheduler/token.json` (gitignored).

## 2. Persist scheduler toggles to config (C++)

The config write-back only saved `scheduler.lead_minutes`, so a user's `config.json` ended up as just `{"lead_minutes":N}` and the other options (notably `autostart`) were invisible and stuck at their in-code defaults. Now `enabled` + `autostart` are also written back so the toggles appear in `config.json` and persist after one run. Paths are intentionally *not* written back, to avoid baking absolute default paths into every config.

## Test plan
- [x] `py_compile` of `run.py` + `gcal.py`; event normalization unit-tested (RFC3339 offset→UTC, all-day→local-hour epoch, edge cases).
- [x] Full daemon run **without** credentials: web form works, Google cleanly `disconnected`, no crash.
- [ ] Live OAuth device flow against a real Google account — not exercisable in the cloud sandbox (no Google network/credentials); needs a manual run with a real `client_secret.json`.
- [ ] C++ build on the CM5 target (FetchContent deps unavailable in sandbox); after one run, confirm `config.json` shows `enabled`/`autostart` under `scheduler`.

https://claude.ai/code/session_016Shy65EG8rEG8ttucJJXzW