### PR TITLE
USB cameras: regroup deep menu + live-feed context panels

### DIFF
--- a/scheduler_daemon/README.md
+++ b/scheduler_daemon/README.md
@@ -9,18 +9,21 @@ phone browser ──► web form (this daemon) ─┐
 Google Calendar ──► (later) sync ─────────┘    scheduler_status.json
 ```
 
-## What it does today
+## What it does
 
 - Serves a phone-friendly **web form** on `http://<device-ip>:<web_port>` (default
   `8770`) to add/delete calendar events (title, date, start/end or all-day, location).
+- Syncs **Google Calendar** (`gcal.py`) via the OAuth 2.0 device flow — see setup
+  below. Active only when a `client_secret.json` is present; otherwise the state stays
+  `disconnected` and only the web form is used.
 - Merges all sources and **atomically** writes:
   - `events.json` — the merged event list the HUD reads.
-  - `scheduler_status.json` — web URL, Google auth state, event count (the HUD shows
-    these in the Scheduler menu).
+  - `scheduler_status.json` — web URL, Google auth state (incl. the device-flow
+    code/URL while pending), event count (the HUD shows these in the Scheduler menu).
 - A heartbeat rewrites those files periodically so the HUD can tell the daemon is alive.
 
-Google Calendar sync is stubbed (`load_google_events()` / `google_state()` return
-empty/"disconnected") and lands in a later pass; `requests` will be added then.
+No third-party dependencies — both the web form and Google sync use the Python
+standard library (`urllib`). HTTPS to Google needs system CA certificates.
 
 ## Run it
 
@@ -49,12 +52,17 @@ No authentication — intended for a personal device on a trusted LAN, same mode
 rest of ProtoHUD. User-entered text is HTML-escaped before display. Do not expose the
 port to the public internet.
 
-## Google sync setup (for the later pass)
+## Google sync setup
 
 1. In Google Cloud Console create an OAuth client of type **TV and Limited Input
-   devices**.
+   devices** and enable the Google Calendar API. Add yourself as a test user (or
+   publish the consent screen).
 2. Copy `client_secret.example.json` → `client_secret.json` and fill in your client id/
    secret. **Never commit** `client_secret.json` or `token.json` (both gitignored).
-3. The daemon will run the device flow: the glasses show a short URL + code, you
-   authorize on your phone, and the refresh token is stored at
-   `~/.config/protohud-scheduler/token.json`.
+3. Start the daemon. It runs the device flow automatically: the Scheduler menu on the
+   glasses (and the daemon log) shows a short URL + code — open the URL on your phone
+   and enter the code. The refresh token is then stored at
+   `~/.config/protohud-scheduler/token.json` and events sync every 5 minutes.
+
+Scope is `calendar.readonly` (events are pulled, never modified). Events are fetched
+30 days ahead from the user's primary calendar; recurring events are expanded.

--- a/scheduler_daemon/gcal.py
+++ b/scheduler_daemon/gcal.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""Google Calendar sync for the ProtoHUD scheduler daemon.
+
+Implements the OAuth 2.0 *device authorization flow* (for "TV and Limited Input
+devices") so the user authorizes on their phone — the glasses only display a
+short code + URL, never any typed input. Uses the Python standard library only
+(urllib); no third-party dependencies.
+
+Flow:
+  1. POST device/code  -> device_code + user_code + verification_url (shown on HUD)
+  2. Poll token        -> access_token + refresh_token once the user authorizes
+  3. Refresh as needed -> pull upcoming events from Calendar v3, normalize to the
+     scheduler event schema, and hand them to the daemon to merge/publish.
+
+State is exposed via snapshot() for scheduler_status.json:
+  state: "disconnected" (no client secret) | "pending" (awaiting authorization)
+       | "connected" | "error"
+"""
+
+import datetime
+import json
+import os
+import threading
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+DEVICE_CODE_URL = "https://oauth2.googleapis.com/device/code"
+TOKEN_URL       = "https://oauth2.googleapis.com/token"
+CAL_EVENTS_URL  = "https://www.googleapis.com/calendar/v3/calendars/primary/events"
+SCOPE           = "https://www.googleapis.com/auth/calendar.readonly"
+GRANT_DEVICE    = "urn:ietf:params:oauth:grant-type:device_code"
+
+TOKEN_PATH      = os.path.expanduser("~/.config/protohud-scheduler/token.json")
+SYNC_INTERVAL_S = 300          # pull cadence once connected
+HORIZON_DAYS    = 30           # how far ahead to fetch events
+HTTP_TIMEOUT_S  = 30
+
+
+def _http(req):
+    """Return (status, parsed_json). Never raises; error bodies are parsed too."""
+    try:
+        with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT_S) as r:
+            return r.status, json.load(r)
+    except urllib.error.HTTPError as e:
+        try:
+            return e.code, json.load(e)
+        except Exception:  # noqa: BLE001
+            return e.code, {}
+    except Exception as e:  # noqa: BLE001 — network/SSL/etc.
+        return 0, {"error": str(e)}
+
+
+def _post(url, data):
+    body = urllib.parse.urlencode(data).encode()
+    return _http(urllib.request.Request(url, data=body, method="POST"))
+
+
+def _get(url, token):
+    return _http(urllib.request.Request(
+        url, headers={"Authorization": "Bearer " + token}))
+
+
+def _rfc3339(epoch):
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(epoch))
+
+
+def _parse_dt(s):
+    """RFC3339 datetime string -> epoch seconds (UTC)."""
+    try:
+        return int(datetime.datetime.fromisoformat(
+            s.replace("Z", "+00:00")).timestamp())
+    except (ValueError, AttributeError):
+        return None
+
+
+def _date_to_epoch(d, hour):
+    """'YYYY-MM-DD' (local) at the given hour -> epoch seconds."""
+    try:
+        return int(datetime.datetime.strptime(d, "%Y-%m-%d")
+                   .replace(hour=hour).timestamp())
+    except (ValueError, TypeError):
+        return None
+
+
+class GoogleSync:
+    def __init__(self, cfg, on_change):
+        self.cfg = cfg
+        self.on_change = on_change          # called when state/events change
+        self.lock = threading.Lock()
+        self.state = "disconnected"
+        self.user_code = ""
+        self.verify_url = ""
+        self.events = []
+        self._client = self._load_client_secret()
+        self._refresh_token = self._load_refresh_token()
+        self._access_token = None
+        self._access_expiry = 0
+
+    # ── public ────────────────────────────────────────────────────────────────
+    def enabled(self):
+        return self._client is not None
+
+    def snapshot(self):
+        with self.lock:
+            return self.state, self.user_code, self.verify_url, list(self.events)
+
+    def start(self):
+        if not self.enabled():
+            print("[scheduler] Google: no client_secret.json — sync disabled")
+            return
+        threading.Thread(target=self._run, daemon=True).start()
+
+    # ── credential loading ──────────────────────────────────────────────────────
+    def _load_client_secret(self):
+        path = os.path.join(os.path.dirname(__file__), "client_secret.json")
+        if not os.path.isfile(path):
+            return None
+        try:
+            with open(path) as f:
+                blob = json.load(f)
+            node = blob.get("installed") or blob.get("web") or blob
+            if node.get("client_id") and node.get("client_secret"):
+                return {"client_id": node["client_id"],
+                        "client_secret": node["client_secret"]}
+        except Exception as e:  # noqa: BLE001
+            print(f"[scheduler] Google: bad client_secret.json ({e})")
+        return None
+
+    def _load_refresh_token(self):
+        try:
+            with open(TOKEN_PATH) as f:
+                return json.load(f).get("refresh_token")
+        except Exception:  # noqa: BLE001
+            return None
+
+    def _save_refresh_token(self, tok):
+        os.makedirs(os.path.dirname(TOKEN_PATH), exist_ok=True)
+        with open(TOKEN_PATH, "w") as f:
+            json.dump({"refresh_token": tok}, f)
+        try:
+            os.chmod(TOKEN_PATH, 0o600)
+        except OSError:
+            pass
+
+    def _set_state(self, state, user_code="", verify_url=""):
+        with self.lock:
+            self.state = state
+            self.user_code = user_code
+            self.verify_url = verify_url
+        if self.on_change:
+            self.on_change()
+
+    # ── main loop ───────────────────────────────────────────────────────────────
+    def _run(self):
+        while True:
+            try:
+                if not self._refresh_token and not self._device_flow():
+                    time.sleep(30)
+                    continue
+                if not self._ensure_access():
+                    self._set_state("error")
+                    self._refresh_token = None   # force re-auth on next pass
+                    time.sleep(60)
+                    continue
+                events = self._pull()
+                if events is None:
+                    self._set_state("error")
+                    time.sleep(60)
+                    continue
+                with self.lock:
+                    self.events = events
+                    self.state = "connected"
+                if self.on_change:
+                    self.on_change()
+            except Exception as e:  # noqa: BLE001 — keep the thread alive
+                print(f"[scheduler] Google sync error: {e}")
+                self._set_state("error")
+            time.sleep(SYNC_INTERVAL_S)
+
+    def _device_flow(self):
+        st, resp = _post(DEVICE_CODE_URL,
+                         {"client_id": self._client["client_id"], "scope": SCOPE})
+        if st != 200 or "device_code" not in resp:
+            self._set_state("error")
+            return False
+        device_code = resp["device_code"]
+        interval = resp.get("interval", 5)
+        verify = resp.get("verification_url") or resp.get("verification_uri", "")
+        self._set_state("pending", resp.get("user_code", ""), verify)
+        print(f"[scheduler] Google: visit {verify} and enter {resp.get('user_code')}")
+
+        deadline = time.time() + resp.get("expires_in", 1800)
+        while time.time() < deadline:
+            time.sleep(interval)
+            st, tok = _post(TOKEN_URL, {
+                "client_id": self._client["client_id"],
+                "client_secret": self._client["client_secret"],
+                "device_code": device_code,
+                "grant_type": GRANT_DEVICE,
+            })
+            if "access_token" in tok:
+                self._access_token = tok["access_token"]
+                self._access_expiry = time.time() + tok.get("expires_in", 3600)
+                if tok.get("refresh_token"):
+                    self._refresh_token = tok["refresh_token"]
+                    self._save_refresh_token(self._refresh_token)
+                return True
+            err = tok.get("error", "")
+            if err == "authorization_pending":
+                continue
+            if err == "slow_down":
+                interval += 5
+                continue
+            # access_denied / expired_token / other → abort this attempt
+            self._set_state("error")
+            return False
+        self._set_state("error")
+        return False
+
+    def _ensure_access(self):
+        if self._access_token and time.time() < self._access_expiry - 60:
+            return True
+        st, tok = _post(TOKEN_URL, {
+            "client_id": self._client["client_id"],
+            "client_secret": self._client["client_secret"],
+            "refresh_token": self._refresh_token,
+            "grant_type": "refresh_token",
+        })
+        if "access_token" in tok:
+            self._access_token = tok["access_token"]
+            self._access_expiry = time.time() + tok.get("expires_in", 3600)
+            return True
+        return False
+
+    def _pull(self):
+        now = int(time.time())
+        params = urllib.parse.urlencode({
+            "timeMin": _rfc3339(now),
+            "timeMax": _rfc3339(now + HORIZON_DAYS * 86400),
+            "singleEvents": "true",
+            "orderBy": "startTime",
+            "maxResults": "50",
+        })
+        st, data = _get(CAL_EVENTS_URL + "?" + params, self._access_token)
+        if st != 200:
+            return None
+        out = []
+        for item in data.get("items", []):
+            ev = self._normalize(item)
+            if ev:
+                out.append(ev)
+        return out
+
+    def _normalize(self, item):
+        eid = item.get("id")
+        if not eid:
+            return None
+        start, end = item.get("start", {}), item.get("end", {})
+        if "dateTime" in start:
+            s = _parse_dt(start["dateTime"])
+            e = _parse_dt(end.get("dateTime", "")) or s
+            all_day = False
+        elif "date" in start:
+            hour = int(self.cfg.get("all_day_reminder_hour", 8))
+            s = _date_to_epoch(start["date"], hour)
+            e = _date_to_epoch(end.get("date", start["date"]), 0)  # end date is exclusive
+            all_day = True
+        else:
+            return None
+        if s is None:
+            return None
+        return {
+            "uid": "g:" + eid,
+            "title": item.get("summary", "(no title)"),
+            "location": item.get("location", ""),
+            "start_utc": s,
+            "end_utc": e or s,
+            "all_day": all_day,
+            "source": "google",
+        }

--- a/scheduler_daemon/requirements.txt
+++ b/scheduler_daemon/requirements.txt
@@ -1,6 +1,5 @@
-# The web-form daemon uses only the Python 3 standard library — nothing to install.
+# No third-party dependencies — Python 3 standard library only.
 #
-# Google Calendar sync (a later pass) will add:
-#   requests>=2.31
-# (OAuth 2.0 device flow + Calendar v3 REST are simple enough to drive with requests;
-#  swap in google-api-python-client if you prefer the official client.)
+# Both the web form and Google Calendar sync (OAuth 2.0 device flow + Calendar v3)
+# are implemented with urllib, so nothing needs to be pip-installed. Requires
+# system CA certificates (the `ca-certificates` package) for HTTPS to Google.

--- a/scheduler_daemon/run.py
+++ b/scheduler_daemon/run.py
@@ -31,6 +31,8 @@ import uuid
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from urllib.parse import parse_qs, urlparse
 
+from gcal import GoogleSync
+
 # ── Config resolution ──────────────────────────────────────────────────────────
 
 DEFAULTS = {
@@ -115,10 +117,14 @@ class Store:
     def __init__(self, cfg):
         self.cfg = cfg
         self.lock = threading.Lock()
+        self.gsync = None  # GoogleSync, set after construction (events second source)
         data_dir = os.path.dirname(cfg["events_path"])
         os.makedirs(data_dir, exist_ok=True)
         self.manual_path = os.path.join(data_dir, "manual_events.json")
         self.manual = read_json(self.manual_path, {"events": []}).get("events", [])
+
+    def _google_events(self):
+        return self.gsync.snapshot()[3] if self.gsync else []
 
     # --- manual event mutations (call under self.lock via public methods) ---
     def add_manual(self, ev):
@@ -134,42 +140,34 @@ class Store:
         self.publish()
 
     def list_events(self):
+        gevents = self._google_events()
         with self.lock:
-            return sorted(self._merged(), key=lambda e: e["start_utc"])
+            return sorted(list(self.manual) + gevents, key=lambda e: e["start_utc"])
 
     def _save_manual(self):
         atomic_write_json(self.manual_path, {"events": self.manual})
 
-    def _merged(self):
-        # Manual + Google (Google returns [] until that pass lands).
-        return list(self.manual) + load_google_events(self.cfg)
-
     # --- publish to the HUD-facing files ---
     def publish(self):
+        gstate, gcode, gurl = "disconnected", "", ""
+        gevents = []
+        if self.gsync:
+            gstate, gcode, gurl, gevents = self.gsync.snapshot()
         with self.lock:
-            events = sorted(self._merged(), key=lambda e: e["start_utc"])
+            events = sorted(list(self.manual) + gevents,
+                            key=lambda e: e["start_utc"])
         atomic_write_json(self.cfg["events_path"],
                           {"version": 1,
                            "generated_utc": int(time.time()),
                            "events": events})
         atomic_write_json(self.cfg["status_path"], {
             "web_url": f"http://{detect_ip()}:{self.cfg['web_port']}",
-            "gcal_state": google_state(self.cfg),
-            "gcal_user_code": "",
-            "gcal_verify_url": "",
+            "gcal_state": gstate,
+            "gcal_user_code": gcode,
+            "gcal_verify_url": gurl,
             "last_sync_utc": int(time.time()),
             "event_count": len(events),
         })
-
-
-# ── Google Calendar seam (implemented in a later pass) ───────────────────────────
-
-def google_state(cfg):
-    return "disconnected"
-
-
-def load_google_events(cfg):
-    return []
 
 
 # ── Time helpers ─────────────────────────────────────────────────────────────────
@@ -320,6 +318,13 @@ def heartbeat(store, period_s):
 def main():
     cfg = load_config()
     store = Store(cfg)
+
+    # Google Calendar is the second event source. It runs only when a
+    # client_secret.json is present; otherwise state stays "disconnected".
+    gsync = GoogleSync(cfg, on_change=store.publish)
+    store.gsync = gsync
+    gsync.start()
+
     store.publish()  # write initial events.json + status
 
     threading.Thread(target=heartbeat,

--- a/src/face/renderer.cpp
+++ b/src/face/renderer.cpp
@@ -29,9 +29,10 @@ cv::Mat apply_material(const cv::Mat& face_rgba, const cv::Mat& material_rgb) {
     m[2].convertTo(mb, CV_32F);
 
     cv::Mat cr, cg, cb;               // colour × luminance, saturate to 0..255
-    mr.mul(lum).convertTo(cr, CV_8U);
-    mg.mul(lum).convertTo(cg, CV_8U);
-    mb.mul(lum).convertTo(cb, CV_8U);
+    // mul() yields a cv::MatExpr (no convertTo); materialize to a Mat first.
+    cv::Mat(mr.mul(lum)).convertTo(cr, CV_8U);
+    cv::Mat(mg.mul(lum)).convertTo(cg, CV_8U);
+    cv::Mat(mb.mul(lum)).convertTo(cb, CV_8U);
 
     std::vector<cv::Mat> out{cr, cg, cb, f[3]};
     cv::Mat result;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -313,7 +313,13 @@ static std::vector<MenuItem> build_menu(
         std::string       map_dir         = "/home/user/Pictures/protohud/maps",
         // Eye source selection (render-thread only, no mutex needed)
         EyeSource* left_eye_src  = nullptr,
-        EyeSource* right_eye_src = nullptr)
+        EyeSource* right_eye_src = nullptr,
+        // USB camera live-preview wiring: GL texture handles sampled by the camera
+        // image-setting context panels, plus a per-frame "preview request" the
+        // panels set (1/2/3) so the render loop opens the stream, hides the
+        // on-screen PiP, and shows the feed in the context pane while adjusting.
+        GLuint* tex_usb1 = nullptr, GLuint* tex_usb2 = nullptr, GLuint* tex_usb3 = nullptr,
+        int*    usb_preview_req = nullptr)
 {
     (void)lora; (void)knob;
 
@@ -1132,6 +1138,90 @@ static std::vector<MenuItem> build_menu(
         };
     };
 
+    // Schematic preview of where / how big / which orientation the PiP sits on
+    // screen — like the Digital Zoom preview, no live feed (the real on-screen PiP
+    // already updates live as Position/Size/Rotation change).
+    auto make_pip_placement_panel = [menu_sys_pp](OverlayConfig* cfg) -> MenuContextPanelDraw {
+        return [cfg, menu_sys_pp](ImDrawList* dl, ImVec2 o, ImVec2 sz) {
+            const ImU32 accent = (menu_sys_pp && *menu_sys_pp)
+                ? (*menu_sys_pp)->accent_color() : IM_COL32(255, 255, 255, 255);
+            // 16:9 screen outline, letterboxed into the content rect (leave a text line).
+            const float availH = sz.y - 16.f;
+            float sw = sz.x, sh = availH;
+            const float screenAR = 16.f / 9.f;
+            if (sw / sh > screenAR) sw = sh * screenAR; else sh = sw / screenAR;
+            const ImVec2 smin{ o.x + (sz.x - sw) * 0.5f, o.y + (availH - sh) * 0.5f };
+            const ImVec2 smax{ smin.x + sw, smin.y + sh };
+            dl->AddRectFilled(smin, smax, IM_COL32(20, 25, 30, 180), 3.f);
+            dl->AddRect(smin, smax, IM_COL32(120, 130, 140, 200), 3.f, 0, 1.5f);
+            // PiP rect: height = size fraction of screen height; aspect by rotation.
+            const bool portrait = (cfg->rotation == OverlayConfig::Rotation::Portrait ||
+                                   cfg->rotation == OverlayConfig::Rotation::PortraitFlipped);
+            const float pratio = portrait ? (9.f / 16.f) : (16.f / 9.f);
+            float ph = sh * std::clamp(cfg->size, 0.05f, 1.0f);
+            float pw = ph * pratio;
+            if (pw > sw) { pw = sw; ph = pw / pratio; }
+            // anchor_x/y are the PiP centre fraction (matches hud_renderer); clamp inside.
+            float cx = smin.x + sw * cfg->anchor_x;
+            float cy = smin.y + sh * cfg->anchor_y;
+            ImVec2 pmin{ cx - pw * 0.5f, cy - ph * 0.5f };
+            pmin.x = std::clamp(pmin.x, smin.x, smax.x - pw);
+            pmin.y = std::clamp(pmin.y, smin.y, smax.y - ph);
+            const ImVec2 pmax{ pmin.x + pw, pmin.y + ph };
+            dl->AddRectFilled(pmin, pmax, (accent & 0x00FFFFFFu) | (60u << 24), 2.f);
+            dl->AddRect(pmin, pmax, (accent & 0x00FFFFFFu) | (235u << 24), 2.f, 0, 2.f);
+            char buf[64];
+            snprintf(buf, sizeof(buf), "Size %.0f%%   %s", cfg->size * 100.f,
+                     portrait ? "Portrait" : "Landscape");
+            dl->AddText({ o.x, o.y + sz.y - 14.f }, IM_COL32(200, 200, 200, 200), buf);
+        };
+    };
+
+    // Live-feed preview for the image settings (Brightness / Exposure / White
+    // Balance / Resolution).  Sets *usb_preview_req = cam while visible so the
+    // render loop opens the stream, hides the on-screen PiP, and keeps the texture
+    // uploaded; draws the actual frame plus an info line read from `info`.
+    auto make_usb_live_panel = [cameras, menu_sys_pp, usb_preview_req](
+            int cam, GLuint* tex,
+            std::function<std::string()> info) -> MenuContextPanelDraw {
+        return [cameras, menu_sys_pp, usb_preview_req, cam, tex, info]
+               (ImDrawList* dl, ImVec2 o, ImVec2 sz) {
+            if (usb_preview_req) *usb_preview_req = cam;
+            const ImU32 accent = (menu_sys_pp && *menu_sys_pp)
+                ? (*menu_sys_pp)->accent_color() : IM_COL32(255, 255, 255, 255);
+            // Feed area on top, two text lines reserved below.
+            const float textH = 34.f;
+            const ImVec2 fa_o{ o.x, o.y };
+            const ImVec2 fa_s{ sz.x, sz.y - textH };
+            float ar = 16.f / 9.f;
+            if (cameras) {
+                UsbCamConfig c = (cam == 1) ? cameras->usb1_cfg()
+                               : (cam == 2) ? cameras->usb2_cfg()
+                                            : cameras->usb3_cfg();
+                if (c.width > 0 && c.height > 0) ar = float(c.width) / float(c.height);
+            }
+            float fw = fa_s.x, fh = fa_s.y;
+            if (fw / fh > ar) fw = fh * ar; else fh = fw / ar;
+            const ImVec2 fmin{ fa_o.x + (fa_s.x - fw) * 0.5f, fa_o.y + (fa_s.y - fh) * 0.5f };
+            const ImVec2 fmax{ fmin.x + fw, fmin.y + fh };
+            const GLuint t = tex ? *tex : 0u;
+            if (t) {
+                dl->AddImage(reinterpret_cast<ImTextureID>(static_cast<uintptr_t>(t)),
+                             fmin, fmax);
+            } else {
+                dl->AddRectFilled(fmin, fmax, IM_COL32(20, 25, 30, 180), 3.f);
+                dl->AddText({ fmin.x + 8.f, fmin.y + 8.f },
+                            IM_COL32(200, 200, 200, 200), "Starting preview...");
+            }
+            dl->AddRect(fmin, fmax, (accent & 0x00FFFFFFu) | (235u << 24), 3.f, 0, 2.f);
+            if (info) {
+                const std::string s = info();
+                dl->AddText({ o.x, o.y + sz.y - textH + 2.f },
+                            IM_COL32(210, 210, 210, 220), s.c_str());
+            }
+        };
+    };
+
     // ── USB camera menus ──────────────────────────────────────────────────────
     // Helper: build a "Resolution" submenu for one USB camera slot.
     // If the stream is currently open, close it and reopen with the new dimensions.
@@ -1189,94 +1279,78 @@ static std::vector<MenuItem> build_menu(
         return items;
     };
 
-    std::vector<MenuItem> cam1_overlay_menu = {
-        toggle("Show Overlay",
-            [pip_cam1_overlay]{ return *pip_cam1_overlay; },
-            [pip_cam1_overlay](bool v){ *pip_cam1_overlay = v; }),
-        submenu("Position", make_position_items(pip_cfg1)),
-        make_size_slider("Size", pip_cfg1),
-        submenu("Rotation", make_rotation_items(pip_cfg1)),
+    std::vector<MenuItem> usb1_pip_menu = {
+        with_panel(submenu("Window Position", make_position_items(pip_cfg1)),
+                   "PiP Placement", make_pip_placement_panel(pip_cfg1)),
+        with_panel(submenu("Window Size", std::vector<MenuItem>{ make_size_slider("Size", pip_cfg1) }),
+                   "PiP Placement", make_pip_placement_panel(pip_cfg1)),
+        with_panel(submenu("Window Rotation", make_rotation_items(pip_cfg1)),
+                   "PiP Placement", make_pip_placement_panel(pip_cfg1)),
+        with_panel(submenu("Brightness", std::vector<MenuItem>{
+            toggle("Auto Brightness",
+                [cameras]{ return cameras && cameras->usb1_cfg().auto_brightness; },
+                [cameras](bool v){ if (!cameras) return; UsbCamConfig c = cameras->usb1_cfg(); c.auto_brightness = v; cameras->update_usb1_cfg(c); }),
+            slider("Auto Brightness Target", 40.f, 220.f, 5.f, "",
+                [cameras]{ return cameras ? cameras->usb1_cfg().auto_brightness_target : 100.f; },
+                [cameras](float v){ if (!cameras) return; UsbCamConfig c = cameras->usb1_cfg(); c.auto_brightness_target = v; cameras->update_usb1_cfg(c); }),
+            slider("Manual Brightness", 50.f, 300.f, 25.f, " %",
+                [cameras]{ return cameras ? cameras->usb1_brightness() * 100.f : 100.f; },
+                [cameras](float v){ if (cameras) cameras->set_usb1_brightness(v / 100.f); }),
+        }), "Brightness", make_usb_live_panel(1, tex_usb1, [cameras]{
+            if (!cameras) return std::string("Brightness");
+            UsbCamConfig c = cameras->usb1_cfg();
+            char b[96]; snprintf(b, sizeof(b), "Auto %s   Target %.0f\nManual %.0f%%",
+                c.auto_brightness ? "ON" : "OFF", c.auto_brightness_target, cameras->usb1_brightness() * 100.f);
+            return std::string(b);
+        })),
+        with_panel(submenu("Exposure", std::vector<MenuItem>{
+            toggle("Auto Exposure",
+                [cameras]{ return !cameras || cameras->usb1_cfg().auto_exposure; },
+                [cameras](bool v){ if (!cameras) return; UsbCamConfig c = cameras->usb1_cfg(); c.auto_exposure = v; cameras->update_usb1_cfg(c); cameras->set_usb1_ctrl(V4L2_CID_EXPOSURE_AUTO, v ? 3 : 1); }),
+            slider("Exposure Time", 1.f, 5000.f, 10.f, "",
+                [cameras]{ return cameras ? (float)cameras->usb1_cfg().exposure_time : 157.f; },
+                [cameras](float v){ if (!cameras) return; UsbCamConfig c = cameras->usb1_cfg(); c.exposure_time = (int)v; cameras->update_usb1_cfg(c); cameras->set_usb1_ctrl(V4L2_CID_EXPOSURE_ABSOLUTE, (int)v); }),
+        }), "Exposure", make_usb_live_panel(1, tex_usb1, [cameras]{
+            if (!cameras) return std::string("Exposure");
+            UsbCamConfig c = cameras->usb1_cfg();
+            char b[96]; snprintf(b, sizeof(b), "Auto %s\nTime %d", c.auto_exposure ? "ON" : "OFF", c.exposure_time);
+            return std::string(b);
+        })),
+        with_panel(submenu("White Balance", std::vector<MenuItem>{
+            toggle("Auto White Balance",
+                [cameras]{ return !cameras || cameras->usb1_cfg().auto_wb; },
+                [cameras](bool v){ if (!cameras) return; UsbCamConfig c = cameras->usb1_cfg(); c.auto_wb = v; cameras->update_usb1_cfg(c); cameras->set_usb1_ctrl(V4L2_CID_AUTO_WHITE_BALANCE, v ? 1 : 0); }),
+            slider("Manual White Balance", 2800.f, 6500.f, 100.f, "K",
+                [cameras]{ return cameras ? (float)cameras->usb1_cfg().wb_temp : 4600.f; },
+                [cameras](float v){ if (!cameras) return; UsbCamConfig c = cameras->usb1_cfg(); c.wb_temp = (int)v; cameras->update_usb1_cfg(c); cameras->set_usb1_ctrl(V4L2_CID_WHITE_BALANCE_TEMPERATURE, (int)v); }),
+        }), "White Balance", make_usb_live_panel(1, tex_usb1, [cameras]{
+            if (!cameras) return std::string("White Balance");
+            UsbCamConfig c = cameras->usb1_cfg();
+            char b[96]; snprintf(b, sizeof(b), "Auto %s\nTemp %dK", c.auto_wb ? "ON" : "OFF", c.wb_temp);
+            return std::string(b);
+        })),
+        with_panel(submenu("Resolution and Framerate", std::vector<MenuItem>{
+            submenu("Resolution", make_resolution_items(
+                [cameras]{ return cameras->usb1_cfg(); },
+                [cameras](UsbCamConfig c){ cameras->update_usb1_cfg(c); },
+                [cameras]{ return cameras && cameras->usb1_ok(); },
+                [cameras]{ cameras->close_usb1(); },
+                [cameras]{ cameras->open_usb1(); })),
+            toggle("Dynamic Framerate",
+                [cameras]{ return cameras && cameras->usb1_cfg().dynamic_framerate; },
+                [cameras](bool v){ if (!cameras) return; UsbCamConfig c = cameras->usb1_cfg(); c.dynamic_framerate = v; cameras->update_usb1_cfg(c); cameras->set_usb1_ctrl(V4L2_CID_EXPOSURE_AUTO_PRIORITY, v ? 1 : 0); }),
+        }), "Resolution", make_usb_live_panel(1, tex_usb1, [cameras]{
+            if (!cameras) return std::string("Resolution");
+            UsbCamConfig c = cameras->usb1_cfg();
+            char b[96]; snprintf(b, sizeof(b), "%dx%d\nDynamic FPS %s", c.width, c.height, c.dynamic_framerate ? "ON" : "OFF");
+            return std::string(b);
+        })),
     };
-    std::vector<MenuItem> usb1_brightness_menu = {
-        leaf_sel("50%",  [cameras]{ if (cameras) cameras->set_usb1_brightness(0.5f); }, [cameras]{ return cameras && cameras->usb1_brightness() == 0.5f; }),
-        leaf_sel("100%", [cameras]{ if (cameras) cameras->set_usb1_brightness(1.0f); }, [cameras]{ return cameras && cameras->usb1_brightness() == 1.0f; }),
-        leaf_sel("150%", [cameras]{ if (cameras) cameras->set_usb1_brightness(1.5f); }, [cameras]{ return cameras && cameras->usb1_brightness() == 1.5f; }),
-        leaf_sel("200%", [cameras]{ if (cameras) cameras->set_usb1_brightness(2.0f); }, [cameras]{ return cameras && cameras->usb1_brightness() == 2.0f; }),
-        leaf_sel("300%", [cameras]{ if (cameras) cameras->set_usb1_brightness(3.0f); }, [cameras]{ return cameras && cameras->usb1_brightness() == 3.0f; }),
-    };
-    std::vector<MenuItem> usb1_exposure_menu = {
-        toggle("Auto Exposure",
-            [cameras]{ return !cameras || cameras->usb1_cfg().auto_exposure; },
-            [cameras](bool v){
-                if (!cameras) return;
-                UsbCamConfig c = cameras->usb1_cfg(); c.auto_exposure = v;
-                cameras->update_usb1_cfg(c);
-                cameras->set_usb1_ctrl(V4L2_CID_EXPOSURE_AUTO, v ? 3 : 1);
-            }),
-        slider("Exposure Time", 1.f, 5000.f, 10.f, "",
-            [cameras]{ return cameras ? (float)cameras->usb1_cfg().exposure_time : 157.f; },
-            [cameras](float v){
-                if (!cameras) return;
-                UsbCamConfig c = cameras->usb1_cfg(); c.exposure_time = (int)v;
-                cameras->update_usb1_cfg(c);
-                cameras->set_usb1_ctrl(V4L2_CID_EXPOSURE_ABSOLUTE, (int)v);
-            }),
-        toggle("Auto White Balance",
-            [cameras]{ return !cameras || cameras->usb1_cfg().auto_wb; },
-            [cameras](bool v){
-                if (!cameras) return;
-                UsbCamConfig c = cameras->usb1_cfg(); c.auto_wb = v;
-                cameras->update_usb1_cfg(c);
-                cameras->set_usb1_ctrl(V4L2_CID_AUTO_WHITE_BALANCE, v ? 1 : 0);
-            }),
-        slider("WB Temperature", 2800.f, 6500.f, 100.f, "K",
-            [cameras]{ return cameras ? (float)cameras->usb1_cfg().wb_temp : 4600.f; },
-            [cameras](float v){
-                if (!cameras) return;
-                UsbCamConfig c = cameras->usb1_cfg(); c.wb_temp = (int)v;
-                cameras->update_usb1_cfg(c);
-                cameras->set_usb1_ctrl(V4L2_CID_WHITE_BALANCE_TEMPERATURE, (int)v);
-            }),
-        toggle("Dynamic Framerate",
-            [cameras]{ return cameras && cameras->usb1_cfg().dynamic_framerate; },
-            [cameras](bool v){
-                if (!cameras) return;
-                UsbCamConfig c = cameras->usb1_cfg(); c.dynamic_framerate = v;
-                cameras->update_usb1_cfg(c);
-                cameras->set_usb1_ctrl(V4L2_CID_EXPOSURE_AUTO_PRIORITY, v ? 1 : 0);
-            }),
-    };
-    std::vector<MenuItem> usb_cam1_menu = {
-        toggle("Open Stream",
-            [cameras]{ return cameras && cameras->usb1_ok(); },
-            [pip_cam1_overlay](bool v){ *pip_cam1_overlay = v; }),
-        submenu("Select Device", make_dev_select(
+    std::vector<MenuItem> usb1_device_menu = {
+        submenu("Device Select", make_dev_select(
             [cameras]{ return cameras ? cameras->usb1_cfg().device : ""; },
             [cameras](const std::string& p){ if (cameras) cameras->reassign_usb1(p); })),
-        toggle("Auto Brightness",
-            [cameras]{ return cameras && cameras->usb1_cfg().auto_brightness; },
-            [cameras](bool v){
-                if (!cameras) return;
-                UsbCamConfig c = cameras->usb1_cfg(); c.auto_brightness = v;
-                cameras->update_usb1_cfg(c);
-            }),
-        slider("Brightness Target", 40.f, 220.f, 5.f, "",
-            [cameras]{ return cameras ? cameras->usb1_cfg().auto_brightness_target : 100.f; },
-            [cameras](float v){
-                if (!cameras) return;
-                UsbCamConfig c = cameras->usb1_cfg(); c.auto_brightness_target = v;
-                cameras->update_usb1_cfg(c);
-            }),
-        submenu("Overlay",     std::move(cam1_overlay_menu)),
-        submenu("Brightness",  std::move(usb1_brightness_menu)),
-        submenu("Exposure",    std::move(usb1_exposure_menu)),
-        submenu("Resolution",  make_resolution_items(
-            [cameras]{ return cameras->usb1_cfg(); },
-            [cameras](UsbCamConfig c){ cameras->update_usb1_cfg(c); },
-            [cameras]{ return cameras && cameras->usb1_ok(); },
-            [cameras]{ cameras->close_usb1(); },
-            [cameras]{ cameras->open_usb1(); })),
-        leaf("Scan for Camera", [cameras, &state]{
+        leaf("Scan for Devices", [cameras, &state]{
             if (cameras) {
                 bool ok = cameras->scan_usb1();
                 std::lock_guard<std::mutex> lk(state.mtx);
@@ -1284,95 +1358,86 @@ static std::vector<MenuItem> build_menu(
             }
         }),
     };
+    std::vector<MenuItem> usb_cam1_menu = {
+        toggle("Open Camera",
+            [cameras]{ return cameras && cameras->usb1_ok(); },
+            [pip_cam1_overlay](bool v){ *pip_cam1_overlay = v; }),
+        submenu("PiP Window Settings", std::move(usb1_pip_menu)),
+        submenu("Device Options",      std::move(usb1_device_menu)),
+    };
 
-    std::vector<MenuItem> cam2_overlay_menu = {
-        toggle("Show Overlay",
-            [pip_cam2_overlay]{ return *pip_cam2_overlay; },
-            [pip_cam2_overlay](bool v){ *pip_cam2_overlay = v; }),
-        submenu("Position", make_position_items(pip_cfg2)),
-        make_size_slider("Size", pip_cfg2),
-        submenu("Rotation", make_rotation_items(pip_cfg2)),
+    std::vector<MenuItem> usb2_pip_menu = {
+        with_panel(submenu("Window Position", make_position_items(pip_cfg2)),
+                   "PiP Placement", make_pip_placement_panel(pip_cfg2)),
+        with_panel(submenu("Window Size", std::vector<MenuItem>{ make_size_slider("Size", pip_cfg2) }),
+                   "PiP Placement", make_pip_placement_panel(pip_cfg2)),
+        with_panel(submenu("Window Rotation", make_rotation_items(pip_cfg2)),
+                   "PiP Placement", make_pip_placement_panel(pip_cfg2)),
+        with_panel(submenu("Brightness", std::vector<MenuItem>{
+            toggle("Auto Brightness",
+                [cameras]{ return cameras && cameras->usb2_cfg().auto_brightness; },
+                [cameras](bool v){ if (!cameras) return; UsbCamConfig c = cameras->usb2_cfg(); c.auto_brightness = v; cameras->update_usb2_cfg(c); }),
+            slider("Auto Brightness Target", 40.f, 220.f, 5.f, "",
+                [cameras]{ return cameras ? cameras->usb2_cfg().auto_brightness_target : 100.f; },
+                [cameras](float v){ if (!cameras) return; UsbCamConfig c = cameras->usb2_cfg(); c.auto_brightness_target = v; cameras->update_usb2_cfg(c); }),
+            slider("Manual Brightness", 50.f, 300.f, 25.f, " %",
+                [cameras]{ return cameras ? cameras->usb2_brightness() * 100.f : 100.f; },
+                [cameras](float v){ if (cameras) cameras->set_usb2_brightness(v / 100.f); }),
+        }), "Brightness", make_usb_live_panel(2, tex_usb2, [cameras]{
+            if (!cameras) return std::string("Brightness");
+            UsbCamConfig c = cameras->usb2_cfg();
+            char b[96]; snprintf(b, sizeof(b), "Auto %s   Target %.0f\nManual %.0f%%",
+                c.auto_brightness ? "ON" : "OFF", c.auto_brightness_target, cameras->usb2_brightness() * 100.f);
+            return std::string(b);
+        })),
+        with_panel(submenu("Exposure", std::vector<MenuItem>{
+            toggle("Auto Exposure",
+                [cameras]{ return !cameras || cameras->usb2_cfg().auto_exposure; },
+                [cameras](bool v){ if (!cameras) return; UsbCamConfig c = cameras->usb2_cfg(); c.auto_exposure = v; cameras->update_usb2_cfg(c); cameras->set_usb2_ctrl(V4L2_CID_EXPOSURE_AUTO, v ? 3 : 1); }),
+            slider("Exposure Time", 1.f, 5000.f, 10.f, "",
+                [cameras]{ return cameras ? (float)cameras->usb2_cfg().exposure_time : 157.f; },
+                [cameras](float v){ if (!cameras) return; UsbCamConfig c = cameras->usb2_cfg(); c.exposure_time = (int)v; cameras->update_usb2_cfg(c); cameras->set_usb2_ctrl(V4L2_CID_EXPOSURE_ABSOLUTE, (int)v); }),
+        }), "Exposure", make_usb_live_panel(2, tex_usb2, [cameras]{
+            if (!cameras) return std::string("Exposure");
+            UsbCamConfig c = cameras->usb2_cfg();
+            char b[96]; snprintf(b, sizeof(b), "Auto %s\nTime %d", c.auto_exposure ? "ON" : "OFF", c.exposure_time);
+            return std::string(b);
+        })),
+        with_panel(submenu("White Balance", std::vector<MenuItem>{
+            toggle("Auto White Balance",
+                [cameras]{ return !cameras || cameras->usb2_cfg().auto_wb; },
+                [cameras](bool v){ if (!cameras) return; UsbCamConfig c = cameras->usb2_cfg(); c.auto_wb = v; cameras->update_usb2_cfg(c); cameras->set_usb2_ctrl(V4L2_CID_AUTO_WHITE_BALANCE, v ? 1 : 0); }),
+            slider("Manual White Balance", 2800.f, 6500.f, 100.f, "K",
+                [cameras]{ return cameras ? (float)cameras->usb2_cfg().wb_temp : 4600.f; },
+                [cameras](float v){ if (!cameras) return; UsbCamConfig c = cameras->usb2_cfg(); c.wb_temp = (int)v; cameras->update_usb2_cfg(c); cameras->set_usb2_ctrl(V4L2_CID_WHITE_BALANCE_TEMPERATURE, (int)v); }),
+        }), "White Balance", make_usb_live_panel(2, tex_usb2, [cameras]{
+            if (!cameras) return std::string("White Balance");
+            UsbCamConfig c = cameras->usb2_cfg();
+            char b[96]; snprintf(b, sizeof(b), "Auto %s\nTemp %dK", c.auto_wb ? "ON" : "OFF", c.wb_temp);
+            return std::string(b);
+        })),
+        with_panel(submenu("Resolution and Framerate", std::vector<MenuItem>{
+            submenu("Resolution", make_resolution_items(
+                [cameras]{ return cameras->usb2_cfg(); },
+                [cameras](UsbCamConfig c){ cameras->update_usb2_cfg(c); },
+                [cameras]{ return cameras && cameras->usb2_ok(); },
+                [cameras]{ cameras->close_usb2(); },
+                [cameras]{ cameras->open_usb2(); })),
+            toggle("Dynamic Framerate",
+                [cameras]{ return cameras && cameras->usb2_cfg().dynamic_framerate; },
+                [cameras](bool v){ if (!cameras) return; UsbCamConfig c = cameras->usb2_cfg(); c.dynamic_framerate = v; cameras->update_usb2_cfg(c); cameras->set_usb2_ctrl(V4L2_CID_EXPOSURE_AUTO_PRIORITY, v ? 1 : 0); }),
+        }), "Resolution", make_usb_live_panel(2, tex_usb2, [cameras]{
+            if (!cameras) return std::string("Resolution");
+            UsbCamConfig c = cameras->usb2_cfg();
+            char b[96]; snprintf(b, sizeof(b), "%dx%d\nDynamic FPS %s", c.width, c.height, c.dynamic_framerate ? "ON" : "OFF");
+            return std::string(b);
+        })),
     };
-    std::vector<MenuItem> usb2_brightness_menu = {
-        leaf_sel("50%",  [cameras]{ if (cameras) cameras->set_usb2_brightness(0.5f); }, [cameras]{ return cameras && cameras->usb2_brightness() == 0.5f; }),
-        leaf_sel("100%", [cameras]{ if (cameras) cameras->set_usb2_brightness(1.0f); }, [cameras]{ return cameras && cameras->usb2_brightness() == 1.0f; }),
-        leaf_sel("150%", [cameras]{ if (cameras) cameras->set_usb2_brightness(1.5f); }, [cameras]{ return cameras && cameras->usb2_brightness() == 1.5f; }),
-        leaf_sel("200%", [cameras]{ if (cameras) cameras->set_usb2_brightness(2.0f); }, [cameras]{ return cameras && cameras->usb2_brightness() == 2.0f; }),
-        leaf_sel("300%", [cameras]{ if (cameras) cameras->set_usb2_brightness(3.0f); }, [cameras]{ return cameras && cameras->usb2_brightness() == 3.0f; }),
-    };
-    std::vector<MenuItem> usb2_exposure_menu = {
-        toggle("Auto Exposure",
-            [cameras]{ return !cameras || cameras->usb2_cfg().auto_exposure; },
-            [cameras](bool v){
-                if (!cameras) return;
-                UsbCamConfig c = cameras->usb2_cfg(); c.auto_exposure = v;
-                cameras->update_usb2_cfg(c);
-                cameras->set_usb2_ctrl(V4L2_CID_EXPOSURE_AUTO, v ? 3 : 1);
-            }),
-        slider("Exposure Time", 1.f, 5000.f, 10.f, "",
-            [cameras]{ return cameras ? (float)cameras->usb2_cfg().exposure_time : 157.f; },
-            [cameras](float v){
-                if (!cameras) return;
-                UsbCamConfig c = cameras->usb2_cfg(); c.exposure_time = (int)v;
-                cameras->update_usb2_cfg(c);
-                cameras->set_usb2_ctrl(V4L2_CID_EXPOSURE_ABSOLUTE, (int)v);
-            }),
-        toggle("Auto White Balance",
-            [cameras]{ return !cameras || cameras->usb2_cfg().auto_wb; },
-            [cameras](bool v){
-                if (!cameras) return;
-                UsbCamConfig c = cameras->usb2_cfg(); c.auto_wb = v;
-                cameras->update_usb2_cfg(c);
-                cameras->set_usb2_ctrl(V4L2_CID_AUTO_WHITE_BALANCE, v ? 1 : 0);
-            }),
-        slider("WB Temperature", 2800.f, 6500.f, 100.f, "K",
-            [cameras]{ return cameras ? (float)cameras->usb2_cfg().wb_temp : 4600.f; },
-            [cameras](float v){
-                if (!cameras) return;
-                UsbCamConfig c = cameras->usb2_cfg(); c.wb_temp = (int)v;
-                cameras->update_usb2_cfg(c);
-                cameras->set_usb2_ctrl(V4L2_CID_WHITE_BALANCE_TEMPERATURE, (int)v);
-            }),
-        toggle("Dynamic Framerate",
-            [cameras]{ return cameras && cameras->usb2_cfg().dynamic_framerate; },
-            [cameras](bool v){
-                if (!cameras) return;
-                UsbCamConfig c = cameras->usb2_cfg(); c.dynamic_framerate = v;
-                cameras->update_usb2_cfg(c);
-                cameras->set_usb2_ctrl(V4L2_CID_EXPOSURE_AUTO_PRIORITY, v ? 1 : 0);
-            }),
-    };
-    std::vector<MenuItem> usb_cam2_menu = {
-        toggle("Open Stream",
-            [cameras]{ return cameras && cameras->usb2_ok(); },
-            [pip_cam2_overlay](bool v){ *pip_cam2_overlay = v; }),
-        submenu("Select Device", make_dev_select(
+    std::vector<MenuItem> usb2_device_menu = {
+        submenu("Device Select", make_dev_select(
             [cameras]{ return cameras ? cameras->usb2_cfg().device : ""; },
             [cameras](const std::string& p){ if (cameras) cameras->reassign_usb2(p); })),
-        toggle("Auto Brightness",
-            [cameras]{ return cameras && cameras->usb2_cfg().auto_brightness; },
-            [cameras](bool v){
-                if (!cameras) return;
-                UsbCamConfig c = cameras->usb2_cfg(); c.auto_brightness = v;
-                cameras->update_usb2_cfg(c);
-            }),
-        slider("Brightness Target", 40.f, 220.f, 5.f, "",
-            [cameras]{ return cameras ? cameras->usb2_cfg().auto_brightness_target : 100.f; },
-            [cameras](float v){
-                if (!cameras) return;
-                UsbCamConfig c = cameras->usb2_cfg(); c.auto_brightness_target = v;
-                cameras->update_usb2_cfg(c);
-            }),
-        submenu("Overlay",    std::move(cam2_overlay_menu)),
-        submenu("Brightness", std::move(usb2_brightness_menu)),
-        submenu("Exposure",   std::move(usb2_exposure_menu)),
-        submenu("Resolution", make_resolution_items(
-            [cameras]{ return cameras->usb2_cfg(); },
-            [cameras](UsbCamConfig c){ cameras->update_usb2_cfg(c); },
-            [cameras]{ return cameras && cameras->usb2_ok(); },
-            [cameras]{ cameras->close_usb2(); },
-            [cameras]{ cameras->open_usb2(); })),
-        leaf("Scan for Camera", [cameras, &state]{
+        leaf("Scan for Devices", [cameras, &state]{
             if (cameras) {
                 bool ok = cameras->scan_usb2();
                 std::lock_guard<std::mutex> lk(state.mtx);
@@ -1380,101 +1445,99 @@ static std::vector<MenuItem> build_menu(
             }
         }),
     };
+    std::vector<MenuItem> usb_cam2_menu = {
+        toggle("Open Camera",
+            [cameras]{ return cameras && cameras->usb2_ok(); },
+            [pip_cam2_overlay](bool v){ *pip_cam2_overlay = v; }),
+        submenu("PiP Window Settings", std::move(usb2_pip_menu)),
+        submenu("Device Options",      std::move(usb2_device_menu)),
+    };
 
-    std::vector<MenuItem> cam3_overlay_menu = {
-        toggle("Show Overlay",
-            [pip_cam3_overlay]{ return *pip_cam3_overlay; },
-            [pip_cam3_overlay](bool v){ *pip_cam3_overlay = v; }),
-        submenu("Position", make_position_items(pip_cfg3)),
-        make_size_slider("Size", pip_cfg3),
-        submenu("Rotation", make_rotation_items(pip_cfg3)),
+    std::vector<MenuItem> usb3_pip_menu = {
+        with_panel(submenu("Window Position", make_position_items(pip_cfg3)),
+                   "PiP Placement", make_pip_placement_panel(pip_cfg3)),
+        with_panel(submenu("Window Size", std::vector<MenuItem>{ make_size_slider("Size", pip_cfg3) }),
+                   "PiP Placement", make_pip_placement_panel(pip_cfg3)),
+        with_panel(submenu("Window Rotation", make_rotation_items(pip_cfg3)),
+                   "PiP Placement", make_pip_placement_panel(pip_cfg3)),
+        with_panel(submenu("Brightness", std::vector<MenuItem>{
+            toggle("Auto Brightness",
+                [cameras]{ return cameras && cameras->usb3_cfg().auto_brightness; },
+                [cameras](bool v){ if (!cameras) return; UsbCamConfig c = cameras->usb3_cfg(); c.auto_brightness = v; cameras->update_usb3_cfg(c); }),
+            slider("Auto Brightness Target", 40.f, 220.f, 5.f, "",
+                [cameras]{ return cameras ? cameras->usb3_cfg().auto_brightness_target : 100.f; },
+                [cameras](float v){ if (!cameras) return; UsbCamConfig c = cameras->usb3_cfg(); c.auto_brightness_target = v; cameras->update_usb3_cfg(c); }),
+            slider("Manual Brightness", 50.f, 300.f, 25.f, " %",
+                [cameras]{ return cameras ? cameras->usb3_brightness() * 100.f : 100.f; },
+                [cameras](float v){ if (cameras) cameras->set_usb3_brightness(v / 100.f); }),
+        }), "Brightness", make_usb_live_panel(3, tex_usb3, [cameras]{
+            if (!cameras) return std::string("Brightness");
+            UsbCamConfig c = cameras->usb3_cfg();
+            char b[96]; snprintf(b, sizeof(b), "Auto %s   Target %.0f\nManual %.0f%%",
+                c.auto_brightness ? "ON" : "OFF", c.auto_brightness_target, cameras->usb3_brightness() * 100.f);
+            return std::string(b);
+        })),
+        with_panel(submenu("Exposure", std::vector<MenuItem>{
+            toggle("Auto Exposure",
+                [cameras]{ return !cameras || cameras->usb3_cfg().auto_exposure; },
+                [cameras](bool v){ if (!cameras) return; UsbCamConfig c = cameras->usb3_cfg(); c.auto_exposure = v; cameras->update_usb3_cfg(c); cameras->set_usb3_ctrl(V4L2_CID_EXPOSURE_AUTO, v ? 3 : 1); }),
+            slider("Exposure Time", 1.f, 5000.f, 10.f, "",
+                [cameras]{ return cameras ? (float)cameras->usb3_cfg().exposure_time : 157.f; },
+                [cameras](float v){ if (!cameras) return; UsbCamConfig c = cameras->usb3_cfg(); c.exposure_time = (int)v; cameras->update_usb3_cfg(c); cameras->set_usb3_ctrl(V4L2_CID_EXPOSURE_ABSOLUTE, (int)v); }),
+        }), "Exposure", make_usb_live_panel(3, tex_usb3, [cameras]{
+            if (!cameras) return std::string("Exposure");
+            UsbCamConfig c = cameras->usb3_cfg();
+            char b[96]; snprintf(b, sizeof(b), "Auto %s\nTime %d", c.auto_exposure ? "ON" : "OFF", c.exposure_time);
+            return std::string(b);
+        })),
+        with_panel(submenu("White Balance", std::vector<MenuItem>{
+            toggle("Auto White Balance",
+                [cameras]{ return !cameras || cameras->usb3_cfg().auto_wb; },
+                [cameras](bool v){ if (!cameras) return; UsbCamConfig c = cameras->usb3_cfg(); c.auto_wb = v; cameras->update_usb3_cfg(c); cameras->set_usb3_ctrl(V4L2_CID_AUTO_WHITE_BALANCE, v ? 1 : 0); }),
+            slider("Manual White Balance", 2800.f, 6500.f, 100.f, "K",
+                [cameras]{ return cameras ? (float)cameras->usb3_cfg().wb_temp : 4600.f; },
+                [cameras](float v){ if (!cameras) return; UsbCamConfig c = cameras->usb3_cfg(); c.wb_temp = (int)v; cameras->update_usb3_cfg(c); cameras->set_usb3_ctrl(V4L2_CID_WHITE_BALANCE_TEMPERATURE, (int)v); }),
+        }), "White Balance", make_usb_live_panel(3, tex_usb3, [cameras]{
+            if (!cameras) return std::string("White Balance");
+            UsbCamConfig c = cameras->usb3_cfg();
+            char b[96]; snprintf(b, sizeof(b), "Auto %s\nTemp %dK", c.auto_wb ? "ON" : "OFF", c.wb_temp);
+            return std::string(b);
+        })),
+        with_panel(submenu("Resolution and Framerate", std::vector<MenuItem>{
+            submenu("Resolution", make_resolution_items(
+                [cameras]{ return cameras->usb3_cfg(); },
+                [cameras](UsbCamConfig c){ cameras->update_usb3_cfg(c); },
+                [cameras]{ return cameras && cameras->usb3_ok(); },
+                [cameras]{ cameras->close_usb3(); },
+                [cameras]{ cameras->open_usb3(); })),
+            toggle("Dynamic Framerate",
+                [cameras]{ return cameras && cameras->usb3_cfg().dynamic_framerate; },
+                [cameras](bool v){ if (!cameras) return; UsbCamConfig c = cameras->usb3_cfg(); c.dynamic_framerate = v; cameras->update_usb3_cfg(c); cameras->set_usb3_ctrl(V4L2_CID_EXPOSURE_AUTO_PRIORITY, v ? 1 : 0); }),
+        }), "Resolution", make_usb_live_panel(3, tex_usb3, [cameras]{
+            if (!cameras) return std::string("Resolution");
+            UsbCamConfig c = cameras->usb3_cfg();
+            char b[96]; snprintf(b, sizeof(b), "%dx%d\nDynamic FPS %s", c.width, c.height, c.dynamic_framerate ? "ON" : "OFF");
+            return std::string(b);
+        })),
     };
-    std::vector<MenuItem> usb3_brightness_menu = {
-        leaf_sel("50%",  [cameras]{ if (cameras) cameras->set_usb3_brightness(0.5f); }, [cameras]{ return cameras && cameras->usb3_brightness() == 0.5f; }),
-        leaf_sel("100%", [cameras]{ if (cameras) cameras->set_usb3_brightness(1.0f); }, [cameras]{ return cameras && cameras->usb3_brightness() == 1.0f; }),
-        leaf_sel("150%", [cameras]{ if (cameras) cameras->set_usb3_brightness(1.5f); }, [cameras]{ return cameras && cameras->usb3_brightness() == 1.5f; }),
-        leaf_sel("200%", [cameras]{ if (cameras) cameras->set_usb3_brightness(2.0f); }, [cameras]{ return cameras && cameras->usb3_brightness() == 2.0f; }),
-        leaf_sel("300%", [cameras]{ if (cameras) cameras->set_usb3_brightness(3.0f); }, [cameras]{ return cameras && cameras->usb3_brightness() == 3.0f; }),
-    };
-    std::vector<MenuItem> usb3_exposure_menu = {
-        toggle("Auto Exposure",
-            [cameras]{ return !cameras || cameras->usb3_cfg().auto_exposure; },
-            [cameras](bool v){
-                if (!cameras) return;
-                UsbCamConfig c = cameras->usb3_cfg(); c.auto_exposure = v;
-                cameras->update_usb3_cfg(c);
-                cameras->set_usb3_ctrl(V4L2_CID_EXPOSURE_AUTO, v ? 3 : 1);
-            }),
-        slider("Exposure Time", 1.f, 5000.f, 10.f, "",
-            [cameras]{ return cameras ? (float)cameras->usb3_cfg().exposure_time : 157.f; },
-            [cameras](float v){
-                if (!cameras) return;
-                UsbCamConfig c = cameras->usb3_cfg(); c.exposure_time = (int)v;
-                cameras->update_usb3_cfg(c);
-                cameras->set_usb3_ctrl(V4L2_CID_EXPOSURE_ABSOLUTE, (int)v);
-            }),
-        toggle("Auto White Balance",
-            [cameras]{ return !cameras || cameras->usb3_cfg().auto_wb; },
-            [cameras](bool v){
-                if (!cameras) return;
-                UsbCamConfig c = cameras->usb3_cfg(); c.auto_wb = v;
-                cameras->update_usb3_cfg(c);
-                cameras->set_usb3_ctrl(V4L2_CID_AUTO_WHITE_BALANCE, v ? 1 : 0);
-            }),
-        slider("WB Temperature", 2800.f, 6500.f, 100.f, "K",
-            [cameras]{ return cameras ? (float)cameras->usb3_cfg().wb_temp : 4600.f; },
-            [cameras](float v){
-                if (!cameras) return;
-                UsbCamConfig c = cameras->usb3_cfg(); c.wb_temp = (int)v;
-                cameras->update_usb3_cfg(c);
-                cameras->set_usb3_ctrl(V4L2_CID_WHITE_BALANCE_TEMPERATURE, (int)v);
-            }),
-        toggle("Dynamic Framerate",
-            [cameras]{ return cameras && cameras->usb3_cfg().dynamic_framerate; },
-            [cameras](bool v){
-                if (!cameras) return;
-                UsbCamConfig c = cameras->usb3_cfg(); c.dynamic_framerate = v;
-                cameras->update_usb3_cfg(c);
-                cameras->set_usb3_ctrl(V4L2_CID_EXPOSURE_AUTO_PRIORITY, v ? 1 : 0);
-            }),
-    };
-    std::vector<MenuItem> usb_cam3_menu = {
-        toggle("Open Stream",
-            [cameras]{ return cameras && cameras->usb3_ok(); },
-            [pip_cam3_overlay](bool v){ *pip_cam3_overlay = v; }),
-        submenu("Select Device", make_dev_select(
+    std::vector<MenuItem> usb3_device_menu = {
+        submenu("Device Select", make_dev_select(
             [cameras]{ return cameras ? cameras->usb3_cfg().device : ""; },
             [cameras](const std::string& p){ if (cameras) cameras->reassign_usb3(p); })),
-        toggle("Auto Brightness",
-            [cameras]{ return cameras && cameras->usb3_cfg().auto_brightness; },
-            [cameras](bool v){
-                if (!cameras) return;
-                UsbCamConfig c = cameras->usb3_cfg(); c.auto_brightness = v;
-                cameras->update_usb3_cfg(c);
-            }),
-        slider("Brightness Target", 40.f, 220.f, 5.f, "",
-            [cameras]{ return cameras ? cameras->usb3_cfg().auto_brightness_target : 100.f; },
-            [cameras](float v){
-                if (!cameras) return;
-                UsbCamConfig c = cameras->usb3_cfg(); c.auto_brightness_target = v;
-                cameras->update_usb3_cfg(c);
-            }),
-        submenu("Overlay",     std::move(cam3_overlay_menu)),
-        submenu("Brightness",  std::move(usb3_brightness_menu)),
-        submenu("Exposure",    std::move(usb3_exposure_menu)),
-        submenu("Resolution",  make_resolution_items(
-            [cameras]{ return cameras->usb3_cfg(); },
-            [cameras](UsbCamConfig c){ cameras->update_usb3_cfg(c); },
-            [cameras]{ return cameras && cameras->usb3_ok(); },
-            [cameras]{ cameras->close_usb3(); },
-            [cameras]{ cameras->open_usb3(); })),
-        leaf("Scan for Camera", [cameras, &state]{
+        leaf("Scan for Devices", [cameras, &state]{
             if (cameras) {
                 bool ok = cameras->scan_usb3();
                 std::lock_guard<std::mutex> lk(state.mtx);
                 state.health.cam_usb3 = ok;
             }
         }),
+    };
+    std::vector<MenuItem> usb_cam3_menu = {
+        toggle("Open Camera",
+            [cameras]{ return cameras && cameras->usb3_ok(); },
+            [pip_cam3_overlay](bool v){ *pip_cam3_overlay = v; }),
+        submenu("PiP Window Settings", std::move(usb3_pip_menu)),
+        submenu("Device Options",      std::move(usb3_device_menu)),
     };
 
     // Build USB cam submenu items with visibility predicates so slots without a
@@ -1504,16 +1567,6 @@ static std::vector<MenuItem> build_menu(
                 cameras->set_usb2_reconnect(v);
                 cameras->set_usb3_reconnect(v);
             }),
-        leaf("Scan for Cameras", [cameras, &state]{
-            if (!cameras) return;
-            bool ok1 = cameras->scan_usb1();
-            bool ok2 = cameras->scan_usb2();
-            bool ok3 = cameras->scan_usb3();
-            std::lock_guard<std::mutex> lk(state.mtx);
-            state.health.cam_usb1 = ok1;
-            state.health.cam_usb2 = ok2;
-            state.health.cam_usb3 = ok3;
-        }),
     };
 
     std::vector<MenuItem> cameras_menu = {
@@ -3739,6 +3792,11 @@ int main(int argc, char* argv[]) {
     // into MenuSystem without a circular dependency at build time.
     bool panel_preview_enabled = false;
     MenuSystem* menu_ptr = nullptr;
+    // GL texture handles for USB camera sources — declared before build_menu so the
+    // camera image-setting context panels can sample the live feed.  usb_preview_req
+    // is set by those panels (1/2/3) and consumed by the render loop below.
+    GLuint tex_usb1 = 0, tex_usb2 = 0, tex_usb3 = 0;
+    int    usb_preview_req = 0;
     MenuSystem menu(build_menu(&face_proxy, &xr, &cameras, &lora, &knob, &audio, state,
                                &android_mirror, &android_overlay_active,
                                &pip_overlay_cfg1, &pip_overlay_cfg2, &pip_overlay_cfg3,
@@ -3754,7 +3812,8 @@ int main(int argc, char* argv[]) {
                                &protoface_preview_cfg,
                                &protoface_preview_view,
                                cfg_map_dir,
-                               &left_eye_src, &right_eye_src));
+                               &left_eye_src, &right_eye_src,
+                               &tex_usb1, &tex_usb2, &tex_usb3, &usb_preview_req));
     menu_ptr = &menu;
 
     // Wire wireless controller callbacks now that menu exists
@@ -3954,10 +4013,8 @@ int main(int argc, char* argv[]) {
     });
 
     // ── GL texture handles for camera sources ─────────────────────────────────
+    // tex_usb1/2/3 and usb_preview_req are declared above (before build_menu).
 
-    GLuint tex_usb1  = 0;
-    GLuint tex_usb2  = 0;
-    GLuint tex_usb3  = 0;
     GLuint tex_beast = 0;
 
     teensy.request_status();
@@ -4157,22 +4214,32 @@ int main(int argc, char* argv[]) {
         // ── USB camera stream lifecycle ───────────────────────────────────────
         // Rising edge  → open stream in background (window appears on first frame).
         // Falling edge → close stream, clear texture (no stale frame on re-open).
+        // A camera image-setting panel (Brightness/Exposure/WB/Resolution) sets
+        // usb_preview_req to its slot while visible; that forces the stream open and
+        // keeps the texture uploaded (want_n), and hides the on-screen PiP for that
+        // slot so the feed shows only in the context pane.  On exit the request
+        // clears, restoring the PiP if it was on or closing a temp-opened stream.
+        int preview = usb_preview_req;   // set during last frame's menu draw
+        usb_preview_req = 0;             // re-set this frame if a panel is still up
         bool p1 = pip_cam1_overlay_active || pip_left_active  || kb_pip_left  || wc_pip_left;
         bool p2 = pip_cam2_overlay_active || pip_right_active || kb_pip_right || wc_pip_right;
         bool p3 = pip_cam3_overlay_active;
-        if (p1 && !prev_p1) { tex_usb1 = 0; std::thread([&cameras]{ cameras.open_usb1(); }).detach(); }
-        if (!p1 && prev_p1) { cameras.close_usb1(); tex_usb1 = 0; }
-        if (p2 && !prev_p2) { tex_usb2 = 0; std::thread([&cameras]{ cameras.open_usb2(); }).detach(); }
-        if (!p2 && prev_p2) { cameras.close_usb2(); tex_usb2 = 0; }
-        if (p3 && !prev_p3) { tex_usb3 = 0; std::thread([&cameras]{ cameras.open_usb3(); }).detach(); }
-        if (!p3 && prev_p3) { cameras.close_usb3(); tex_usb3 = 0; }
-        prev_p1 = p1; prev_p2 = p2; prev_p3 = p3;
+        bool want1 = p1 || preview == 1;
+        bool want2 = p2 || preview == 2;
+        bool want3 = p3 || preview == 3;
+        if (want1 && !prev_p1) { tex_usb1 = 0; std::thread([&cameras]{ cameras.open_usb1(); }).detach(); }
+        if (!want1 && prev_p1) { cameras.close_usb1(); tex_usb1 = 0; }
+        if (want2 && !prev_p2) { tex_usb2 = 0; std::thread([&cameras]{ cameras.open_usb2(); }).detach(); }
+        if (!want2 && prev_p2) { cameras.close_usb2(); tex_usb2 = 0; }
+        if (want3 && !prev_p3) { tex_usb3 = 0; std::thread([&cameras]{ cameras.open_usb3(); }).detach(); }
+        if (!want3 && prev_p3) { cameras.close_usb3(); tex_usb3 = 0; }
+        prev_p1 = want1; prev_p2 = want2; prev_p3 = want3;
 
         // ── Camera texture uploads (CPU paths) ────────────────────────────────
         if (use_beast_cam) beast_cam.get_frame(tex_beast);
-        if (p1) cameras.get_usb1(tex_usb1);
-        if (p2) cameras.get_usb2(tex_usb2);
-        if (p3) cameras.get_usb3(tex_usb3);
+        if (want1) cameras.get_usb1(tex_usb1);
+        if (want2) cameras.get_usb2(tex_usb2);
+        if (want3) cameras.get_usb3(tex_usb3);
         android_mirror.get_frame(tex_android);
 
         // ── GPIO PiP button state ─────────────────────────────────────────────
@@ -4783,9 +4850,11 @@ int main(int argc, char* argv[]) {
         // Pass full display dimensions so NanoVG covers both eye halves.
         glViewport(0, 0, xr.display_width(), xr.display_height());
         hud.begin_nvg_overlay(xr.display_width(), xr.display_height());
-        hud.draw_pip_underlays(tex_usb1, p1, pip_overlay_cfg1,
-                               tex_usb2, p2, pip_overlay_cfg2,
-                               tex_usb3, p3, pip_overlay_cfg3,
+        // Hide the on-screen PiP for a slot whose live-preview panel is up — its
+        // feed is shown in the context pane instead (preview set above this frame).
+        hud.draw_pip_underlays(tex_usb1, p1 && preview != 1, pip_overlay_cfg1,
+                               tex_usb2, p2 && preview != 2, pip_overlay_cfg2,
+                               tex_usb3, p3 && preview != 3, pip_overlay_cfg3,
                                xr.display_width(), xr.display_height());
         hud.draw_hud_frame(snap, xr.display_width(), xr.display_height(), fps_overlay_active);
         hud.draw_toasts(state.notifs, xr.display_width(), xr.display_height());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4882,6 +4882,8 @@ int main(int argc, char* argv[]) {
         cfg["protoface"]["preview"]["size"]     = protoface_preview_cfg.size;
         cfg["protoface"]["preview"]["view"]     = protoface_preview_view;
 
+        cfg["scheduler"]["enabled"]             = sched_enabled;
+        cfg["scheduler"]["autostart"]           = sched_autostart;
         cfg["scheduler"]["lead_minutes"]        = state.scheduler_lead_min;
 
         auto& jpp = cfg["post_process"];

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3118,6 +3118,7 @@ int main(int argc, char* argv[]) {
     bool        sched_enabled    = true;
     bool        sched_autostart  = false;
     int         sched_poll_s     = 20;
+    int         sched_lead_min   = 10;   // applied to state once it exists (below)
     std::string sched_events_path =
         "/home/user/.local/share/protohud-scheduler/events.json";
     std::string sched_status_path =
@@ -3129,7 +3130,7 @@ int main(int argc, char* argv[]) {
         sched_poll_s      = jval(jsc, "poll_interval_s", sched_poll_s);
         sched_events_path = jval(jsc, "events_path",     sched_events_path);
         sched_status_path = jval(jsc, "status_path",     sched_status_path);
-        state.scheduler_lead_min = jval(jsc, "lead_minutes", state.scheduler_lead_min);
+        sched_lead_min    = jval(jsc, "lead_minutes",    sched_lead_min);
     }
 
     if (cfg.contains("pip")) {
@@ -3182,6 +3183,7 @@ int main(int argc, char* argv[]) {
     AppState state;
     state.max_messages        = jval(jhud, "lora_message_history", 50);
     state.compass_bg_enabled  = jhud.value("compass_bg", true);
+    state.scheduler_lead_min  = sched_lead_min;
 
     if (jhud.contains("effects")) {
         auto& jfx = jhud["effects"];

--- a/src/sys/scheduler_monitor.cpp
+++ b/src/sys/scheduler_monitor.cpp
@@ -7,6 +7,7 @@
 #include <fstream>
 #include <sys/stat.h>
 #include <thread>
+#include <utility>
 
 #include <nlohmann/json.hpp>
 


### PR DESCRIPTION
## Summary
- Restructure each USB camera slot into **Open Camera / PiP Window Settings / Device Options**, with the seven PiP settings (Position, Size, Rotation, Brightness, Exposure, White Balance, Resolution & Framerate) attached to context-overlay panels.
- Position/Size/Rotation get a schematic placement preview; Brightness/Exposure/White Balance/Resolution show the actual live camera feed in the context pane while the on-screen PiP is hidden. Entering one of those panels temp-opens the stream if needed and closes it on exit.
- Manual Brightness is now a 50–300 % slider in 25 % steps; White Balance and Dynamic Framerate split out of the old Exposure submenu. The redundant global "Scan for Cameras" is dropped (each slot has its own Scan for Devices under Device Options); Auto-Reconnect is unchanged.

Also bundles earlier scheduler fixes already on this branch (Google Calendar OAuth device flow, persist enabled/autostart, lead_minutes ordering, MatExpr materialize build fix).

## Test plan
- [ ] Build with CMake; no warnings from `build_menu` signature / call-site changes.
- [ ] Deep menu → Cameras → USB Cameras → USB Cam 1 shows the three new groups; no global Scan for Cameras leaf; Auto-Reconnect still present.
- [ ] Window Position/Size/Rotation: schematic panel updates with the value and the on-screen PiP also moves/resizes/rotates.
- [ ] Brightness/Exposure/White Balance/Resolution: opening the panel hides the on-screen PiP and shows the live feed in the context pane; adjusting a slider visibly changes the feed; Manual Brightness steps 50 → 300 in 25 % increments.
- [ ] Camera OFF → opening one of those four panels temp-opens the stream (feed appears after a frame or two); leaving closes it. Camera ON → leaving restores the on-screen PiP.
- [ ] Spot-check USB Cam 2 / 3 to confirm per-cam bindings (correct cfg/setter wiring, correct texture passed to the live panel).
- [ ] Confirm `AddImage` feed orientation matches the NanoVG PiP (flip UVs vertically if upside-down).

https://claude.ai/code/session_016Shy65EG8rEG8ttucJJXzW

---
_Generated by [Claude Code](https://claude.ai/code/session_016Shy65EG8rEG8ttucJJXzW)_