### PR TITLE
Phone integration: KDE Connect notifications + Phone Inbox + battery indicator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,6 +225,7 @@ set(SOURCES
     src/video_recorder.cpp
     src/qr_scanner.cpp
     src/splash.cpp
+    src/integrations/phone_inbox.cpp
     $<$<BOOL:${DBUS_FOUND}>:src/integrations/kdeconnect_bridge.cpp>
     src/nanovg_gl_impl.cpp
     src/hud/toast_renderer.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,14 @@ else()
     message(STATUS "SDL2 not found — gamepad input disabled (sudo apt install libsdl2-dev)")
 endif()
 
+# DBus (KDE Connect bridge) — optional; install with: sudo apt install libdbus-1-dev
+pkg_check_modules(DBUS dbus-1)
+if(DBUS_FOUND)
+    message(STATUS "DBus found — KDE Connect bridge enabled")
+else()
+    message(STATUS "DBus not found — KDE Connect bridge disabled (sudo apt install libdbus-1-dev)")
+endif()
+
 # ── Dear ImGui (vendored source, no external install required) ───────────────
 # Fetched once by CMake; cached in build/_deps after first configure.
 include(FetchContent)
@@ -217,6 +225,7 @@ set(SOURCES
     src/video_recorder.cpp
     src/qr_scanner.cpp
     src/splash.cpp
+    $<$<BOOL:${DBUS_FOUND}>:src/integrations/kdeconnect_bridge.cpp>
     src/nanovg_gl_impl.cpp
     src/hud/toast_renderer.cpp
 )
@@ -239,6 +248,7 @@ target_include_directories(protohud PRIVATE
     ${ALSA_INCLUDE_DIRS}
     $<$<BOOL:${ZBAR_FOUND}>:${ZBAR_INCLUDE_DIRS}>
     $<$<BOOL:${SDL2_FOUND}>:${SDL2_INCLUDE_DIRS}>
+    $<$<BOOL:${DBUS_FOUND}>:${DBUS_INCLUDE_DIRS}>
 )
 
 target_link_libraries(protohud PRIVATE
@@ -258,6 +268,7 @@ target_link_libraries(protohud PRIVATE
     Threads::Threads
     $<$<BOOL:${ZBAR_FOUND}>:${ZBAR_LIBRARIES}>
     $<$<BOOL:${SDL2_FOUND}>:${SDL2_LIBRARIES}>
+    $<$<BOOL:${DBUS_FOUND}>:${DBUS_LIBRARIES}>
 )
 
 if(ZBAR_FOUND)
@@ -266,6 +277,10 @@ endif()
 
 if(SDL2_FOUND)
     target_compile_definitions(protohud PRIVATE HAVE_SDL2)
+endif()
+
+if(DBUS_FOUND)
+    target_compile_definitions(protohud PRIVATE HAVE_DBUS)
 endif()
 
 target_compile_options(protohud PRIVATE

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -183,6 +183,14 @@
     "all_day_reminder_hour": 8,
     "web_port": 8770
   },
+  "kdeconnect": {
+    "_about": "Bridges phone notifications from KDE Connect (over LAN or USB tether) into the HUD's notification queue. Requires kdeconnectd running on the Pi and the phone paired via the KDE Connect Android/iOS app. Bridge is gated by libdbus-1-dev being available at build time; on platforms without DBus the section is silently ignored.",
+    "enabled": true,
+    "device_id": "",
+    "_device_id_note": "Empty picks the first paired+reachable device. Set to a specific id (see kdeconnect-cli --list-devices) when multiple phones are paired.",
+    "auto_dismiss_s": 8.0,
+    "app_blocklist": "KDE Connect"
+  },
   "audio": {
     "_note": "Audio capture is handled by the RP2350 helmet audio processor (USB Audio UAC2). The CM5 receives pre-processed stereo and routes it to the chosen output. Run 'arecord -l' to verify the RP2350 card name after connecting via USB.",
     "enabled": true,

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -191,6 +191,15 @@
     "auto_dismiss_s": 8.0,
     "app_blocklist": "KDE Connect"
   },
+  "phone_inbox": {
+    "_about": "Watches a directory for files dropped in from the phone (KDE Connect's Share & Receive lands them in ~/Downloads by default). New face PNGs / GIFs surface an Import toast in the HUD; accept moves the file to <watch_dir>/.processed/, dismiss moves it to <watch_dir>/.dismissed/.",
+    "enabled": true,
+    "watch_dir": "",
+    "_watch_dir_note": "Empty defaults to $XDG_DOWNLOAD_DIR / ~/Downloads. Point this at a dedicated dir if you want a cleaner inbox (then change KDE Connect's Share destination to match).",
+    "settle_seconds": 2,
+    "auto_dismiss_s": 0.0,
+    "_auto_dismiss_note": "0 keeps the import toast sticky until you act on it. Setting it would let untouched files quietly skip import, which is usually not what you want."
+  },
   "audio": {
     "_note": "Audio capture is handled by the RP2350 helmet audio processor (USB Audio UAC2). The CM5 receives pre-processed stereo and routes it to the chosen output. Run 'arecord -l' to verify the RP2350 card name after connecting via USB.",
     "enabled": true,

--- a/src/app_state.h
+++ b/src/app_state.h
@@ -113,6 +113,11 @@ struct SystemHealth {
     bool gamepad_ok      = false;
     bool wireless_ok     = false;
     int  wireless_battery_pct = -1;  // -1 = unknown
+    // Paired phone battery (via KDE Connect bridge). -1 when no phone is
+    // bound or the daemon isn't running; charging flag is meaningless in
+    // that case.
+    int  phone_battery_pct    = -1;
+    bool phone_charging       = false;
     bool cam_owl_left    = false;
     bool cam_owl_right   = false;
     bool cam_usb1        = false;

--- a/src/face/face_loader.cpp
+++ b/src/face/face_loader.cpp
@@ -170,4 +170,17 @@ cv::Mat FaceLoader::get_frame(const FaceState& state) {
     return frame;
 }
 
+cv::Mat FaceLoader::get_expression_image(const std::string& name) const {
+    auto it = expressions_.find(name);
+    if (it == expressions_.end()) return cv::Mat();
+    return it->second.clone();
+}
+
+bool FaceLoader::set_expression_image(const std::string& name, const cv::Mat& rgba) {
+    auto it = expressions_.find(name);
+    if (it == expressions_.end() || rgba.empty()) return false;
+    it->second = rgba.clone();
+    return true;
+}
+
 } // namespace face

--- a/src/face/face_loader.h
+++ b/src/face/face_loader.h
@@ -22,6 +22,16 @@ public:
     const std::vector<std::string>& expression_names() const { return expr_order_; }
     bool valid() const { return !expressions_.empty(); }
 
+    // Transient-image plumbing for the editor's "Preview to panels" key.
+    // get_expression_image returns a deep copy (caller can stash and
+    // restore); set_expression_image swaps the named expression's image
+    // wholesale (no resize — caller is responsible for sending a Mat sized
+    // to (w, h)). Returns false if the name isn't a known expression.
+    cv::Mat get_expression_image(const std::string& name) const;
+    bool    set_expression_image(const std::string& name, const cv::Mat& rgba);
+    int     panel_width()  const { return w_; }
+    int     panel_height() const { return h_; }
+
 private:
     struct Region { int x = 0, y = 0, w = 0, h = 0; bool set = false; };
 

--- a/src/face/native_face_controller.cpp
+++ b/src/face/native_face_controller.cpp
@@ -115,6 +115,19 @@ bool NativeFaceController::start() {
 void NativeFaceController::stop() {
     if (!running_.exchange(false)) return;
     if (thread_.joinable()) thread_.join();
+    // Restore any still-active transient face overlays so the saved
+    // PNG image survives the next start() (loaders cache in-memory).
+    {
+        std::lock_guard<std::mutex> lk(state_mtx_);
+        for (const auto& t : transient_faces_) {
+            if (t.panel_idx < 0 || t.panel_idx >= static_cast<int>(panels_.size()))
+                continue;
+            auto& pn = panels_[t.panel_idx];
+            if (pn.loader)
+                pn.loader->set_expression_image(t.expression, t.original_image);
+        }
+        transient_faces_.clear();
+    }
     if (output_) output_->close();   // blank the panels on shutdown
 }
 
@@ -134,6 +147,28 @@ void NativeFaceController::render_thread() {
                                   cfg_.background[2]));
         {
             std::lock_guard<std::mutex> lk(state_mtx_);
+
+            // Expire any transient face overlays whose deadline has passed —
+            // restore the original expression image to the loader and drop
+            // the record. Done before render so this tick uses the restored
+            // image.
+            if (!transient_faces_.empty()) {
+                auto tnow = clock::now();
+                for (auto it = transient_faces_.begin(); it != transient_faces_.end();) {
+                    if (tnow >= it->deadline) {
+                        if (it->panel_idx >= 0 &&
+                            it->panel_idx < static_cast<int>(panels_.size())) {
+                            auto& pn = panels_[it->panel_idx];
+                            if (pn.loader)
+                                pn.loader->set_expression_image(it->expression,
+                                                                it->original_image);
+                        }
+                        it = transient_faces_.erase(it);
+                    } else {
+                        ++it;
+                    }
+                }
+            }
 
             // Render each self-rendering panel into its region.
             for (auto& pn : panels_) {
@@ -597,6 +632,61 @@ void NativeFaceController::reload_active_face() {
         if (pn.is_mirror || !pn.state) continue;
         pn.loader = std::make_unique<FaceLoader>(
             cfg_.faces_dir + "/" + pn.cfg.face.active, pn.cfg.w, pn.cfg.h);
+    }
+}
+
+void NativeFaceController::push_transient_face(const std::string& expression,
+                                                const cv::Mat& rgba_canvas,
+                                                double duration_s) {
+    if (rgba_canvas.empty() || duration_s <= 0.0) return;
+    std::lock_guard<std::mutex> lk(state_mtx_);
+
+    const auto deadline =
+        std::chrono::steady_clock::now() +
+        std::chrono::duration_cast<std::chrono::steady_clock::duration>(
+            std::chrono::duration<double>(duration_s));
+    const cv::Rect canvas_bounds(0, 0, rgba_canvas.cols, rgba_canvas.rows);
+
+    for (size_t i = 0; i < panels_.size(); ++i) {
+        auto& pn = panels_[i];
+        if (pn.is_mirror || !pn.loader) continue;
+
+        const PanelCfg& pc = pn.cfg;
+        cv::Rect roi = cv::Rect(pc.x, pc.y, pc.w, pc.h) & canvas_bounds;
+        if (roi.area() <= 0) continue;
+
+        cv::Mat crop = rgba_canvas(roi).clone();
+        if (crop.cols != pn.loader->panel_width() ||
+            crop.rows != pn.loader->panel_height()) {
+            cv::Mat resized;
+            cv::resize(crop, resized,
+                       cv::Size(pn.loader->panel_width(), pn.loader->panel_height()),
+                       0, 0, cv::INTER_NEAREST);
+            crop = resized;
+        }
+
+        // Stash the current image so the deadline pass can restore it.
+        // If we already pushed a transient for this panel+expression, keep
+        // the *earlier* original (avoids stacking previews from overwriting
+        // the user's saved image with another preview).
+        bool already = false;
+        for (auto& t : transient_faces_) {
+            if (t.panel_idx == static_cast<int>(i) && t.expression == expression) {
+                t.deadline = deadline;
+                already = true;
+                break;
+            }
+        }
+        if (!already) {
+            TransientFace t;
+            t.panel_idx      = static_cast<int>(i);
+            t.expression     = expression;
+            t.original_image = pn.loader->get_expression_image(expression);
+            t.deadline       = deadline;
+            transient_faces_.push_back(std::move(t));
+        }
+
+        pn.loader->set_expression_image(expression, crop);
     }
 }
 

--- a/src/face/native_face_controller.cpp
+++ b/src/face/native_face_controller.cpp
@@ -527,6 +527,27 @@ bool NativeFaceController::import_face_image(const std::string& expression,
         return false;
     }
 
+    // Stamp the face folder with the active layout name on first import so
+    // the menu can flag mismatches when the user switches layouts. Already-
+    // tagged folders are left alone — re-importing into an existing face
+    // shouldn't silently re-bind it to whatever the user picked since.
+    if (!active_layout_name_.empty()) {
+        const std::string cfg_path = folder + "/config.json";
+        nlohmann::json jcfg = nlohmann::json::object();
+        std::ifstream fr(cfg_path);
+        if (fr) { try { fr >> jcfg; } catch (...) { jcfg = nlohmann::json::object(); } }
+        if (!jcfg.is_object()) jcfg = nlohmann::json::object();
+        bool tagged = jcfg.contains("layout") && jcfg["layout"].is_string() &&
+                      !jcfg["layout"].get<std::string>().empty();
+        if (!tagged) {
+            jcfg["layout"] = active_layout_name_;
+            const std::string tmp = cfg_path + ".tmp";
+            { std::ofstream fw(tmp); if (fw) fw << jcfg.dump(2); }
+            std::error_code rec;
+            std::filesystem::rename(tmp, cfg_path, rec);
+        }
+    }
+
     // Rebuild every non-mirror panel's loader so the new PNG takes effect on
     // the next render tick. (Cheap — just re-decodes the folder's images.)
     for (auto& pn : panels_) {
@@ -535,6 +556,39 @@ bool NativeFaceController::import_face_image(const std::string& expression,
             cfg_.faces_dir + "/" + pn.cfg.face.active, pn.cfg.w, pn.cfg.h);
     }
     return true;
+}
+
+void NativeFaceController::set_active_layout_name(const std::string& name) {
+    std::lock_guard<std::mutex> lk(state_mtx_);
+    active_layout_name_ = name;
+}
+
+std::string NativeFaceController::face_image_layout(const std::string& expression) const {
+    std::lock_guard<std::mutex> lk(state_mtx_);
+    // Layout tags live at face-folder scope (faces/<folder>/config.json),
+    // so all expressions in the same folder share a tag. We look at the
+    // first non-mirror panel's active folder, same as face_image_path.
+    for (const auto& pn : panels_) {
+        if (pn.is_mirror || !pn.loader) continue;
+        const std::string cfg_path =
+            cfg_.faces_dir + "/" + pn.cfg.face.active + "/config.json";
+        // Only return a tag when the actual PNG exists — keeps "(empty)"
+        // slots from picking up a folder-wide tag they don't own.
+        const std::string png =
+            cfg_.faces_dir + "/" + pn.cfg.face.active + "/" +
+            canonical_face_filename(expression);
+        std::error_code ec;
+        if (!std::filesystem::exists(png, ec)) return {};
+        std::ifstream fr(cfg_path);
+        if (!fr) return {};
+        try {
+            nlohmann::json j; fr >> j;
+            if (j.is_object() && j.contains("layout") && j["layout"].is_string())
+                return j["layout"].get<std::string>();
+        } catch (...) {}
+        return {};
+    }
+    return {};
 }
 
 void NativeFaceController::clear_face_image(const std::string& expression) {

--- a/src/face/native_face_controller.h
+++ b/src/face/native_face_controller.h
@@ -104,6 +104,15 @@ public:
     void set_expression_fade(double seconds);
     void set_wiggle(const WiggleCfg& w);
 
+    // Push a "transient" image for the named expression onto every panel
+    // for duration_s seconds. The current image is stashed and restored
+    // automatically when the timer expires (or on stop()). Used by the
+    // face editor's "Preview to panels" key so the user can see their
+    // unsaved canvas on the physical LEDs for a moment.
+    void push_transient_face(const std::string& expression,
+                             const cv::Mat& rgba_canvas,
+                             double duration_s);
+
 private:
     struct Panel {
         PanelCfg                      cfg;
@@ -137,6 +146,16 @@ private:
     mutable std::mutex frame_mtx_;   // latest_
     cv::Mat            latest_;
     bool               have_frame_ = false;
+    // Transient face overlays — one record per panel a push_transient_face
+    // call has touched. tick_render_locked() restores them as their deadlines
+    // pass. stop() restores any still-active records before tearing down.
+    struct TransientFace {
+        int         panel_idx = -1;
+        std::string expression;
+        cv::Mat     original_image;     // RGBA, sized to (panel.w, panel.h)
+        std::chrono::steady_clock::time_point deadline{};
+    };
+    std::vector<TransientFace> transient_faces_;
 
     std::thread        thread_;
     std::atomic<bool>  running_{false};

--- a/src/face/native_face_controller.h
+++ b/src/face/native_face_controller.h
@@ -89,6 +89,13 @@ public:
     // sub-region coverage info (MAX7219 / RGB matrix backends).
     bool has_led_face_editor() const override;
 
+    // HUB75 named-layout tagging. main pushes the active layout name in here
+    // and import_face_image stamps the face folder's config.json with it
+    // (unless already tagged). face_image_layout reads back the stored tag —
+    // empty string for untagged / legacy folders.
+    void        set_active_layout_name(const std::string& name) override;
+    std::string face_image_layout(const std::string& expression) const override;
+
     // Copy the latest rendered RGB canvas (CV_8UC3) for the preview. Returns
     // false until the first frame exists. Safe to call from the main/GL thread.
     bool latest_frame(cv::Mat& out) const;
@@ -159,6 +166,11 @@ private:
 
     std::thread        thread_;
     std::atomic<bool>  running_{false};
+
+    // Name of the currently-active HUB75 layout (or "" when unset). Used to
+    // stamp face folders on import_face_image and surfaced via
+    // face_image_layout. Lives under state_mtx_.
+    std::string        active_layout_name_;
 };
 
 } // namespace face

--- a/src/face/shm_pusher_output.cpp
+++ b/src/face/shm_pusher_output.cpp
@@ -10,9 +10,24 @@
 
 namespace face {
 
-ShmPusherOutput::ShmPusherOutput(int width, int height, std::string path)
-    : w_(width), h_(height), path_(std::move(path)) {
+ShmPusherOutput::ShmPusherOutput(int width, int height,
+                                 std::vector<Panel> panels, std::string path)
+    : w_(width), h_(height), panels_(std::move(panels)), path_(std::move(path)) {
     size_ = static_cast<size_t>(1) + static_cast<size_t>(w_) * h_ * 3;
+}
+
+std::vector<cv::Rect> ShmPusherOutput::covered_regions() const {
+    std::vector<cv::Rect> out;
+    out.reserve(panels_.size());
+    for (const auto& p : panels_) out.push_back(p.rect);
+    return out;
+}
+
+std::vector<NamedRegion> ShmPusherOutput::covered_named_regions() const {
+    std::vector<NamedRegion> out;
+    out.reserve(panels_.size());
+    for (const auto& p : panels_) out.push_back({p.name, p.rect});
+    return out;
 }
 
 ShmPusherOutput::~ShmPusherOutput() { close(); }

--- a/src/face/shm_pusher_output.h
+++ b/src/face/shm_pusher_output.h
@@ -9,6 +9,7 @@
 
 #include <cstdint>
 #include <string>
+#include <vector>
 
 #include "panel_output.h"
 
@@ -16,21 +17,35 @@ namespace face {
 
 class ShmPusherOutput : public PanelOutput {
 public:
+    // Optional panel inventory used by the in-HUD face editor: when populated
+    // the editor knows which canvas rects correspond to physical HUB75 panels
+    // (so it can outline them and write face PNGs sized to the panel set).
+    // Empty = legacy daemon-mode behaviour, editor stays hidden.
+    struct Panel {
+        std::string name;
+        cv::Rect    rect;
+    };
+
     explicit ShmPusherOutput(int width = 128, int height = 32,
+                             std::vector<Panel> panels = {},
                              std::string path = "/dev/shm/protoface_frame");
     ~ShmPusherOutput() override;
 
     bool open() override;
     void show(const cv::Mat& rgb) override;
     void close() override;
+    std::vector<cv::Rect>    covered_regions()       const override;
+    std::vector<NamedRegion> covered_named_regions() const override;
+    bool supports_face_editor() const override { return !panels_.empty(); }
 
 private:
-    int         w_, h_;
-    std::string path_;
-    int         fd_   = -1;
-    uint8_t*    map_  = nullptr;
-    size_t      size_ = 0;
-    uint8_t     seq_  = 0;
+    int                w_, h_;
+    std::vector<Panel> panels_;
+    std::string        path_;
+    int                fd_   = -1;
+    uint8_t*           map_  = nullptr;
+    size_t             size_ = 0;
+    uint8_t            seq_  = 0;
 };
 
 } // namespace face

--- a/src/hud/hud_renderer.cpp
+++ b/src/hud/hud_renderer.cpp
@@ -569,15 +569,35 @@ void HudRenderer::draw_map_overlay(NVGcontext* vg, const AppState& s, float fw, 
             gauge(r1, a0 + off, a1 + off, cpu, load_col(cpu), cb, true);  // inner, raised = CPU
             gauge(r2, a0,       a1,       gpu, load_col(gpu), gb, true);  // outer = GPU
         } else {
+            // Controller battery — always drawn (inner arc). If a phone
+            // battery is known (KDE Connect bridge bound to a paired
+            // device), draw it on the outer arc using the same colour
+            // ramp so the two read consistently. "P" prefix on the label
+            // disambiguates from the controller's bare percentage.
             const int bpct = s.health.wireless_battery_pct;   // -1 = unknown
             const float pct = std::clamp(bpct / 100.f, 0.f, 1.f);
-            NVGcolor bc = pct > 0.5f ? nvgRGBA(70, 210, 90, 230)
-                        : pct > 0.2f ? nvgRGBA(235, 180, 50, 230)
-                        :              nvgRGBA(230, 70, 60, 235);
+            auto bat_col = [](float v) {
+                return v > 0.5f ? nvgRGBA(70, 210, 90, 230)
+                     : v > 0.2f ? nvgRGBA(235, 180, 50, 230)
+                     :            nvgRGBA(230, 70, 60, 235);
+            };
+            NVGcolor bc = bat_col(pct);
             char pb[8];
             if (bpct >= 0) snprintf(pb, sizeof(pb), "%d%%", bpct);
             else           snprintf(pb, sizeof(pb), "--");
-            gauge(r1, a0, a1, pct, bc, pb, bpct >= 0);
+
+            const int  ppct = s.health.phone_battery_pct;
+            if (ppct >= 0) {
+                const float ppc = std::clamp(ppct / 100.f, 0.f, 1.f);
+                NVGcolor pc = bat_col(ppc);
+                char ppb[10];
+                snprintf(ppb, sizeof(ppb), "%s%d%%",
+                         s.health.phone_charging ? "P+" : "P", ppct);
+                gauge(r1, a0 + off, a1 + off, pct, bc, pb, bpct >= 0);
+                gauge(r2, a0,       a1,       ppc, pc, ppb, true);
+            } else {
+                gauge(r1, a0, a1, pct, bc, pb, bpct >= 0);
+            }
         }
     }
 

--- a/src/integrations/kdeconnect_bridge.cpp
+++ b/src/integrations/kdeconnect_bridge.cpp
@@ -1,0 +1,353 @@
+#include "kdeconnect_bridge.h"
+
+#include <algorithm>
+#include <cctype>
+#include <chrono>
+#include <cstdio>
+#include <cstring>
+#include <sstream>
+
+#include <dbus/dbus.h>
+
+#include "../app_state.h"
+
+namespace integrations {
+
+namespace {
+
+// Standard KDE Connect bus locations.
+constexpr const char* kKdeService           = "org.kde.kdeconnect";
+constexpr const char* kDaemonObject         = "/modules/kdeconnect";
+constexpr const char* kDaemonInterface      = "org.kde.kdeconnect.daemon";
+constexpr const char* kDeviceInterface      = "org.kde.kdeconnect.device";
+constexpr const char* kNotificationsIface   = "org.kde.kdeconnect.device.notifications";
+constexpr const char* kNotificationIface    = "org.kde.kdeconnect.device.notifications.notification";
+constexpr const char* kPropertiesIface      = "org.freedesktop.DBus.Properties";
+
+// Helper: append a single string argument to a DBus message.
+void msg_append_str(DBusMessage* msg, const char* s) {
+    DBusMessageIter it; dbus_message_iter_init_append(msg, &it);
+    dbus_message_iter_append_basic(&it, DBUS_TYPE_STRING, &s);
+}
+
+// Method call returning a single string reply (e.g. property Get on a string).
+// Returns empty on any error so callers can keep going without crashing on
+// missing fields.
+std::string call_get_str_prop(DBusConnection* conn,
+                              const char* path,
+                              const char* iface_for_prop,
+                              const char* prop) {
+    DBusMessage* msg = dbus_message_new_method_call(
+        kKdeService, path, kPropertiesIface, "Get");
+    if (!msg) return {};
+    DBusMessageIter it; dbus_message_iter_init_append(msg, &it);
+    dbus_message_iter_append_basic(&it, DBUS_TYPE_STRING, &iface_for_prop);
+    dbus_message_iter_append_basic(&it, DBUS_TYPE_STRING, &prop);
+
+    DBusError err; dbus_error_init(&err);
+    DBusMessage* reply = dbus_connection_send_with_reply_and_block(conn, msg, 1500, &err);
+    dbus_message_unref(msg);
+    if (dbus_error_is_set(&err)) { dbus_error_free(&err); if (reply) dbus_message_unref(reply); return {}; }
+    if (!reply) return {};
+
+    // Reply is a variant carrying a string.
+    DBusMessageIter rit, vit;
+    if (!dbus_message_iter_init(reply, &rit) ||
+        dbus_message_iter_get_arg_type(&rit) != DBUS_TYPE_VARIANT) {
+        dbus_message_unref(reply); return {};
+    }
+    dbus_message_iter_recurse(&rit, &vit);
+    if (dbus_message_iter_get_arg_type(&vit) != DBUS_TYPE_STRING) {
+        dbus_message_unref(reply); return {};
+    }
+    const char* val = nullptr;
+    dbus_message_iter_get_basic(&vit, &val);
+    std::string out = val ? std::string(val) : std::string();
+    dbus_message_unref(reply);
+    return out;
+}
+
+// Call a method returning array of strings (e.g. daemon.devices, notifications.activeNotifications).
+std::vector<std::string> call_get_str_array(DBusConnection* conn,
+                                            const char* path,
+                                            const char* iface,
+                                            const char* method,
+                                            // Optional two bool args for daemon.devices(visible, paired)
+                                            bool has_bool_args = false,
+                                            bool b1 = true, bool b2 = true) {
+    DBusMessage* msg = dbus_message_new_method_call(
+        kKdeService, path, iface, method);
+    if (!msg) return {};
+    if (has_bool_args) {
+        DBusMessageIter it; dbus_message_iter_init_append(msg, &it);
+        dbus_bool_t bv1 = b1 ? TRUE : FALSE;
+        dbus_bool_t bv2 = b2 ? TRUE : FALSE;
+        dbus_message_iter_append_basic(&it, DBUS_TYPE_BOOLEAN, &bv1);
+        dbus_message_iter_append_basic(&it, DBUS_TYPE_BOOLEAN, &bv2);
+    }
+    DBusError err; dbus_error_init(&err);
+    DBusMessage* reply = dbus_connection_send_with_reply_and_block(conn, msg, 1500, &err);
+    dbus_message_unref(msg);
+    if (dbus_error_is_set(&err)) { dbus_error_free(&err); if (reply) dbus_message_unref(reply); return {}; }
+    if (!reply) return {};
+
+    std::vector<std::string> out;
+    DBusMessageIter rit, ait;
+    if (!dbus_message_iter_init(reply, &rit) ||
+        dbus_message_iter_get_arg_type(&rit) != DBUS_TYPE_ARRAY) {
+        dbus_message_unref(reply); return out;
+    }
+    dbus_message_iter_recurse(&rit, &ait);
+    while (dbus_message_iter_get_arg_type(&ait) == DBUS_TYPE_STRING) {
+        const char* s = nullptr;
+        dbus_message_iter_get_basic(&ait, &s);
+        if (s) out.emplace_back(s);
+        dbus_message_iter_next(&ait);
+    }
+    dbus_message_unref(reply);
+    return out;
+}
+
+// Whether the well-known service is currently owned by anyone — quick way
+// to tell if kdeconnectd is running without a method call that might block.
+bool service_present(DBusConnection* conn) {
+    DBusError err; dbus_error_init(&err);
+    dbus_bool_t has = dbus_bus_name_has_owner(conn, kKdeService, &err);
+    if (dbus_error_is_set(&err)) { dbus_error_free(&err); return false; }
+    return has == TRUE;
+}
+
+std::vector<std::string> split_csv(const std::string& s) {
+    std::vector<std::string> out;
+    std::stringstream ss(s);
+    std::string tok;
+    while (std::getline(ss, tok, ',')) {
+        // trim
+        auto l = tok.find_first_not_of(" \t");
+        auto r = tok.find_last_not_of(" \t");
+        if (l == std::string::npos) continue;
+        out.push_back(tok.substr(l, r - l + 1));
+    }
+    return out;
+}
+
+bool icontains(const std::string& hay, const std::string& needle) {
+    if (needle.empty()) return false;
+    auto it = std::search(hay.begin(), hay.end(),
+                          needle.begin(), needle.end(),
+                          [](char a, char b){ return std::tolower(a) == std::tolower(b); });
+    return it != hay.end();
+}
+
+} // namespace
+
+KdeConnectBridge::KdeConnectBridge(AppState& state, KdeConnectConfig cfg)
+    : state_(state), cfg_(std::move(cfg)) {}
+
+KdeConnectBridge::~KdeConnectBridge() { stop(); }
+
+std::string KdeConnectBridge::active_device_name() const {
+    std::lock_guard<std::mutex> lk(info_mtx_);
+    return active_device_name_;
+}
+
+std::string KdeConnectBridge::active_device_id() const {
+    std::lock_guard<std::mutex> lk(info_mtx_);
+    return active_device_id_;
+}
+
+void KdeConnectBridge::set_app_blocklist(std::string csv) {
+    cfg_.app_blocklist = std::move(csv);
+}
+
+bool KdeConnectBridge::start() {
+    if (running_.load() || !cfg_.enabled) return false;
+
+    DBusError err; dbus_error_init(&err);
+    DBusConnection* conn = dbus_bus_get_private(DBUS_BUS_SESSION, &err);
+    if (dbus_error_is_set(&err) || !conn) {
+        if (dbus_error_is_set(&err)) {
+            std::fprintf(stderr, "[kdeconnect] session bus get failed: %s\n", err.message);
+            dbus_error_free(&err);
+        }
+        return false;
+    }
+    // Don't tear down the whole process if the connection drops.
+    dbus_connection_set_exit_on_disconnect(conn, FALSE);
+    conn_ = conn;
+
+    running_.store(true);
+    thread_ = std::thread(&KdeConnectBridge::worker, this);
+    return true;
+}
+
+void KdeConnectBridge::stop() {
+    if (!running_.exchange(false)) return;
+    if (thread_.joinable()) thread_.join();
+    if (conn_) {
+        DBusConnection* c = static_cast<DBusConnection*>(conn_);
+        dbus_connection_close(c);
+        dbus_connection_unref(c);
+        conn_ = nullptr;
+    }
+    std::lock_guard<std::mutex> lk(seen_mtx_);
+    seen_.clear();
+}
+
+void KdeConnectBridge::worker() {
+    using clock = std::chrono::steady_clock;
+    DBusConnection* conn = static_cast<DBusConnection*>(conn_);
+
+    // Discovery state.
+    std::string current_dev_id;
+    std::string current_match_rule;
+    auto next_discovery = clock::now();
+    const auto discovery_interval = std::chrono::seconds(5);
+
+    auto drop_match = [&](const std::string& rule){
+        if (rule.empty()) return;
+        DBusError e; dbus_error_init(&e);
+        dbus_bus_remove_match(conn, rule.c_str(), &e);
+        if (dbus_error_is_set(&e)) dbus_error_free(&e);
+    };
+
+    auto pick_device = [&]() -> std::string {
+        // Honor cfg device_id first; otherwise first paired + reachable.
+        if (!cfg_.device_id.empty()) return cfg_.device_id;
+        auto ids = call_get_str_array(conn, kDaemonObject, kDaemonInterface,
+                                      "devices", true, true, true);
+        if (ids.empty()) return {};
+        return ids.front();
+    };
+
+    auto rebind_to = [&](const std::string& dev_id) {
+        drop_match(current_match_rule);
+        current_match_rule.clear();
+        current_dev_id = dev_id;
+
+        if (dev_id.empty()) {
+            device_ok_.store(false);
+            std::lock_guard<std::mutex> lk(info_mtx_);
+            active_device_id_.clear();
+            active_device_name_.clear();
+            return;
+        }
+
+        // Resolve a friendly device name (best-effort).
+        const std::string dev_path =
+            std::string("/modules/kdeconnect/devices/") + dev_id;
+        std::string nm = call_get_str_prop(conn, dev_path.c_str(),
+                                           kDeviceInterface, "name");
+        {
+            std::lock_guard<std::mutex> lk(info_mtx_);
+            active_device_id_   = dev_id;
+            active_device_name_ = nm.empty() ? dev_id : nm;
+        }
+        device_ok_.store(true);
+
+        // Subscribe to notificationPosted signals for this device's
+        // notifications plugin object.
+        const std::string notif_path = dev_path + "/notifications";
+        std::ostringstream rule;
+        rule << "type='signal',sender='" << kKdeService << "',"
+             << "interface='" << kNotificationsIface << "',"
+             << "member='notificationPosted',"
+             << "path='" << notif_path << "'";
+        current_match_rule = rule.str();
+        DBusError e; dbus_error_init(&e);
+        dbus_bus_add_match(conn, current_match_rule.c_str(), &e);
+        if (dbus_error_is_set(&e)) {
+            std::fprintf(stderr, "[kdeconnect] add_match failed: %s\n", e.message);
+            dbus_error_free(&e);
+            current_match_rule.clear();
+        }
+    };
+
+    auto handle_notification = [&](const std::string& notif_id) {
+        if (notif_id.empty() || current_dev_id.empty()) return;
+        {
+            std::lock_guard<std::mutex> lk(seen_mtx_);
+            if (!seen_.insert(notif_id).second) return;   // already pushed
+        }
+        const std::string obj =
+            "/modules/kdeconnect/devices/" + current_dev_id + "/notifications/" + notif_id;
+        // Pull the human-facing fields. ticker is the canonical "what to
+        // display" — it's the same string KDE Connect shows on its
+        // notification toast on a desktop.
+        std::string app_name = call_get_str_prop(conn, obj.c_str(),
+                                                 kNotificationIface, "appName");
+        std::string ticker   = call_get_str_prop(conn, obj.c_str(),
+                                                 kNotificationIface, "ticker");
+        std::string title    = call_get_str_prop(conn, obj.c_str(),
+                                                 kNotificationIface, "title");
+        std::string text     = call_get_str_prop(conn, obj.c_str(),
+                                                 kNotificationIface, "text");
+
+        // Blocklist (case-insensitive substring match on appName).
+        const auto bl = split_csv(cfg_.app_blocklist);
+        for (const auto& b : bl)
+            if (icontains(app_name, b)) return;
+
+        // Compose: prefer "<title> — <text>" when both are present;
+        // ticker is the catch-all fallback used by most chat apps.
+        Notification n;
+        n.type           = NotifType::App;
+        n.title          = !app_name.empty() ? app_name : std::string("Phone");
+        if (!title.empty() && !text.empty())   n.body = title + " — " + text;
+        else if (!ticker.empty())              n.body = ticker;
+        else if (!title.empty())               n.body = title;
+        else if (!text.empty())                n.body = text;
+        else                                   n.body = "(empty)";
+        n.auto_dismiss_s = cfg_.auto_dismiss_s;
+
+        std::lock_guard<std::mutex> lk(state_.mtx);
+        state_.notifs.push(std::move(n));
+    };
+
+    while (running_.load()) {
+        const auto now = clock::now();
+
+        // Periodic discovery: detect kdeconnectd appearing/disappearing
+        // and re-pick the device if our binding has gone stale.
+        if (now >= next_discovery) {
+            next_discovery = now + discovery_interval;
+            const bool present = service_present(conn);
+            daemon_ok_.store(present);
+            if (!present) {
+                if (!current_dev_id.empty()) rebind_to({});
+            } else {
+                const std::string want = pick_device();
+                if (want != current_dev_id) rebind_to(want);
+            }
+        }
+
+        // Dispatch incoming signals. read_write blocks briefly so we
+        // don't busy-spin when nothing is happening.
+        if (!dbus_connection_read_write(conn, 200)) {
+            // Connection died — wait for daemon to come back.
+            daemon_ok_.store(false);
+            device_ok_.store(false);
+            std::this_thread::sleep_for(std::chrono::seconds(2));
+            continue;
+        }
+        while (true) {
+            DBusMessage* m = dbus_connection_pop_message(conn);
+            if (!m) break;
+            if (dbus_message_is_signal(m, kNotificationsIface, "notificationPosted")) {
+                const char* notif_id = nullptr;
+                DBusError e; dbus_error_init(&e);
+                if (dbus_message_get_args(m, &e,
+                                          DBUS_TYPE_STRING, &notif_id,
+                                          DBUS_TYPE_INVALID) && notif_id) {
+                    handle_notification(notif_id);
+                }
+                if (dbus_error_is_set(&e)) dbus_error_free(&e);
+            }
+            dbus_message_unref(m);
+        }
+    }
+
+    drop_match(current_match_rule);
+}
+
+} // namespace integrations

--- a/src/integrations/kdeconnect_bridge.cpp
+++ b/src/integrations/kdeconnect_bridge.cpp
@@ -385,11 +385,15 @@ void KdeConnectBridge::worker() {
             state_.health.phone_charging    = false;
             return;
         }
-        const std::string dev_path =
-            std::string("/modules/kdeconnect/devices/") + current_dev_id;
-        const int  pct      = call_get_int_prop(conn, dev_path.c_str(),
+        // KDE Connect publishes the battery plugin on a sub-object of the
+        // device, not on the device root — gdbus introspect of
+        // /modules/kdeconnect/devices/<id>/battery shows the charge +
+        // isCharging properties live there.
+        const std::string batt_path =
+            std::string("/modules/kdeconnect/devices/") + current_dev_id + "/battery";
+        const int  pct      = call_get_int_prop(conn, batt_path.c_str(),
                                                 kBatteryIface, "charge", -1);
-        const bool charging = call_get_bool_prop(conn, dev_path.c_str(),
+        const bool charging = call_get_bool_prop(conn, batt_path.c_str(),
                                                  kBatteryIface, "isCharging", false);
         std::lock_guard<std::mutex> lk(state_.mtx);
         state_.health.phone_battery_pct = (pct >= 0 && pct <= 100) ? pct : -1;

--- a/src/integrations/kdeconnect_bridge.cpp
+++ b/src/integrations/kdeconnect_bridge.cpp
@@ -378,6 +378,8 @@ void KdeConnectBridge::worker() {
         state_.notifs.push(std::move(n));
     };
 
+    int  last_logged_pct      = -2;   // -2 = never logged
+    bool last_logged_charging = false;
     auto poll_battery = [&]() {
         if (current_dev_id.empty()) {
             std::lock_guard<std::mutex> lk(state_.mtx);
@@ -396,10 +398,14 @@ void KdeConnectBridge::worker() {
         const bool charging = call_get_bool_prop(conn, batt_path.c_str(),
                                                  kBatteryIface, "isCharging", false);
         const int clamped = (pct >= 0 && pct <= 100) ? pct : -1;
-        // One-line diagnostic so the journal shows whether the property
-        // get is succeeding. Print every poll for now; quiet once trusted.
-        std::fprintf(stderr, "[kdeconnect] battery poll %s charge=%d charging=%d\n",
-                     batt_path.c_str(), pct, charging ? 1 : 0);
+        // Log only on first read or when the values change, so the journal
+        // doesn't fill with per-poll noise once the bridge is healthy.
+        if (clamped != last_logged_pct || charging != last_logged_charging) {
+            std::fprintf(stderr, "[kdeconnect] phone battery %d%%%s\n",
+                         clamped, charging ? " (charging)" : "");
+            last_logged_pct      = clamped;
+            last_logged_charging = charging;
+        }
         std::lock_guard<std::mutex> lk(state_.mtx);
         state_.health.phone_battery_pct = clamped;
         state_.health.phone_charging    = charging;

--- a/src/integrations/kdeconnect_bridge.cpp
+++ b/src/integrations/kdeconnect_bridge.cpp
@@ -395,8 +395,13 @@ void KdeConnectBridge::worker() {
                                                 kBatteryIface, "charge", -1);
         const bool charging = call_get_bool_prop(conn, batt_path.c_str(),
                                                  kBatteryIface, "isCharging", false);
+        const int clamped = (pct >= 0 && pct <= 100) ? pct : -1;
+        // One-line diagnostic so the journal shows whether the property
+        // get is succeeding. Print every poll for now; quiet once trusted.
+        std::fprintf(stderr, "[kdeconnect] battery poll %s charge=%d charging=%d\n",
+                     batt_path.c_str(), pct, charging ? 1 : 0);
         std::lock_guard<std::mutex> lk(state_.mtx);
-        state_.health.phone_battery_pct = (pct >= 0 && pct <= 100) ? pct : -1;
+        state_.health.phone_battery_pct = clamped;
         state_.health.phone_charging    = charging;
     };
 

--- a/src/integrations/kdeconnect_bridge.cpp
+++ b/src/integrations/kdeconnect_bridge.cpp
@@ -22,6 +22,7 @@ constexpr const char* kDaemonInterface      = "org.kde.kdeconnect.daemon";
 constexpr const char* kDeviceInterface      = "org.kde.kdeconnect.device";
 constexpr const char* kNotificationsIface   = "org.kde.kdeconnect.device.notifications";
 constexpr const char* kNotificationIface    = "org.kde.kdeconnect.device.notifications.notification";
+constexpr const char* kBatteryIface         = "org.kde.kdeconnect.device.battery";
 constexpr const char* kPropertiesIface      = "org.freedesktop.DBus.Properties";
 
 // Helper: append a single string argument to a DBus message.
@@ -63,6 +64,72 @@ std::string call_get_str_prop(DBusConnection* conn,
     const char* val = nullptr;
     dbus_message_iter_get_basic(&vit, &val);
     std::string out = val ? std::string(val) : std::string();
+    dbus_message_unref(reply);
+    return out;
+}
+
+// Variant of call_get_str_prop for int / bool properties. Returns the
+// caller's fallback when the property is missing or the wrong type so
+// "not bound yet" cleanly stays the empty state.
+int call_get_int_prop(DBusConnection* conn,
+                      const char* path,
+                      const char* iface_for_prop,
+                      const char* prop, int fallback) {
+    DBusMessage* msg = dbus_message_new_method_call(
+        kKdeService, path, kPropertiesIface, "Get");
+    if (!msg) return fallback;
+    DBusMessageIter it; dbus_message_iter_init_append(msg, &it);
+    dbus_message_iter_append_basic(&it, DBUS_TYPE_STRING, &iface_for_prop);
+    dbus_message_iter_append_basic(&it, DBUS_TYPE_STRING, &prop);
+    DBusError err; dbus_error_init(&err);
+    DBusMessage* reply = dbus_connection_send_with_reply_and_block(conn, msg, 1500, &err);
+    dbus_message_unref(msg);
+    if (dbus_error_is_set(&err)) { dbus_error_free(&err); if (reply) dbus_message_unref(reply); return fallback; }
+    if (!reply) return fallback;
+    DBusMessageIter rit, vit;
+    if (!dbus_message_iter_init(reply, &rit) ||
+        dbus_message_iter_get_arg_type(&rit) != DBUS_TYPE_VARIANT) {
+        dbus_message_unref(reply); return fallback;
+    }
+    dbus_message_iter_recurse(&rit, &vit);
+    const int t = dbus_message_iter_get_arg_type(&vit);
+    int out = fallback;
+    if (t == DBUS_TYPE_INT32 || t == DBUS_TYPE_UINT32) {
+        dbus_uint32_t v = 0;
+        dbus_message_iter_get_basic(&vit, &v);
+        out = static_cast<int>(v);
+    }
+    dbus_message_unref(reply);
+    return out;
+}
+
+bool call_get_bool_prop(DBusConnection* conn,
+                        const char* path,
+                        const char* iface_for_prop,
+                        const char* prop, bool fallback) {
+    DBusMessage* msg = dbus_message_new_method_call(
+        kKdeService, path, kPropertiesIface, "Get");
+    if (!msg) return fallback;
+    DBusMessageIter it; dbus_message_iter_init_append(msg, &it);
+    dbus_message_iter_append_basic(&it, DBUS_TYPE_STRING, &iface_for_prop);
+    dbus_message_iter_append_basic(&it, DBUS_TYPE_STRING, &prop);
+    DBusError err; dbus_error_init(&err);
+    DBusMessage* reply = dbus_connection_send_with_reply_and_block(conn, msg, 1500, &err);
+    dbus_message_unref(msg);
+    if (dbus_error_is_set(&err)) { dbus_error_free(&err); if (reply) dbus_message_unref(reply); return fallback; }
+    if (!reply) return fallback;
+    DBusMessageIter rit, vit;
+    if (!dbus_message_iter_init(reply, &rit) ||
+        dbus_message_iter_get_arg_type(&rit) != DBUS_TYPE_VARIANT) {
+        dbus_message_unref(reply); return fallback;
+    }
+    dbus_message_iter_recurse(&rit, &vit);
+    bool out = fallback;
+    if (dbus_message_iter_get_arg_type(&vit) == DBUS_TYPE_BOOLEAN) {
+        dbus_bool_t v = FALSE;
+        dbus_message_iter_get_basic(&vit, &v);
+        out = (v == TRUE);
+    }
     dbus_message_unref(reply);
     return out;
 }
@@ -190,8 +257,15 @@ void KdeConnectBridge::stop() {
         dbus_connection_unref(c);
         conn_ = nullptr;
     }
-    std::lock_guard<std::mutex> lk(seen_mtx_);
-    seen_.clear();
+    {
+        std::lock_guard<std::mutex> lk(seen_mtx_);
+        seen_.clear();
+    }
+    {
+        std::lock_guard<std::mutex> lk(state_.mtx);
+        state_.health.phone_battery_pct = -1;
+        state_.health.phone_charging    = false;
+    }
 }
 
 void KdeConnectBridge::worker() {
@@ -304,11 +378,33 @@ void KdeConnectBridge::worker() {
         state_.notifs.push(std::move(n));
     };
 
+    auto poll_battery = [&]() {
+        if (current_dev_id.empty()) {
+            std::lock_guard<std::mutex> lk(state_.mtx);
+            state_.health.phone_battery_pct = -1;
+            state_.health.phone_charging    = false;
+            return;
+        }
+        const std::string dev_path =
+            std::string("/modules/kdeconnect/devices/") + current_dev_id;
+        const int  pct      = call_get_int_prop(conn, dev_path.c_str(),
+                                                kBatteryIface, "charge", -1);
+        const bool charging = call_get_bool_prop(conn, dev_path.c_str(),
+                                                 kBatteryIface, "isCharging", false);
+        std::lock_guard<std::mutex> lk(state_.mtx);
+        state_.health.phone_battery_pct = (pct >= 0 && pct <= 100) ? pct : -1;
+        state_.health.phone_charging    = charging;
+    };
+
     while (running_.load()) {
         const auto now = clock::now();
 
         // Periodic discovery: detect kdeconnectd appearing/disappearing
-        // and re-pick the device if our binding has gone stale.
+        // and re-pick the device if our binding has gone stale. Battery
+        // is polled in the same cycle — KDE Connect doesn't push a
+        // PropertiesChanged signal we can subscribe to from libdbus
+        // without a generated proxy, and a 5 s refresh is plenty for a
+        // chrome indicator.
         if (now >= next_discovery) {
             next_discovery = now + discovery_interval;
             const bool present = service_present(conn);
@@ -319,6 +415,7 @@ void KdeConnectBridge::worker() {
                 const std::string want = pick_device();
                 if (want != current_dev_id) rebind_to(want);
             }
+            poll_battery();
         }
 
         // Dispatch incoming signals. read_write blocks briefly so we

--- a/src/integrations/kdeconnect_bridge.h
+++ b/src/integrations/kdeconnect_bridge.h
@@ -1,0 +1,95 @@
+#pragma once
+// ── kdeconnect_bridge.h ───────────────────────────────────────────────────────
+// Subscribes to the paired phone's KDE Connect notifications (DBus session bus)
+// and pushes them into AppState::notifs so they surface in the same toast +
+// log pipeline as scheduler reminders. Phase 1 covers RX only — the public
+// surface is sized for the later phases (TX notifications, battery, media,
+// run-command) but those methods are stubbed until we get there.
+//
+// Threading: a single worker thread owns the DBus connection; the public
+// methods just poke atomics or post requests it picks up on the next dispatch.
+// Safe to construct + start() before AppState is fully populated; the worker
+// no-ops cleanly when kdeconnectd isn't reachable so dev hosts without it
+// installed don't error.
+
+#include <atomic>
+#include <functional>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <unordered_set>
+#include <vector>
+
+struct AppState;
+
+namespace integrations {
+
+struct KdeConnectConfig {
+    bool        enabled         = true;
+    // Preferred device id (KDE Connect assigns each pairing a stable id).
+    // Empty → use the first paired + reachable device the daemon reports.
+    std::string device_id;
+    // Auto-dismiss applied to each phone notification when pushed into
+    // AppState::notifs. 0 keeps the toast until manually dismissed.
+    float       auto_dismiss_s  = 8.f;
+    // Comma-separated app-name substrings that should NOT be forwarded
+    // (e.g. "KDE Connect" so the daemon's own status pings don't loop).
+    std::string app_blocklist   = "KDE Connect";
+};
+
+class KdeConnectBridge {
+public:
+    KdeConnectBridge(AppState& state, KdeConnectConfig cfg);
+    ~KdeConnectBridge();
+
+    KdeConnectBridge(const KdeConnectBridge&)            = delete;
+    KdeConnectBridge& operator=(const KdeConnectBridge&) = delete;
+
+    // Open the session-bus connection and spawn the worker. Returns false
+    // when the daemon isn't reachable or libdbus isn't compiled in; the
+    // object stays usable (stop()/destroy are safe) but no events flow.
+    bool start();
+    void stop();
+
+    bool running()        const { return running_.load(); }
+    bool daemon_present() const { return daemon_ok_.load(); }   // kdeconnectd visible
+    bool device_ready()   const { return device_ok_.load(); }   // a paired+reachable device picked
+
+    // What the worker resolved on its most recent scan — useful for the
+    // System menu's KDE Connect status row. Empty until the worker has
+    // run a discovery pass.
+    std::string active_device_name() const;
+    std::string active_device_id()   const;
+
+    // Live-tunable config — applied on the next worker dispatch.
+    void set_auto_dismiss(float seconds) { cfg_.auto_dismiss_s = seconds; }
+    void set_app_blocklist(std::string csv);
+
+private:
+    void worker();
+
+    AppState&            state_;
+    KdeConnectConfig     cfg_;
+
+    std::atomic<bool>    running_{false};
+    std::atomic<bool>    daemon_ok_{false};
+    std::atomic<bool>    device_ok_{false};
+
+    mutable std::mutex   info_mtx_;
+    std::string          active_device_name_;
+    std::string          active_device_id_;
+
+    // Notification IDs we've already pushed this session, so reposted /
+    // re-emitted signals don't duplicate. Cleared on stop().
+    mutable std::mutex          seen_mtx_;
+    std::unordered_set<std::string> seen_;
+
+    std::thread          thread_;
+
+    // Opaque pointer to DBusConnection — kept void* in the header so we
+    // don't drag dbus headers into translation units that don't need
+    // them. cpp file casts back to DBusConnection*.
+    void*                conn_ = nullptr;
+};
+
+} // namespace integrations

--- a/src/integrations/phone_inbox.cpp
+++ b/src/integrations/phone_inbox.cpp
@@ -1,0 +1,227 @@
+#include "phone_inbox.h"
+
+#include <algorithm>
+#include <cctype>
+#include <cstdio>
+#include <cstdlib>
+#include <filesystem>
+
+#include "../app_state.h"
+
+namespace fs = std::filesystem;
+
+namespace integrations {
+
+namespace {
+
+std::string xdg_download_dir() {
+    // KDE Connect uses xdg-user-dirs; we don't link xdg, so resolve the
+    // same way the spec describes: $XDG_DOWNLOAD_DIR if set, else
+    // $HOME/Downloads.
+    const char* x = std::getenv("XDG_DOWNLOAD_DIR");
+    if (x && *x) return std::string(x);
+    const char* h = std::getenv("HOME");
+    return std::string(h && *h ? h : "/tmp") + "/Downloads";
+}
+
+std::string to_lower(std::string s) {
+    std::transform(s.begin(), s.end(), s.begin(),
+                   [](unsigned char c){ return static_cast<char>(std::tolower(c)); });
+    return s;
+}
+
+bool is_ext(const fs::path& p, const std::string& want_lower) {
+    return to_lower(p.extension().string()) == want_lower;
+}
+
+int64_t mtime_ns(const fs::path& p) {
+    std::error_code ec;
+    auto ft = fs::last_write_time(p, ec);
+    if (ec) return 0;
+    return std::chrono::duration_cast<std::chrono::nanoseconds>(
+        ft.time_since_epoch()).count();
+}
+
+void move_to_subdir(const fs::path& src, const fs::path& subdir) {
+    std::error_code ec;
+    fs::create_directories(subdir, ec);
+    fs::path dst = subdir / src.filename();
+    // Suffix with a counter if a same-named file is already there so we
+    // don't clobber prior history.
+    if (fs::exists(dst, ec)) {
+        for (int i = 1; i < 1000; ++i) {
+            char buf[32]; std::snprintf(buf, sizeof(buf), ".%d", i);
+            fs::path candidate = subdir /
+                (src.stem().string() + buf + src.extension().string());
+            if (!fs::exists(candidate, ec)) { dst = candidate; break; }
+        }
+    }
+    fs::rename(src, dst, ec);
+    // rename across devices fails with EXDEV — fall back to copy+remove.
+    if (ec) {
+        ec.clear();
+        fs::copy_file(src, dst,
+                      fs::copy_options::overwrite_existing, ec);
+        if (!ec) fs::remove(src, ec);
+    }
+}
+
+} // namespace
+
+PhoneInbox::PhoneInbox(AppState& state, PhoneInboxConfig cfg,
+                       ImportFaceFn import_face, ImportGifFn import_gif)
+    : state_(state), cfg_(std::move(cfg)),
+      import_face_(std::move(import_face)),
+      import_gif_(std::move(import_gif)) {
+    if (cfg_.watch_dir.empty()) cfg_.watch_dir = xdg_download_dir();
+}
+
+PhoneInbox::~PhoneInbox() { stop(); }
+
+bool PhoneInbox::start() {
+    if (running_.load() || !cfg_.enabled) return false;
+    std::error_code ec;
+    fs::create_directories(cfg_.watch_dir, ec);
+    if (ec) {
+        std::fprintf(stderr, "[phone-inbox] cannot create %s: %s\n",
+                     cfg_.watch_dir.c_str(), ec.message().c_str());
+        return false;
+    }
+    running_.store(true);
+    thread_ = std::thread(&PhoneInbox::worker, this);
+    return true;
+}
+
+void PhoneInbox::stop() {
+    if (!running_.exchange(false)) return;
+    if (thread_.joinable()) thread_.join();
+    std::lock_guard<std::mutex> lk(seen_mtx_);
+    seen_.clear();
+}
+
+void PhoneInbox::worker() {
+    const fs::path root   = cfg_.watch_dir;
+    const fs::path proc   = root / ".processed";
+    const fs::path dismd  = root / ".dismissed";
+
+    auto push_face_toast = [this, proc, dismd](const fs::path& src) {
+        const std::string expression =
+            to_lower(src.stem().string());
+        const std::string path_str   = src.string();
+
+        Notification n;
+        n.type           = NotifType::App;
+        n.title          = "Phone Inbox";
+        n.body           = std::string("Got ") + src.filename().string() +
+                           "  —  import as '" + expression + "'?";
+        n.auto_dismiss_s = cfg_.auto_dismiss_s;
+
+        // Action lambdas just touch the filesystem — pushing into
+        // state.notifs here would invalidate the toast-renderer's for-loop
+        // iterators. The user gets feedback when the import-prompt toast
+        // disappears (and, for face PNGs, when the new face shows on the
+        // panels on the next render tick).
+        ImportFaceFn handler = import_face_;
+        n.actions.push_back({"IMPORT",
+            [handler, path_str, expression, proc](AppState&) {
+                if (handler) handler(path_str, expression);
+                move_to_subdir(path_str, proc);
+            }});
+        n.actions.push_back({"DISMISS",
+            [path_str, dismd](AppState&) {
+                move_to_subdir(path_str, dismd);
+            }});
+
+        uint32_t id = 0;
+        {
+            std::lock_guard<std::mutex> lk(state_.mtx);
+            state_.notifs.push(std::move(n));
+            id = state_.notifs.items.front().id;
+        }
+        std::lock_guard<std::mutex> lk(seen_mtx_);
+        seen_[path_str] = {id, mtime_ns(src)};
+    };
+
+    auto push_gif_toast = [this, proc, dismd](const fs::path& src) {
+        const std::string filename = src.filename().string();
+        const std::string path_str = src.string();
+
+        Notification n;
+        n.type           = NotifType::App;
+        n.title          = "Phone Inbox";
+        n.body           = std::string("Got ") + filename +
+                           "  —  add to GIF library?";
+        n.auto_dismiss_s = cfg_.auto_dismiss_s;
+
+        ImportGifFn handler = import_gif_;
+        n.actions.push_back({"IMPORT",
+            [handler, path_str, filename, proc](AppState&) {
+                if (handler) handler(path_str, filename);
+                move_to_subdir(path_str, proc);
+            }});
+        n.actions.push_back({"DISMISS",
+            [path_str, dismd](AppState&) {
+                move_to_subdir(path_str, dismd);
+            }});
+
+        uint32_t id = 0;
+        {
+            std::lock_guard<std::mutex> lk(state_.mtx);
+            state_.notifs.push(std::move(n));
+            id = state_.notifs.items.front().id;
+        }
+        std::lock_guard<std::mutex> lk(seen_mtx_);
+        seen_[path_str] = {id, mtime_ns(src)};
+    };
+
+    while (running_.load()) {
+        const auto loop_start = std::chrono::steady_clock::now();
+
+        std::error_code ec;
+        if (fs::exists(root, ec) && fs::is_directory(root, ec)) {
+            const auto now_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                std::chrono::system_clock::now().time_since_epoch()).count();
+            const int64_t settle_ns =
+                static_cast<int64_t>(cfg_.settle_seconds) * 1'000'000'000LL;
+
+            for (auto& entry : fs::directory_iterator(root, ec)) {
+                if (!entry.is_regular_file(ec)) continue;
+                fs::path p = entry.path();
+                // Skip dotfiles + our own subdirs.
+                if (!p.filename().empty() && p.filename().string()[0] == '.') continue;
+
+                const int64_t mt = mtime_ns(p);
+                if (mt == 0) continue;
+                if ((now_ns - mt) < settle_ns) continue;   // still transferring
+
+                const std::string key = p.string();
+                {
+                    std::lock_guard<std::mutex> lk(seen_mtx_);
+                    auto it = seen_.find(key);
+                    if (it != seen_.end() && it->second.mtime_ns == mt) continue;
+                }
+
+                if (is_ext(p, ".png"))      push_face_toast(p);
+                else if (is_ext(p, ".gif")) push_gif_toast(p);
+                // Other extensions are left in the inbox unannounced —
+                // they're presumably general downloads the user is
+                // handling outside ProtoHUD.
+            }
+        }
+
+        // Garbage-collect seen entries whose files are gone (imported /
+        // dismissed) so the map doesn't grow without bound.
+        {
+            std::lock_guard<std::mutex> lk(seen_mtx_);
+            for (auto it = seen_.begin(); it != seen_.end(); ) {
+                std::error_code e;
+                if (!fs::exists(it->first, e)) it = seen_.erase(it);
+                else ++it;
+            }
+        }
+
+        std::this_thread::sleep_until(loop_start + std::chrono::milliseconds(500));
+    }
+}
+
+} // namespace integrations

--- a/src/integrations/phone_inbox.h
+++ b/src/integrations/phone_inbox.h
@@ -1,0 +1,86 @@
+#pragma once
+// ── phone_inbox.h ────────────────────────────────────────────────────────────
+// Watches a directory for files dropped in by the phone (typically via KDE
+// Connect's Share & Receive → ~/Downloads, but any path works — sftp, scp,
+// manual move) and surfaces interactive toasts: "Phone shared happy.png —
+// Import as 'happy'?" → [Import] [Dismiss]. Import calls a host-supplied
+// handler so the watcher stays decoupled from NativeFaceController; the
+// host wires the handler with whatever face/gif controller is live.
+//
+// Worker polls at 2 Hz (cheap; the directory rarely has more than a handful
+// of files). On import, the file is moved to <inbox>/.processed/; on
+// dismiss, to <inbox>/.dismissed/. That preserves the user's data and
+// keeps the inbox itself tidy so the next poll doesn't re-notify.
+
+#include <atomic>
+#include <chrono>
+#include <functional>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <unordered_map>
+
+struct AppState;
+
+namespace integrations {
+
+struct PhoneInboxConfig {
+    bool        enabled        = true;
+    // Directory the watcher scans. Defaults at construction time to
+    // $XDG_DOWNLOAD_DIR / ~/Downloads (KDE Connect's default share target).
+    std::string watch_dir;
+    // Seconds before an unmodified file is considered "settled" and worth
+    // notifying about — guards against picking up a half-transferred file.
+    int         settle_seconds = 2;
+    // Auto-dismiss applied to the import-prompt toast. 0 keeps it sticky
+    // until the user acts on it (recommended — dropping in a face you
+    // wanted to import would be annoying).
+    float       auto_dismiss_s = 0.0f;
+};
+
+class PhoneInbox {
+public:
+    // Returns true on success. The host populates these from main's scope so
+    // the inbox can stay free of face/controller dependencies. src_path is
+    // an absolute path inside the watch dir; the watcher takes care of
+    // moving it into .processed/ on success.
+    using ImportFaceFn = std::function<bool(const std::string& src_path,
+                                            const std::string& expression)>;
+    using ImportGifFn  = std::function<bool(const std::string& src_path,
+                                            const std::string& filename)>;
+
+    PhoneInbox(AppState& state, PhoneInboxConfig cfg,
+               ImportFaceFn import_face, ImportGifFn import_gif);
+    ~PhoneInbox();
+
+    PhoneInbox(const PhoneInbox&)            = delete;
+    PhoneInbox& operator=(const PhoneInbox&) = delete;
+
+    bool start();
+    void stop();
+
+    const std::string& watch_dir() const { return cfg_.watch_dir; }
+
+private:
+    void worker();
+
+    AppState&            state_;
+    PhoneInboxConfig     cfg_;
+    ImportFaceFn         import_face_;
+    ImportGifFn          import_gif_;
+
+    std::atomic<bool>    running_{false};
+    std::thread          thread_;
+
+    // Per-file tracker: notif id we pushed (so we can dismiss the toast
+    // after the user acts), and the last-seen mtime so we re-notify when
+    // the user re-shares the same name with new content.
+    struct Seen {
+        uint32_t notif_id  = 0;
+        int64_t  mtime_ns  = 0;
+    };
+    mutable std::mutex   seen_mtx_;
+    std::unordered_map<std::string, Seen> seen_;
+};
+
+} // namespace integrations

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -460,6 +460,12 @@ static void pf_hub75_panel_dims(const std::string& sz, int& w, int& h) {
 // Returns each panel's (x, y, panel_w, panel_h) with the user's nudge applied
 // and a canonical name ("panel_0" .. "panel_N"). The first panel always
 // anchors at (0, 0) + nudge[0]; subsequent panels lay out per arrangement.
+// 32-px background margin on each side of the panel set. Sized so the
+// per-panel nudge (±32 px) can slide a panel that much past a neighbour's
+// edge without the canvas truncating any pixels. With two 128×... panels
+// in a horizontal chain that puts the canvas at 256 + 64 = 320 px wide.
+static constexpr int kHub75Margin = 32;
+
 static std::vector<face::ShmPusherOutput::Panel>
 pf_hub75_panels(const PfHub75Layout& L) {
     const int n = std::clamp(L.panel_count, 1, 4);
@@ -474,10 +480,15 @@ pf_hub75_panels(const PfHub75Layout& L) {
                                ? L.panel_size : L.panel_size_per[i];
         pf_hub75_panel_dims(s, pw[i], ph[i]);
     }
+    // Base positions place the first panel at (0, 0); push() then offsets
+    // every panel by kHub75Margin so the set is centred inside the
+    // margin-padded canvas, then adds each panel's nudge.
     auto push = [&](int i, int x, int y) {
         face::ShmPusherOutput::Panel p;
         p.name = "panel_" + std::to_string(i);
-        p.rect = cv::Rect(x + L.nudge_dx[i], y + L.nudge_dy[i], pw[i], ph[i]);
+        p.rect = cv::Rect(x + kHub75Margin + L.nudge_dx[i],
+                          y + kHub75Margin + L.nudge_dy[i],
+                          pw[i], ph[i]);
         out.push_back(std::move(p));
     };
     if (L.arrangement == "vertical") {
@@ -505,14 +516,39 @@ pf_hub75_panels(const PfHub75Layout& L) {
     return out;
 }
 
-// Total canvas size needed to fit the laid-out panels (after nudges).
+// Total canvas size = bounding box of the *un-nudged* panel set + a 32-px
+// margin on each side. Canvas size is therefore stable as the user tweaks
+// nudges (so the renderer canvas doesn't resize every slider step), and
+// every panel stays inside the canvas even at maximum nudge.
 static void pf_hub75_canvas(const PfHub75Layout& L, int& cw, int& ch) {
-    const auto panels = pf_hub75_panels(L);
-    cw = ch = 0;
-    for (const auto& p : panels) {
-        cw = std::max(cw, p.rect.x + p.rect.width);
-        ch = std::max(ch, p.rect.y + p.rect.height);
+    const int n = std::clamp(L.panel_count, 1, 4);
+    int pw[4] = {0,0,0,0}, ph[4] = {0,0,0,0};
+    for (int i = 0; i < 4; ++i) {
+        const std::string& s = L.panel_size_per[i].empty()
+                               ? L.panel_size : L.panel_size_per[i];
+        pf_hub75_panel_dims(s, pw[i], ph[i]);
     }
+    int bb_w = 0, bb_h = 0;
+    if (L.arrangement == "vertical") {
+        for (int i = 0; i < n; ++i) {
+            bb_w = std::max(bb_w, pw[i]);
+            bb_h += ph[i];
+        }
+    } else if (L.arrangement == "grid2x2") {
+        const int row0_w = pw[0] + (n >= 2 ? pw[1] : 0);
+        const int row1_w = (n >= 3 ? pw[2] : 0) + (n >= 4 ? pw[3] : 0);
+        bb_w = std::max(row0_w, row1_w);
+        const int row0_h = std::max(ph[0], n >= 2 ? ph[1] : 0);
+        const int row1_h = std::max(n >= 3 ? ph[2] : 0, n >= 4 ? ph[3] : 0);
+        bb_h = row0_h + row1_h;
+    } else { // horizontal
+        for (int i = 0; i < n; ++i) {
+            bb_w += pw[i];
+            bb_h = std::max(bb_h, ph[i]);
+        }
+    }
+    cw = bb_w + 2 * kHub75Margin;
+    ch = bb_h + 2 * kHub75Margin;
     if (cw <= 0) cw = 64;
     if (ch <= 0) ch = 32;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1203,6 +1203,15 @@ static std::vector<MenuItem> build_menu(
         // the HUB75 Layout submenu (Phase 3) — for now changes take effect
         // on the next backend hot-swap.
         PfHub75Layout* pf_hub75_p = nullptr,
+        // Named HUB75 layouts — Save As / Load / Rename / Delete management.
+        // pf_hub75_p above is the *working copy* of the active entry; these
+        // pointers expose the map + selection so the menu can swap which
+        // layout is being edited. pf_layout_changed runs after every
+        // mutation (active swap, save-as, rename, delete) so the controller
+        // can pick up the new active-layout name for face-folder stamping.
+        std::map<std::string, PfHub75Layout>* pf_hub75_layouts_p = nullptr,
+        std::string* pf_hub75_active_p = nullptr,
+        std::function<void()> pf_layout_changed = nullptr,
         // Face animation tunables — pointers + a "push live" callback that
         // forwards the current values into native_ctrl after a slider/toggle
         // change. Caller owns the slots and the persistence to config.json.
@@ -1672,8 +1681,15 @@ static std::vector<MenuItem> build_menu(
         m.type  = MenuItemType::SUBMENU;
         m.label = label;
 
-        m.label_fn = [teensy, expr, label]() -> std::string {
-            return teensy->face_image_exists(expr) ? label : (label + " (empty)");
+        // Slot label: "(empty)" when no PNG; "[Other Layout]" when the
+        // saved PNG was stamped with a layout name that doesn't match the
+        // currently-active one. Untagged (legacy) faces show plain.
+        m.label_fn = [teensy, expr, label, pf_hub75_active_p]() -> std::string {
+            if (!teensy->face_image_exists(expr)) return label + " (empty)";
+            const std::string tag = teensy->face_image_layout(expr);
+            if (tag.empty() || !pf_hub75_active_p || tag == *pf_hub75_active_p)
+                return label;
+            return label + "  [" + tag + "]";
         };
 
         m.on_highlight = [face_preview, slot_idx]{ face_preview->want = slot_idx; };
@@ -1830,8 +1846,15 @@ static std::vector<MenuItem> build_menu(
         m.type  = MenuItemType::SUBMENU;
         m.label = label;
 
-        m.label_fn = [teensy, expr, label]() -> std::string {
-            return teensy->face_image_exists(expr) ? label : (label + " (empty)");
+        // Slot label: "(empty)" when no PNG; "[Other Layout]" when the
+        // saved PNG was stamped with a layout name that doesn't match the
+        // currently-active one. Untagged (legacy) faces show plain.
+        m.label_fn = [teensy, expr, label, pf_hub75_active_p]() -> std::string {
+            if (!teensy->face_image_exists(expr)) return label + " (empty)";
+            const std::string tag = teensy->face_image_layout(expr);
+            if (tag.empty() || !pf_hub75_active_p || tag == *pf_hub75_active_p)
+                return label;
+            return label + "  [" + tag + "]";
         };
         m.on_highlight = [mouth_preview, idx]{ mouth_preview->want = idx; };
 
@@ -1986,8 +2009,15 @@ static std::vector<MenuItem> build_menu(
         m.type  = MenuItemType::SUBMENU;
         m.label = label;
 
-        m.label_fn = [teensy, expr, label]() -> std::string {
-            return teensy->face_image_exists(expr) ? label : (label + " (empty)");
+        // Slot label: "(empty)" when no PNG; "[Other Layout]" when the
+        // saved PNG was stamped with a layout name that doesn't match the
+        // currently-active one. Untagged (legacy) faces show plain.
+        m.label_fn = [teensy, expr, label, pf_hub75_active_p]() -> std::string {
+            if (!teensy->face_image_exists(expr)) return label + " (empty)";
+            const std::string tag = teensy->face_image_layout(expr);
+            if (tag.empty() || !pf_hub75_active_p || tag == *pf_hub75_active_p)
+                return label;
+            return label + "  [" + tag + "]";
         };
         m.on_highlight = [boop_face_preview, idx]{ boop_face_preview->want = idx; };
 
@@ -4399,14 +4429,115 @@ static std::vector<MenuItem> build_menu(
             }
         };
 
-        std::vector<MenuItem> hub_items = {
+        std::vector<MenuItem> hub_items;
+
+        // ── Named-layout management (Save As / Load / Rename / Delete) ───────
+        // Shown only when the host wired through the named-layout pointers.
+        // Operations work on the live `*H` so the user's in-progress edits to
+        // the active layout are preserved when switching.
+        if (pf_hub75_layouts_p && pf_hub75_active_p) {
+            auto* M = pf_hub75_layouts_p;
+            auto* A = pf_hub75_active_p;
+            auto layout_changed = pf_layout_changed;
+            // Helper: ith name in the map's iteration order (stable for std::map).
+            auto nth_name = [M](int i) -> std::string {
+                if (i < 0) return {};
+                int k = 0;
+                for (const auto& [n, _] : *M) { if (k++ == i) return n; }
+                return {};
+            };
+
+            // Save As — copy the current working layout into a new named slot
+            // and switch the working copy onto it.
+            hub_items.push_back(with_desc(
+                leaf("Save As...", [H, M, A, layout_changed, menu_sys_pp]{
+                    if (!menu_sys_pp || !*menu_sys_pp) return;
+                    (*menu_sys_pp)->open_keyboard("Layout Name", *A,
+                        [H, M, A, layout_changed](const std::string& name){
+                            if (name.empty()) return;
+                            (*M)[*A]   = *H;          // checkpoint current edits
+                            (*M)[name] = *H;          // copy into new slot
+                            *A = name;
+                            if (layout_changed) layout_changed();
+                        });
+                }),
+                "Save the panels + nudges you've configured here as a new "
+                "named layout. Subsequent edits go to the new layout; switch "
+                "back via Load Layout."));
+
+            // Load — pre-allocated 16 slot rows; each one's label_fn pulls the
+            // i-th map entry and the action loads it. Hidden when i is past
+            // the current map size. Matches the profile-slots pattern.
+            constexpr int kLayoutSlots = 16;
+            std::vector<MenuItem> load_items;
+            for (int i = 0; i < kLayoutSlots; ++i) {
+                MenuItem li;
+                li.type  = MenuItemType::LEAF;
+                li.label = "layout";
+                li.label_fn = [nth_name, A, i]{
+                    const std::string nm = nth_name(i);
+                    if (nm.empty()) return std::string();
+                    return (*A == nm) ? (nm + "  *") : nm;
+                };
+                li.visible_fn = [M, i]{ return i < static_cast<int>(M->size()); };
+                li.action = [H, M, A, layout_changed, nth_name, i]{
+                    const std::string nm = nth_name(i);
+                    if (nm.empty() || *A == nm) return;
+                    (*M)[*A] = *H;
+                    *A = nm;
+                    *H = (*M)[nm];
+                    if (layout_changed) layout_changed();
+                };
+                load_items.push_back(std::move(li));
+            }
+            MenuItem load_sub = submenu("Load Layout", std::move(load_items));
+            load_sub.label_fn = [A]{ return std::string("Load Layout  (") + *A + ")"; };
+            load_sub.description =
+                "Switch to a different saved layout. The current layout's "
+                "edits are checkpointed first. * marks the active one.";
+            hub_items.push_back(std::move(load_sub));
+
+            // Rename — replace the active layout's key without copying data.
+            hub_items.push_back(with_desc(
+                leaf("Rename Active...", [H, M, A, layout_changed, menu_sys_pp]{
+                    if (!menu_sys_pp || !*menu_sys_pp) return;
+                    const std::string old_name = *A;
+                    (*menu_sys_pp)->open_keyboard("Layout Name", old_name,
+                        [H, M, A, layout_changed, old_name](const std::string& name){
+                            if (name.empty() || name == old_name) return;
+                            (*M)[old_name] = *H;
+                            (*M)[name] = (*M)[old_name];
+                            M->erase(old_name);
+                            *A = name;
+                            if (layout_changed) layout_changed();
+                        });
+                }),
+                "Rename the active layout. Face PNGs stamped with the old "
+                "name will read as a mismatch until you re-import them."));
+
+            // Delete — only when there's at least one other layout to fall back to.
+            MenuItem del = leaf("Delete Active",
+                [H, M, A, layout_changed]{
+                    if (M->size() <= 1) return;
+                    M->erase(*A);
+                    *A = M->begin()->first;
+                    *H = M->begin()->second;
+                    if (layout_changed) layout_changed();
+                });
+            del.label_fn = [A]{ return std::string("Delete \"") + *A + "\""; };
+            del.visible_fn = [M]{ return M->size() > 1; };
+            del.description = "Remove this layout. The first remaining "
+                              "saved layout becomes active.";
+            hub_items.push_back(std::move(del));
+        }
+
+        hub_items.push_back(
             with_desc(submenu("Default Panel Size", std::move(size_items)),
                       "Size applied to every panel slot whose Panel N > Size "
                       "is set to \"Use Default\". Per-slot overrides let a "
-                      "build mix sizes."),
-            submenu("Panel Count", std::move(count_items)),
-            submenu("Arrangement", std::move(arr_items)),
-        };
+                      "build mix sizes."));
+        hub_items.push_back(submenu("Panel Count", std::move(count_items)));
+        hub_items.push_back(submenu("Arrangement", std::move(arr_items)));
         for (auto& it : nudge_items) hub_items.push_back(std::move(it));
         hub_items.push_back(with_desc(
             leaf("Reset All Positions",
@@ -4420,8 +4551,15 @@ static std::vector<MenuItem> build_menu(
             "Panel size + count + arrangement for the HUB75 backend. "
             "Each panel exposes a Nudge X/Y slider (±32 px integer) so you "
             "can align the editor canvas to physical mounting offsets. "
-            "Persisted to cfg[\"protoface\"][\"hub75\"]; takes effect on the "
-            "next backend (re)start.");
+            "Save As / Load lets you keep multiple named layouts (e.g. one "
+            "per helmet build); faces are stamped with the active layout "
+            "name on import. Persisted to cfg[\"protoface\"][\"hub75_layouts\"].");
+        if (pf_hub75_active_p) {
+            auto* A = pf_hub75_active_p;
+            pf_hub75_layout_item.label_fn = [A]{
+                return std::string("HUB75 Layout  (") + *A + ")";
+            };
+        }
         pf_hub75_layout_item.visible_fn = [pf_backend_p]{
             return pf_backend_p && *pf_backend_p == "hub75";
         };
@@ -7749,6 +7887,14 @@ int main(int argc, char* argv[]) {
     // configs are unchanged. Once the user picks a layout it persists to
     // cfg["protoface"]["hub75"].
     PfHub75Layout pf_hub75;
+    // Named HUB75 layouts — users can save multiple panel-arrangement profiles
+    // ("Default", "ConTour", "CM5 Helmet", …) and switch between them. The
+    // working `pf_hub75` is the live edit copy of pf_hub75_layouts[
+    // pf_hub75_active]; save_cfg + every layout-management action sync the
+    // two. Faces created while a given layout is active are stamped with its
+    // name (NativeFaceController::set_active_layout_name + import_face_image).
+    std::map<std::string, PfHub75Layout> pf_hub75_layouts;
+    std::string pf_hub75_active = "Default";
     // Face animation tunables — forwarded to every panel's FaceState live
     // and persisted to cfg["protoface"]["animation"] on save.
     bool   pf_blink_enabled   = true;
@@ -7771,23 +7917,37 @@ int main(int argc, char* argv[]) {
             pf_mouth_layout = jl.value("mouth", pf_mouth_layout);
             pf_nose_layout  = jl.value("nose",  pf_nose_layout);
         }
-        if (jpf.contains("hub75") && jpf["hub75"].is_object()) {
-            auto& jh = jpf["hub75"];
-            pf_hub75.panel_size  = jh.value("panel_size",  pf_hub75.panel_size);
-            pf_hub75.arrangement = jh.value("arrangement", pf_hub75.arrangement);
-            pf_hub75.panel_count = jval(jh, "panel_count", pf_hub75.panel_count);
+        auto parse_hub75_layout = [](const json& jh, PfHub75Layout L) -> PfHub75Layout {
+            if (!jh.is_object()) return L;
+            L.panel_size  = jh.value("panel_size",  L.panel_size);
+            L.arrangement = jh.value("arrangement", L.arrangement);
+            L.panel_count = jval(jh, "panel_count", L.panel_count);
             if (jh.contains("panel_size_per") && jh["panel_size_per"].is_array())
                 for (size_t i = 0; i < jh["panel_size_per"].size() && i < 4; ++i)
                     if (jh["panel_size_per"][i].is_string())
-                        pf_hub75.panel_size_per[i] =
-                            jh["panel_size_per"][i].get<std::string>();
+                        L.panel_size_per[i] = jh["panel_size_per"][i].get<std::string>();
             if (jh.contains("nudge_dx") && jh["nudge_dx"].is_array())
                 for (size_t i = 0; i < jh["nudge_dx"].size() && i < 4; ++i)
-                    pf_hub75.nudge_dx[i] = jh["nudge_dx"][i].get<int>();
+                    L.nudge_dx[i] = jh["nudge_dx"][i].get<int>();
             if (jh.contains("nudge_dy") && jh["nudge_dy"].is_array())
                 for (size_t i = 0; i < jh["nudge_dy"].size() && i < 4; ++i)
-                    pf_hub75.nudge_dy[i] = jh["nudge_dy"][i].get<int>();
-            pf_hub75.defaults_applied = jval(jh, "defaults_applied", false);
+                    L.nudge_dy[i] = jh["nudge_dy"][i].get<int>();
+            L.defaults_applied = jval(jh, "defaults_applied", false);
+            return L;
+        };
+        // Multi-layout schema (preferred): hub75_layouts is a name→layout map,
+        // hub75_active picks the working one. Falls back to the legacy single
+        // hub75 block when those aren't present (one-time migration to
+        // hub75_layouts["Default"] on the next save).
+        if (jpf.contains("hub75_layouts") && jpf["hub75_layouts"].is_object()) {
+            for (auto& [name, jh] : jpf["hub75_layouts"].items())
+                pf_hub75_layouts[name] = parse_hub75_layout(jh, PfHub75Layout{});
+            pf_hub75_active = jpf.value("hub75_active", pf_hub75_active);
+            if (!pf_hub75_layouts.count(pf_hub75_active))
+                pf_hub75_active = pf_hub75_layouts.begin()->first;
+            pf_hub75 = pf_hub75_layouts[pf_hub75_active];
+        } else if (jpf.contains("hub75") && jpf["hub75"].is_object()) {
+            pf_hub75 = parse_hub75_layout(jpf["hub75"], pf_hub75);
         }
         if (jpf.contains("animation") && jpf["animation"].is_object()) {
             auto& ja = jpf["animation"];
@@ -7813,6 +7973,15 @@ int main(int argc, char* argv[]) {
     // (first run, or upgrading from the old "delta from base" schema
     // where all-zero nudges would now stack panels at the centre).
     if (!pf_hub75.defaults_applied) pf_hub75_apply_defaults(pf_hub75);
+    // Seed the named-layouts map on first launch (or after migrating from
+    // the legacy single-block schema) so the menu always has something
+    // selectable. Whichever was loaded into pf_hub75 above becomes the
+    // initial Default.
+    if (pf_hub75_layouts.empty()) {
+        pf_hub75_layouts[pf_hub75_active] = pf_hub75;
+    } else {
+        pf_hub75_layouts[pf_hub75_active] = pf_hub75;   // keep the map in sync
+    }
 
     // Scheduler / reminders. Networking lives in the scheduler_daemon companion;
     // ProtoHUD only reads the merged events.json + scheduler_status.json it writes.
@@ -8732,6 +8901,7 @@ int main(int argc, char* argv[]) {
         native_ctrl->set_blink_enabled(pf_blink_enabled);
         native_ctrl->set_blink_timing(pf_blink_min, pf_blink_max, pf_blink_duration);
         native_ctrl->set_expression_fade(pf_expr_fade);
+        native_ctrl->set_active_layout_name(pf_hub75_active);
         protoface_ctrl.start();   // shm reader only — feeds the in-HUD preview
         std::cout << "[main] Protoface: native in-process renderer\n";
 
@@ -8921,6 +9091,7 @@ int main(int argc, char* argv[]) {
         native_ctrl->set_blink_enabled(pf_blink_enabled);
         native_ctrl->set_blink_timing(pf_blink_min, pf_blink_max, pf_blink_duration);
         native_ctrl->set_expression_fade(pf_expr_fade);
+        native_ctrl->set_active_layout_name(pf_hub75_active);
 
         // panel_driver.py choreography. The Python shim is only needed for
         // HUB75 (it reads /dev/shm frames and pushes them via piomatter);
@@ -9135,6 +9306,11 @@ int main(int argc, char* argv[]) {
                                edit_face,
                                &pf_eye_layout, &pf_mouth_layout, &pf_nose_layout,
                                &pf_hub75,
+                               &pf_hub75_layouts, &pf_hub75_active,
+                               /* pf_layout_changed */ [&]{
+                                   if (native_ctrl)
+                                       native_ctrl->set_active_layout_name(pf_hub75_active);
+                               },
                                &pf_blink_enabled, &pf_blink_min, &pf_blink_max,
                                &pf_blink_duration, &pf_expr_fade,
                                &pf_preview_duration_s,
@@ -9825,19 +10001,30 @@ int main(int argc, char* argv[]) {
         cfg["protoface"]["layout"]["eye"]       = pf_eye_layout;
         cfg["protoface"]["layout"]["mouth"]     = pf_mouth_layout;
         cfg["protoface"]["layout"]["nose"]      = pf_nose_layout;
-        cfg["protoface"]["hub75"]["panel_size"]     = pf_hub75.panel_size;
-        cfg["protoface"]["hub75"]["arrangement"]    = pf_hub75.arrangement;
-        cfg["protoface"]["hub75"]["panel_count"]    = pf_hub75.panel_count;
-        cfg["protoface"]["hub75"]["panel_size_per"] = json::array({
-            pf_hub75.panel_size_per[0], pf_hub75.panel_size_per[1],
-            pf_hub75.panel_size_per[2], pf_hub75.panel_size_per[3]});
-        cfg["protoface"]["hub75"]["defaults_applied"] = pf_hub75.defaults_applied;
-        cfg["protoface"]["hub75"]["nudge_dx"]    =
-            json::array({pf_hub75.nudge_dx[0], pf_hub75.nudge_dx[1],
-                         pf_hub75.nudge_dx[2], pf_hub75.nudge_dx[3]});
-        cfg["protoface"]["hub75"]["nudge_dy"]    =
-            json::array({pf_hub75.nudge_dy[0], pf_hub75.nudge_dy[1],
-                         pf_hub75.nudge_dy[2], pf_hub75.nudge_dy[3]});
+        // Sync the working layout into the named-map before serialising so
+        // the in-flight edits the user made to the active layout land on disk.
+        pf_hub75_layouts[pf_hub75_active] = pf_hub75;
+        cfg["protoface"]["hub75_active"] = pf_hub75_active;
+        auto layout_to_json = [](const PfHub75Layout& L) {
+            json jh = json::object();
+            jh["panel_size"]       = L.panel_size;
+            jh["arrangement"]      = L.arrangement;
+            jh["panel_count"]      = L.panel_count;
+            jh["panel_size_per"]   = json::array({L.panel_size_per[0], L.panel_size_per[1],
+                                                  L.panel_size_per[2], L.panel_size_per[3]});
+            jh["defaults_applied"] = L.defaults_applied;
+            jh["nudge_dx"]         = json::array({L.nudge_dx[0], L.nudge_dx[1],
+                                                  L.nudge_dx[2], L.nudge_dx[3]});
+            jh["nudge_dy"]         = json::array({L.nudge_dy[0], L.nudge_dy[1],
+                                                  L.nudge_dy[2], L.nudge_dy[3]});
+            return jh;
+        };
+        json jlayouts = json::object();
+        for (const auto& [name, L] : pf_hub75_layouts) jlayouts[name] = layout_to_json(L);
+        cfg["protoface"]["hub75_layouts"] = std::move(jlayouts);
+        // Drop the legacy single-block key so we don't accumulate stale data
+        // from older versions when the user moves between layouts.
+        cfg["protoface"].erase("hub75");
         cfg["protoface"]["animation"]["blink_enabled"]   = pf_blink_enabled;
         cfg["protoface"]["animation"]["blink_min"]       = pf_blink_min;
         cfg["protoface"]["animation"]["blink_max"]       = pf_blink_max;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -59,6 +59,7 @@
 #include "qr_scanner.h"
 #include "splash.h"
 #include "integrations/kdeconnect_bridge.h"   // header is dbus-free; .cpp guarded by HAVE_DBUS in CMake
+#include "integrations/phone_inbox.h"
 #include "hud/background_library.h"
 #include "profile_manager.h"
 #include "face/face_config.h"
@@ -8020,6 +8021,19 @@ int main(int argc, char* argv[]) {
         kdc_cfg.app_blocklist  = jk.value("app_blocklist",  kdc_cfg.app_blocklist);
     }
 
+    // Phone Inbox — watches a directory (default ~/Downloads) for files
+    // shared from the phone (via KDE Connect Share or anything else) and
+    // surfaces import-prompt toasts. Doesn't depend on DBus; works even
+    // when the user shares files some other way (sftp, scp, etc.).
+    integrations::PhoneInboxConfig pi_cfg;
+    if (cfg.contains("phone_inbox")) {
+        auto& jp = cfg["phone_inbox"];
+        pi_cfg.enabled        = jval(jp, "enabled",        pi_cfg.enabled);
+        pi_cfg.watch_dir      = jp.value("watch_dir",      pi_cfg.watch_dir);
+        pi_cfg.settle_seconds = jval(jp, "settle_seconds", pi_cfg.settle_seconds);
+        pi_cfg.auto_dismiss_s = jval(jp, "auto_dismiss_s", pi_cfg.auto_dismiss_s);
+    }
+
     if (cfg.contains("pip")) {
         auto& jpip = cfg["pip"];
         float def_size = jval(jpip, "size", 0.25f);
@@ -9299,6 +9313,50 @@ int main(int argc, char* argv[]) {
     BackgroundLibrary* bg_lib_ptr = nullptr;   // set after bg_lib is constructed
     std::vector<MenuItem> quick_items;   // curated corner/radial quick-menu tree
     std::string cfg_gifs_dir = pf_build_render_config(cfg).gifs_dir;
+
+    // Phone Inbox — watches the configured drop directory (default
+    // ~/Downloads) and toasts an Import prompt when a face PNG or GIF
+    // appears. Handlers capture face_proxy + cfg_gifs_dir by reference so
+    // they hit whichever backend is live at the moment the user accepts.
+    const bool pi_enabled = pi_cfg.enabled;
+    integrations::PhoneInbox phone_inbox(
+        state, std::move(pi_cfg),
+        /* import_face */
+        [&face_proxy](const std::string& src_path,
+                      const std::string& expression) -> bool {
+            return face_proxy.import_face_image(expression, src_path);
+        },
+        /* import_gif */
+        [&face_proxy, &cfg_gifs_dir](const std::string& src_path,
+                                     const std::string& filename) -> bool {
+            namespace fs = std::filesystem;
+            if (cfg_gifs_dir.empty()) return false;
+            std::error_code ec;
+            fs::create_directories(cfg_gifs_dir, ec);
+            const fs::path dst = fs::path(cfg_gifs_dir) / filename;
+            fs::copy_file(src_path, dst,
+                          fs::copy_options::overwrite_existing, ec);
+            if (ec) return false;
+            // Bind to the first empty slot so the user can play it
+            // immediately via the GIFs quick menu. If every slot is
+            // bound, fall through and let the user pick one manually
+            // later — the file still lives in gifs_dir.
+            for (uint8_t i = 0; i < 8; ++i) {
+                if (face_proxy.gif_slot(i).empty()) {
+                    face_proxy.bind_gif_slot(i, filename);
+                    break;
+                }
+            }
+            return true;
+        });
+    if (pi_enabled) {
+        if (!phone_inbox.start())
+            std::cout << "[phone-inbox] disabled (failed to open watch dir)\n";
+        else
+            std::cout << "[phone-inbox] watching " << phone_inbox.watch_dir() << "\n";
+    } else {
+        std::cout << "[phone-inbox] disabled (cfg.phone_inbox.enabled=false)\n";
+    }
     std::string cfg_bg_user_dir;
     if (const char* home = std::getenv("HOME"))
         cfg_bg_user_dir = std::string(home) + "/protohud/backgrounds";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -58,6 +58,7 @@
 #include "video_recorder.h"
 #include "qr_scanner.h"
 #include "splash.h"
+#include "integrations/kdeconnect_bridge.h"   // header is dbus-free; .cpp guarded by HAVE_DBUS in CMake
 #include "hud/background_library.h"
 #include "profile_manager.h"
 #include "face/face_config.h"
@@ -8007,6 +8008,18 @@ int main(int argc, char* argv[]) {
         sched_lead_min    = jval(jsc, "lead_minutes",    sched_lead_min);
     }
 
+    // KDE Connect bridge — RX phone notifications via DBus session bus.
+    // The bridge owns its own worker thread and no-ops cleanly when
+    // kdeconnectd isn't running, so non-Pi/dev hosts don't fail to start.
+    integrations::KdeConnectConfig kdc_cfg;
+    if (cfg.contains("kdeconnect")) {
+        auto& jk = cfg["kdeconnect"];
+        kdc_cfg.enabled        = jval(jk, "enabled",        kdc_cfg.enabled);
+        kdc_cfg.device_id      = jk.value("device_id",      kdc_cfg.device_id);
+        kdc_cfg.auto_dismiss_s = jval(jk, "auto_dismiss_s", kdc_cfg.auto_dismiss_s);
+        kdc_cfg.app_blocklist  = jk.value("app_blocklist",  kdc_cfg.app_blocklist);
+    }
+
     if (cfg.contains("pip")) {
         auto& jpip = cfg["pip"];
         float def_size = jval(jpip, "size", 0.25f);
@@ -8625,6 +8638,23 @@ int main(int argc, char* argv[]) {
     } else {
         std::cout << "[scheduler] disabled (scheduler.enabled=false)\n";
     }
+
+    // KDE Connect bridge — RX phone notifications, pushed into AppState::notifs.
+    // Optional (gated by HAVE_DBUS at build time + cfg.enabled at runtime); silent
+    // no-op when the daemon isn't running so it doesn't spam logs on dev hosts.
+#ifdef HAVE_DBUS
+    const bool kdc_enabled = kdc_cfg.enabled;
+    integrations::KdeConnectBridge kdc(state, std::move(kdc_cfg));
+    if (kdc_enabled) {
+        if (!kdc.start())
+            std::cout << "[kdeconnect] disabled (failed to attach to session bus)\n";
+        else
+            std::cout << "[kdeconnect] bridge started\n";
+    } else {
+        std::cout << "[kdeconnect] disabled (cfg.kdeconnect.enabled=false)\n";
+    }
+#endif
+
     CrashReporter::install(&state, cfg_crash_dir, GIT_HASH);
 
     // ── Async Timewarp ────────────────────────────────────────────────────────

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9014,13 +9014,20 @@ int main(int argc, char* argv[]) {
             if      (hud.toast_has_focused()) hud.toast_navigate(-1);
             else if (menu.is_open())          menu.back();
         });
+        // Editor lockdown — when the face editor is the active overlay the
+        // wireless cursor must not page through the menu underneath. Up/Down
+        // still route through menu.navigate (which forwards to face_editor_'s
+        // vertical cursor step); Left/Right route through menu.back/select,
+        // which would cancel/paint inside the editor — drop those.
         wireless.on_nav_up   ([&menu]{ if (menu.is_open()) menu.navigate(-1); });
         wireless.on_nav_down ([&menu]{ if (menu.is_open()) menu.navigate(+1); });
         wireless.on_nav_left ([&menu, &hud]{
+            if (menu.is_face_editor_open())   return;
             if      (hud.toast_has_focused()) hud.toast_navigate(-1);
             else if (menu.is_open())          menu.back();
         });
         wireless.on_nav_right([&menu, &hud, &state]{
+            if (menu.is_face_editor_open())   return;
             if      (hud.toast_has_focused()) hud.toast_navigate(+1);
             else if (menu.is_open())          menu.select();
         });
@@ -9290,6 +9297,7 @@ int main(int argc, char* argv[]) {
     gamepad.on_nav_up   ([&menu, &landing, &landing_nav, &state, &map_pan]{ if (state.map_overlay.expanded){map_pan(0,+0.06f);return;} if (menu.is_keyboard_open()){menu.osk_move(0,-1);return;} if (landing.active){landing_nav(-1);return;} if (menu.is_open()) menu.navigate(menu.editing_value() ? +1 : -1); });
     gamepad.on_nav_down ([&menu, &landing, &landing_nav, &state, &map_pan]{ if (state.map_overlay.expanded){map_pan(0,-0.06f);return;} if (menu.is_keyboard_open()){menu.osk_move(0,+1);return;} if (landing.active){landing_nav(+1);return;} if (menu.is_open()) menu.navigate(menu.editing_value() ? -1 : +1); });
     gamepad.on_nav_left ([&menu, &hud, &landing, &bg_lib, &state, &map_pan]{
+        if (menu.is_face_editor_open())   return;   // editor owns the d-pad
         if      (state.map_overlay.expanded) map_pan(+0.06f, 0);
         else if (menu.is_keyboard_open()) menu.osk_move(-1, 0);
         else if (landing.active)          bg_lib.prev();
@@ -9297,6 +9305,7 @@ int main(int argc, char* argv[]) {
         else if (menu.is_open())          menu.back();
     });
     gamepad.on_nav_right([&menu, &hud, &state, &landing, &bg_lib, &map_pan]{
+        if (menu.is_face_editor_open())   return;
         if      (state.map_overlay.expanded) map_pan(-0.06f, 0);
         else if (menu.is_keyboard_open()) menu.osk_move(+1, 0);
         else if (landing.active)          bg_lib.next();
@@ -9304,14 +9313,18 @@ int main(int argc, char* argv[]) {
         else if (menu.is_open())          menu.select();
     });
     // LB/RB: zoom the expanded map, else cycle the landing background, switch
-    // deep-menu tabs while it's open, otherwise toggle the PiPs.
+    // deep-menu tabs while it's open, otherwise toggle the PiPs. While the
+    // editor is open the shoulder buttons cycle the palette (via the menu_system
+    // handler) so we must not also tab through the menu underneath.
     gamepad.on_pip_left ([&menu, &kb_pip_left, &landing, &bg_lib, &state, &map_zoom] {
+        if (menu.is_face_editor_open())  return;
         if      (state.map_overlay.expanded) map_zoom(-0.4f);
         else if (landing.active)        bg_lib.prev();
         else if (menu.is_deep_open())   menu.prev_tab();
         else                            kb_pip_left  = !kb_pip_left;
     });
     gamepad.on_pip_right([&menu, &kb_pip_right, &landing, &bg_lib, &state, &map_zoom]{
+        if (menu.is_face_editor_open())  return;
         if      (state.map_overlay.expanded) map_zoom(+0.4f);
         else if (landing.active)        bg_lib.next();
         else if (menu.is_deep_open())   menu.next_tab();
@@ -10145,7 +10158,13 @@ int main(int argc, char* argv[]) {
             if (key_pressed(ImGuiKey_Escape) || key_pressed(ImGuiKey_F1)) menu.osk_cancel();
             for (ImWchar ch : ImGui::GetIO().InputQueueCharacters)
                 menu.osk_input_char(static_cast<unsigned int>(ch));
-        } else {
+        } else if (!menu.is_face_editor_open()) {
+        // Editor lockdown: skip ALL global ImGui hotkeys (Escape/P quit,
+        // Ctrl+Q/K force-kill, I menu toggle, F1 deep-menu toggle, Tab tab
+        // switch, N expanded map, E/Q/W/D vision-assist, C capture) while
+        // the face editor owns the screen. The editor has its own keyboard
+        // handling in menu_system.cpp; the user can Back out of the editor
+        // first if they need any of these.
         if (key_pressed(ImGuiKey_Escape) || key_pressed(ImGuiKey_P)) { state.quit = true; break; }
         // Ctrl+Q / Ctrl+K — force-kill (immediate exit, skips graceful cleanup)
         if (ImGui::GetIO().KeyCtrl &&
@@ -10264,12 +10283,20 @@ int main(int argc, char* argv[]) {
         // clears, restoring the PiP if it was on or closing a temp-opened stream.
         int preview = usb_preview_req;   // set during last frame's menu draw
         usb_preview_req = 0;             // re-set this frame if a panel is still up
-        bool p1 = pip_cam1_overlay_active || pip_left_active  || kb_pip_left  || wc_pip_left;
-        bool p2 = pip_cam2_overlay_active || pip_right_active || kb_pip_right || wc_pip_right;
-        bool p3 = pip_cam3_overlay_active;
-        bool want1 = p1 || preview == 1;
-        bool want2 = p2 || preview == 2;
-        bool want3 = p3 || preview == 3;
+        // Editor full-screen mode: while the face editor is open we close
+        // every USB camera stream and hide the on-screen PiPs. The existing
+        // open/close edge logic on want1/2/3 picks the streams back up when
+        // the user closes the editor. CSI eye cameras keep running so the
+        // renderer still has eye textures behind the editor overlay.
+        const bool editor_open = menu.is_face_editor_open();
+        bool p1 = (pip_cam1_overlay_active || pip_left_active  || kb_pip_left  || wc_pip_left)
+                  && !editor_open;
+        bool p2 = (pip_cam2_overlay_active || pip_right_active || kb_pip_right || wc_pip_right)
+                  && !editor_open;
+        bool p3 = pip_cam3_overlay_active && !editor_open;
+        bool want1 = (p1 || preview == 1) && !editor_open;
+        bool want2 = (p2 || preview == 2) && !editor_open;
+        bool want3 = (p3 || preview == 3) && !editor_open;
         if (want1 && !prev_p1) { tex_usb1 = 0; std::thread([&cameras]{ cameras.open_usb1(); }).detach(); }
         if (!want1 && prev_p1) { cameras.close_usb1(); tex_usb1 = 0; }
         if (want2 && !prev_p2) { tex_usb2 = 0; std::thread([&cameras]{ cameras.open_usb2(); }).detach(); }
@@ -10974,14 +11001,21 @@ int main(int argc, char* argv[]) {
         // Pass full display dimensions so NanoVG covers both eye halves.
         glViewport(0, 0, xr.display_width(), xr.display_height());
         hud.begin_nvg_overlay(xr.display_width(), xr.display_height());
-        // Hide the on-screen PiP for a slot whose live-preview panel is up — its
-        // feed is shown in the context pane instead (preview set above this frame).
-        hud.draw_pip_underlays(tex_usb1, p1 && preview != 1, pip_overlay_cfg1,
-                               tex_usb2, p2 && preview != 2, pip_overlay_cfg2,
-                               tex_usb3, p3 && preview != 3, pip_overlay_cfg3,
-                               xr.display_width(), xr.display_height());
-        hud.draw_hud_frame(snap, xr.display_width(), xr.display_height(), fps_overlay_active);
-        hud.draw_toasts(state.notifs, xr.display_width(), xr.display_height());
+        // Editor full-screen mode: skip every HUD chrome draw (PiP underlays,
+        // info panel + compass + minimap + clock chrome, toast banners) so
+        // the editor sits cleanly on top of the eye texture with no UI
+        // clutter. Toasts re-appear on close because they're a queue, not a
+        // timed overlay.
+        if (!editor_open) {
+            // Hide the on-screen PiP for a slot whose live-preview panel is up — its
+            // feed is shown in the context pane instead (preview set above this frame).
+            hud.draw_pip_underlays(tex_usb1, p1 && preview != 1, pip_overlay_cfg1,
+                                   tex_usb2, p2 && preview != 2, pip_overlay_cfg2,
+                                   tex_usb3, p3 && preview != 3, pip_overlay_cfg3,
+                                   xr.display_width(), xr.display_height());
+            hud.draw_hud_frame(snap, xr.display_width(), xr.display_height(), fps_overlay_active);
+            hud.draw_toasts(state.notifs, xr.display_width(), xr.display_height());
+        }
         hud.end_nvg_overlay();
 
         // ── Phase 2: ImGui overlays (menu, popups) ────────────────────────
@@ -11082,7 +11116,7 @@ int main(int argc, char* argv[]) {
             return FaceTex{native_tex, native_w, native_h, true};
         };
 
-        if (panel_preview_enabled) {
+        if (panel_preview_enabled && !editor_open) {
             const FaceTex ft = pick_face_tex();
             // On native backends the texture already IS the centred face
             // (canvas-mirroring is HUB75-only), so left/right/full views
@@ -11105,7 +11139,7 @@ int main(int argc, char* argv[]) {
         // System status panel (CPU/RAM/WiFi/ping/BT/SSH/perf/serial).
         // Debug panel: normal toggle, plus an option to show it in the expanded-map
         // view. When expanded, it opens to the right of the info sidebar (~310px).
-        {
+        if (!editor_open) {
             const bool expanded_view = snap.map_overlay.expanded;
             const bool show_dbg = sys_panel_active ||
                                   (expanded_view && snap.expanded_show_debug);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -268,11 +268,15 @@ static PfSideChains pf_auto_side_chains(
 // actual helper definitions live further down (next to the MAX7219
 // layout helpers); forward-declare what's needed here.
 struct PfHub75Layout {
-    std::string panel_size  = "64x32";      // 32x16 / 64x32 / 64x64 / 96x48 / 128x32 / 128x64
-    std::string arrangement = "horizontal"; // horizontal / vertical / grid2x2
-    int         panel_count = 1;            // 1..4
-    int         nudge_dx[4] = {0, 0, 0, 0};
-    int         nudge_dy[4] = {0, 0, 0, 0};
+    // Default size applied to every panel slot. Per-slot overrides in
+    // panel_size_per (empty string = "use default") let a build mix
+    // sizes — e.g. two 64x32 eye panels plus a 64x64 mouth.
+    std::string panel_size      = "64x32";
+    std::string arrangement     = "horizontal"; // horizontal / vertical / grid2x2
+    int         panel_count     = 1;            // 1..4
+    std::string panel_size_per[4] = {"", "", "", ""};
+    int         nudge_dx[4]     = {0, 0, 0, 0};
+    int         nudge_dy[4]     = {0, 0, 0, 0};
 };
 static std::vector<face::ShmPusherOutput::Panel>
 pf_hub75_panels(const PfHub75Layout& L);
@@ -458,22 +462,45 @@ static void pf_hub75_panel_dims(const std::string& sz, int& w, int& h) {
 // anchors at (0, 0) + nudge[0]; subsequent panels lay out per arrangement.
 static std::vector<face::ShmPusherOutput::Panel>
 pf_hub75_panels(const PfHub75Layout& L) {
-    int pw, ph; pf_hub75_panel_dims(L.panel_size, pw, ph);
     const int n = std::clamp(L.panel_count, 1, 4);
     std::vector<face::ShmPusherOutput::Panel> out;
     out.reserve(static_cast<size_t>(n));
+    // Resolve each slot's effective size — its per-slot override if set,
+    // otherwise the global default. Lets users mix panel sizes in one
+    // build (e.g. two 64x32 + one 64x64).
+    int pw[4] = {0,0,0,0}, ph[4] = {0,0,0,0};
+    for (int i = 0; i < 4; ++i) {
+        const std::string& s = L.panel_size_per[i].empty()
+                               ? L.panel_size : L.panel_size_per[i];
+        pf_hub75_panel_dims(s, pw[i], ph[i]);
+    }
     auto push = [&](int i, int x, int y) {
         face::ShmPusherOutput::Panel p;
         p.name = "panel_" + std::to_string(i);
-        p.rect = cv::Rect(x + L.nudge_dx[i], y + L.nudge_dy[i], pw, ph);
+        p.rect = cv::Rect(x + L.nudge_dx[i], y + L.nudge_dy[i], pw[i], ph[i]);
         out.push_back(std::move(p));
     };
     if (L.arrangement == "vertical") {
-        for (int i = 0; i < n; ++i) push(i, 0, i * ph);
+        // Stack: each panel's y = sum of preceding panels' heights.
+        int y = 0;
+        for (int i = 0; i < n; ++i) { push(i, 0, y); y += ph[i]; }
     } else if (L.arrangement == "grid2x2") {
-        for (int i = 0; i < n; ++i) push(i, (i % 2) * pw, (i / 2) * ph);
+        // 2x2 row-major: row 0 holds slots 0-1, row 1 holds slots 2-3.
+        // Each panel's column x is the width of its left sibling; row 1 y
+        // is the taller of the row 0 panels so mixed rows don't overlap.
+        const int row0_h = std::max(ph[0], n >= 2 ? ph[1] : 0);
+        for (int i = 0; i < n; ++i) {
+            const int col = i % 2;
+            const int row = i / 2;
+            int x = 0, y = 0;
+            if (col == 1) x = pw[i - 1];
+            if (row == 1) y = row0_h;
+            push(i, x, y);
+        }
     } else { // horizontal default
-        for (int i = 0; i < n; ++i) push(i, i * pw, 0);
+        // Chain: each panel's x = sum of preceding panels' widths.
+        int x = 0;
+        for (int i = 0; i < n; ++i) { push(i, x, 0); x += pw[i]; }
     }
     return out;
 }
@@ -4166,21 +4193,47 @@ static std::vector<MenuItem> build_menu(
             hub_pick_str("2x2 Grid",         &H->arrangement, "grid2x2"),
         };
 
-        // Per-panel nudge submenus (X / Y, ±32 px integer). Visible only when
-        // the panel index is within the active count.
+        // Per-panel submenus carrying that slot's Size override + Nudge.
+        // "Use Default" tracks the global Panel Size picker; the six other
+        // entries pin this slot to that physical size regardless of the
+        // global. Visible only when the panel index is within the active
+        // count.
+        auto size_pick = [&leaf_sel, H](const char* lbl, int i, const char* v) {
+            return leaf_sel(lbl,
+                [H, i, v]{ H->panel_size_per[i] = v; },
+                [H, i, v]{ return H->panel_size_per[i] == v; });
+        };
         std::vector<MenuItem> nudge_items;
         for (int i = 0; i < 4; ++i) {
+            std::vector<MenuItem> size_items = {
+                size_pick("Use Default", i, ""),
+                size_pick("32x16",       i, "32x16"),
+                size_pick("64x32",       i, "64x32"),
+                size_pick("64x64",       i, "64x64"),
+                size_pick("96x48",       i, "96x48"),
+                size_pick("128x32",      i, "128x32"),
+                size_pick("128x64",      i, "128x64"),
+            };
             std::vector<MenuItem> axis_items = {
+                submenu("Size", std::move(size_items)),
                 slider("Nudge X", -32.f, 32.f, 1.f, " px",
                     [H, i]{ return static_cast<float>(H->nudge_dx[i]); },
                     [H, i](float v){ H->nudge_dx[i] = static_cast<int>(v); }),
                 slider("Nudge Y", -32.f, 32.f, 1.f, " px",
                     [H, i]{ return static_cast<float>(H->nudge_dy[i]); },
                     [H, i](float v){ H->nudge_dy[i] = static_cast<int>(v); }),
-                leaf("Reset", [H, i]{ H->nudge_dx[i] = 0; H->nudge_dy[i] = 0; }),
+                leaf("Reset Nudge",
+                     [H, i]{ H->nudge_dx[i] = 0; H->nudge_dy[i] = 0; }),
             };
-            char nm[24]; std::snprintf(nm, sizeof(nm), "Panel %d Nudge", i + 1);
+            char nm[32]; std::snprintf(nm, sizeof(nm), "Panel %d", i + 1);
             MenuItem m = submenu(nm, std::move(axis_items));
+            // Dynamic label so the parent shows each slot's effective size.
+            m.label_fn = [H, i]{
+                const std::string& s = H->panel_size_per[i].empty()
+                                       ? H->panel_size : H->panel_size_per[i];
+                return std::string("Panel ") + std::to_string(i + 1)
+                       + " (" + s + ")";
+            };
             m.visible_fn = [H, i]{ return i < H->panel_count; };
             nudge_items.push_back(std::move(m));
         }
@@ -4236,7 +4289,10 @@ static std::vector<MenuItem> build_menu(
         };
 
         std::vector<MenuItem> hub_items = {
-            submenu("Panel Size",  std::move(size_items)),
+            with_desc(submenu("Default Panel Size", std::move(size_items)),
+                      "Size applied to every panel slot whose Panel N > Size "
+                      "is set to \"Use Default\". Per-slot overrides let a "
+                      "build mix sizes."),
             submenu("Panel Count", std::move(count_items)),
             submenu("Arrangement", std::move(arr_items)),
         };
@@ -7588,6 +7644,11 @@ int main(int argc, char* argv[]) {
             pf_hub75.panel_size  = jh.value("panel_size",  pf_hub75.panel_size);
             pf_hub75.arrangement = jh.value("arrangement", pf_hub75.arrangement);
             pf_hub75.panel_count = jval(jh, "panel_count", pf_hub75.panel_count);
+            if (jh.contains("panel_size_per") && jh["panel_size_per"].is_array())
+                for (size_t i = 0; i < jh["panel_size_per"].size() && i < 4; ++i)
+                    if (jh["panel_size_per"][i].is_string())
+                        pf_hub75.panel_size_per[i] =
+                            jh["panel_size_per"][i].get<std::string>();
             if (jh.contains("nudge_dx") && jh["nudge_dx"].is_array())
                 for (size_t i = 0; i < jh["nudge_dx"].size() && i < 4; ++i)
                     pf_hub75.nudge_dx[i] = jh["nudge_dx"][i].get<int>();
@@ -9597,9 +9658,12 @@ int main(int argc, char* argv[]) {
         cfg["protoface"]["layout"]["eye"]       = pf_eye_layout;
         cfg["protoface"]["layout"]["mouth"]     = pf_mouth_layout;
         cfg["protoface"]["layout"]["nose"]      = pf_nose_layout;
-        cfg["protoface"]["hub75"]["panel_size"]  = pf_hub75.panel_size;
-        cfg["protoface"]["hub75"]["arrangement"] = pf_hub75.arrangement;
-        cfg["protoface"]["hub75"]["panel_count"] = pf_hub75.panel_count;
+        cfg["protoface"]["hub75"]["panel_size"]     = pf_hub75.panel_size;
+        cfg["protoface"]["hub75"]["arrangement"]    = pf_hub75.arrangement;
+        cfg["protoface"]["hub75"]["panel_count"]    = pf_hub75.panel_count;
+        cfg["protoface"]["hub75"]["panel_size_per"] = json::array({
+            pf_hub75.panel_size_per[0], pf_hub75.panel_size_per[1],
+            pf_hub75.panel_size_per[2], pf_hub75.panel_size_per[3]});
         cfg["protoface"]["hub75"]["nudge_dx"]    =
             json::array({pf_hub75.nudge_dx[0], pf_hub75.nudge_dx[1],
                          pf_hub75.nudge_dx[2], pf_hub75.nudge_dx[3]});

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -263,6 +263,21 @@ static PfSideChains pf_auto_side_chains(
         const std::string& nose_layout,
         int canvas_h);
 
+// HUB75 panel layout state lives near the top of the file so the early
+// pf_build_panel_output / pf_build_render_config can see the type. The
+// actual helper definitions live further down (next to the MAX7219
+// layout helpers); forward-declare what's needed here.
+struct PfHub75Layout {
+    std::string panel_size  = "64x32";      // 32x16 / 64x32 / 64x64 / 96x48 / 128x32 / 128x64
+    std::string arrangement = "horizontal"; // horizontal / vertical / grid2x2
+    int         panel_count = 1;            // 1..4
+    int         nudge_dx[4] = {0, 0, 0, 0};
+    int         nudge_dy[4] = {0, 0, 0, 0};
+};
+static std::vector<face::ShmPusherOutput::Panel>
+pf_hub75_panels(const PfHub75Layout& L);
+static void pf_hub75_canvas(const PfHub75Layout& L, int& cw, int& ch);
+
 // hot-swap action use the exact same construction logic.
 static std::unique_ptr<face::PanelOutput>
 pf_build_panel_output(const json& cfg, const face::RenderConfig& rc,
@@ -425,17 +440,9 @@ pf_build_panel_output(const json& cfg, const face::RenderConfig& rc,
 }
 
 // ── HUB75 panel layout (presets + per-panel nudge) ───────────────────────────
-// User-facing config for the HUB75 face editor: pick a panel size from the
-// presets, how many panels, how they're arranged, then nudge each one ±32 px
-// to compensate for tiny mounting offsets between physical panels. All four
-// nudge slots exist regardless of count; values above count are ignored.
-struct PfHub75Layout {
-    std::string panel_size  = "64x32";      // 32x16 / 64x32 / 64x64 / 96x48 / 128x32 / 128x64
-    std::string arrangement = "horizontal"; // horizontal / vertical / grid2x2
-    int         panel_count = 1;            // 1..4
-    int         nudge_dx[4] = {0, 0, 0, 0};
-    int         nudge_dy[4] = {0, 0, 0, 0};
-};
+// PfHub75Layout is forward-declared above so pf_build_panel_output /
+// pf_build_render_config can see it; the helpers below are the actual
+// implementations.
 
 static void pf_hub75_panel_dims(const std::string& sz, int& w, int& h) {
     if      (sz == "32x16")  { w = 32;  h = 16; }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1211,6 +1211,10 @@ static std::vector<MenuItem> build_menu(
         double* pf_blink_max_p     = nullptr,
         double* pf_blink_dur_p     = nullptr,
         double* pf_expr_fade_p     = nullptr,
+        // Editor "V (Preview to panels)" hold time. No live-push callback —
+        // the value is read each time the editor opens, so changes take
+        // effect on the next Edit… launch.
+        double* pf_preview_duration_p = nullptr,
         std::function<void()> pf_anim_push = nullptr,
         // Pushes an arbitrary particle-system spec (a {"layers":[...]} dict
         // or single-effect spec) directly to the native renderer, bypassing
@@ -4555,6 +4559,19 @@ static std::vector<MenuItem> build_menu(
                         if (pf_anim_push) pf_anim_push();
                     }));
             }
+            if (pf_preview_duration_p) {
+                anim_items.push_back(with_desc(
+                    slider("Editor Preview Hold", 5.0f, 60.0f, 1.0f, "s",
+                        [pf_preview_duration_p]{
+                            return static_cast<float>(*pf_preview_duration_p);
+                        },
+                        [pf_preview_duration_p](float v){
+                            *pf_preview_duration_p = v;
+                        }),
+                    "How long the V (Preview to panels) key in the face "
+                    "editor shows the in-progress canvas on the physical "
+                    "panels before auto-restoring the saved face."));
+            }
             if (anim_items.empty()) {
                 MenuItem empty;
                 empty.visible_fn = []{ return false; };
@@ -7739,6 +7756,9 @@ int main(int argc, char* argv[]) {
     double pf_blink_max       = 7.0;
     double pf_blink_duration  = 0.15;
     double pf_expr_fade       = 0.3;
+    // V (Preview) hold time in the face editor — pushes the in-progress canvas
+    // onto the physical panels for this many seconds, then auto-restores.
+    double pf_preview_duration_s = 10.0;
     if (cfg.contains("protoface")) {
         auto& jpf = cfg["protoface"];
         pf_autostart     = jval(jpf, "autostart", true);
@@ -7776,6 +7796,8 @@ int main(int argc, char* argv[]) {
             pf_blink_max      = jval(ja, "blink_max",      pf_blink_max);
             pf_blink_duration = jval(ja, "blink_duration", pf_blink_duration);
             pf_expr_fade      = jval(ja, "expression_fade", pf_expr_fade);
+            pf_preview_duration_s =
+                jval(ja, "preview_duration_s", pf_preview_duration_s);
         }
         if (jpf.contains("preview")) {
             auto& jpv = jpf["preview"];
@@ -9000,7 +9022,21 @@ int main(int argc, char* argv[]) {
                 // expression in the loader's set (mouth-shape PNGs).
                 if (native_ctrl) native_ctrl->reload_active_face();
                 face_proxy.set_face_by_name(expression);
-            });
+            },
+            /* on_cancel */ {},
+            /* on_preview */ [&native_ctrl, expression, &face_proxy]
+                (const cv::Mat& rgba_canvas, double duration_s) {
+                if (!native_ctrl) return;
+                // Pop the expression so the user is looking at it, then push
+                // the in-progress canvas as a transient. The renderer thread
+                // will composite material + effects on top.
+                face_proxy.set_face_by_name(expression);
+                native_ctrl->push_transient_face(expression, rgba_canvas, duration_s);
+            },
+            /* live_frame */ [&native_ctrl](cv::Mat& out) -> bool {
+                return native_ctrl && native_ctrl->latest_frame(out);
+            },
+            /* preview_duration_s */ pf_preview_duration_s);
     };
 
     // Now that face_proxy exists, hook the audio engine's per-period
@@ -9101,6 +9137,7 @@ int main(int argc, char* argv[]) {
                                &pf_hub75,
                                &pf_blink_enabled, &pf_blink_min, &pf_blink_max,
                                &pf_blink_duration, &pf_expr_fade,
+                               &pf_preview_duration_s,
                                /* pf_anim_push */ [&]{
                                    if (!native_ctrl) return;
                                    native_ctrl->set_blink_enabled(pf_blink_enabled);
@@ -9806,6 +9843,7 @@ int main(int argc, char* argv[]) {
         cfg["protoface"]["animation"]["blink_max"]       = pf_blink_max;
         cfg["protoface"]["animation"]["blink_duration"]  = pf_blink_duration;
         cfg["protoface"]["animation"]["expression_fade"] = pf_expr_fade;
+        cfg["protoface"]["animation"]["preview_duration_s"] = pf_preview_duration_s;
         cfg["protoface"]["preview"]["anchor_x"] = protoface_preview_cfg.anchor_x;
         cfg["protoface"]["preview"]["anchor_y"] = protoface_preview_cfg.anchor_y;
         cfg["protoface"]["preview"]["pan_x"]    = protoface_preview_cfg.pan_x;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -275,12 +275,20 @@ struct PfHub75Layout {
     std::string arrangement     = "horizontal"; // horizontal / vertical / grid2x2
     int         panel_count     = 1;            // 1..4
     std::string panel_size_per[4] = {"", "", "", ""};
+    // Nudge stores each panel's CENTRE as an offset from the canvas centre
+    // (in canvas pixels). Default = auto-placed by apply_defaults() per
+    // arrangement; e.g. for two 64×32 panels in a horizontal chain the
+    // defaults are dx[0] = -32, dx[1] = +32 (P1 left of centre, P2 right).
     int         nudge_dx[4]     = {0, 0, 0, 0};
     int         nudge_dy[4]     = {0, 0, 0, 0};
+    // First-run flag — until apply_defaults has run we treat all-zero
+    // nudges as "uninitialised" and populate them.
+    bool        defaults_applied = false;
 };
 static std::vector<face::ShmPusherOutput::Panel>
 pf_hub75_panels(const PfHub75Layout& L);
 static void pf_hub75_canvas(const PfHub75Layout& L, int& cw, int& ch);
+static void pf_hub75_apply_defaults(PfHub75Layout& L);
 
 // hot-swap action use the exact same construction logic.
 static std::unique_ptr<face::PanelOutput>
@@ -466,54 +474,91 @@ static void pf_hub75_panel_dims(const std::string& sz, int& w, int& h) {
 // in a horizontal chain that puts the canvas at 256 + 64 = 320 px wide.
 static constexpr int kHub75Margin = 32;
 
+// Centre = 0 model. nudge_dx[i] / nudge_dy[i] are stored as the offset of
+// panel i's CENTRE from the canvas centre (px). Default values are the
+// "auto-placed" positions — see pf_hub75_apply_defaults below. To convert
+// stored nudges into a panel rect: rect.x = canvas_w/2 + nudge_dx - pw/2.
 static std::vector<face::ShmPusherOutput::Panel>
 pf_hub75_panels(const PfHub75Layout& L) {
     const int n = std::clamp(L.panel_count, 1, 4);
     std::vector<face::ShmPusherOutput::Panel> out;
     out.reserve(static_cast<size_t>(n));
-    // Resolve each slot's effective size — its per-slot override if set,
-    // otherwise the global default. Lets users mix panel sizes in one
-    // build (e.g. two 64x32 + one 64x64).
     int pw[4] = {0,0,0,0}, ph[4] = {0,0,0,0};
     for (int i = 0; i < 4; ++i) {
         const std::string& s = L.panel_size_per[i].empty()
                                ? L.panel_size : L.panel_size_per[i];
         pf_hub75_panel_dims(s, pw[i], ph[i]);
     }
-    // Base positions place the first panel at (0, 0); push() then offsets
-    // every panel by kHub75Margin so the set is centred inside the
-    // margin-padded canvas, then adds each panel's nudge.
-    auto push = [&](int i, int x, int y) {
+    int cw = 0, ch = 0;
+    pf_hub75_canvas(L, cw, ch);
+    const int cx = cw / 2;
+    const int cy = ch / 2;
+    for (int i = 0; i < n; ++i) {
         face::ShmPusherOutput::Panel p;
         p.name = "panel_" + std::to_string(i);
-        p.rect = cv::Rect(x + kHub75Margin + L.nudge_dx[i],
-                          y + kHub75Margin + L.nudge_dy[i],
+        p.rect = cv::Rect(cx + L.nudge_dx[i] - pw[i] / 2,
+                          cy + L.nudge_dy[i] - ph[i] / 2,
                           pw[i], ph[i]);
         out.push_back(std::move(p));
-    };
+    }
+    return out;
+}
+
+// Compute and store the "auto-placed" centre offsets for the current
+// arrangement / count / sizes. Called when the user picks a new size,
+// count or arrangement (and once at startup if cfg didn't load any).
+static void pf_hub75_apply_defaults(PfHub75Layout& L) {
+    const int n = std::clamp(L.panel_count, 1, 4);
+    int pw[4] = {0,0,0,0}, ph[4] = {0,0,0,0};
+    for (int i = 0; i < 4; ++i) {
+        const std::string& s = L.panel_size_per[i].empty()
+                               ? L.panel_size : L.panel_size_per[i];
+        pf_hub75_panel_dims(s, pw[i], ph[i]);
+    }
+    // First compute centred-set absolute positions (with margin), then
+    // convert to centre-offsets from the canvas centre.
+    int x[4] = {0,0,0,0}, y[4] = {0,0,0,0};
     if (L.arrangement == "vertical") {
-        // Stack: each panel's y = sum of preceding panels' heights.
-        int y = 0;
-        for (int i = 0; i < n; ++i) { push(i, 0, y); y += ph[i]; }
+        int yy = kHub75Margin;
+        int max_w = 0;
+        for (int i = 0; i < n; ++i) max_w = std::max(max_w, pw[i]);
+        for (int i = 0; i < n; ++i) {
+            x[i] = kHub75Margin + (max_w - pw[i]) / 2;
+            y[i] = yy; yy += ph[i];
+        }
     } else if (L.arrangement == "grid2x2") {
-        // 2x2 row-major: row 0 holds slots 0-1, row 1 holds slots 2-3.
-        // Each panel's column x is the width of its left sibling; row 1 y
-        // is the taller of the row 0 panels so mixed rows don't overlap.
         const int row0_h = std::max(ph[0], n >= 2 ? ph[1] : 0);
         for (int i = 0; i < n; ++i) {
             const int col = i % 2;
             const int row = i / 2;
-            int x = 0, y = 0;
-            if (col == 1) x = pw[i - 1];
-            if (row == 1) y = row0_h;
-            push(i, x, y);
+            int xx = kHub75Margin;
+            if (col == 1) xx += pw[i - 1];
+            int yy = kHub75Margin;
+            if (row == 1) yy += row0_h;
+            x[i] = xx; y[i] = yy;
         }
-    } else { // horizontal default
-        // Chain: each panel's x = sum of preceding panels' widths.
-        int x = 0;
-        for (int i = 0; i < n; ++i) { push(i, x, 0); x += pw[i]; }
+    } else { // horizontal
+        int xx = kHub75Margin;
+        int max_h = 0;
+        for (int i = 0; i < n; ++i) max_h = std::max(max_h, ph[i]);
+        for (int i = 0; i < n; ++i) {
+            x[i] = xx;
+            y[i] = kHub75Margin + (max_h - ph[i]) / 2;
+            xx += pw[i];
+        }
     }
-    return out;
+    int cw = 0, ch = 0;
+    pf_hub75_canvas(L, cw, ch);
+    const int cx = cw / 2, cy = ch / 2;
+    for (int i = 0; i < n; ++i) {
+        L.nudge_dx[i] = (x[i] + pw[i] / 2) - cx;
+        L.nudge_dy[i] = (y[i] + ph[i] / 2) - cy;
+    }
+    for (int i = n; i < 4; ++i) {
+        L.nudge_dx[i] = 0;
+        L.nudge_dy[i] = 0;
+    }
+    L.defaults_applied = true;
 }
 
 // Total canvas size = bounding box of the *un-nudged* panel set + a 32-px
@@ -4199,14 +4244,18 @@ static std::vector<MenuItem> build_menu(
     MenuItem pf_hub75_layout_item;
     if (pf_hub75_p) {
         auto* H = pf_hub75_p;
-        auto hub_pick_str = [&leaf_sel](const char* lbl, std::string* slot, const char* v) {
+        // String picker that also reapplies the auto-placed centre offsets
+        // when the global Default Panel Size / Arrangement changes — the
+        // canvas resizes around the new geometry, so the existing nudges
+        // would point at the wrong canvas centres.
+        auto hub_pick_str = [&leaf_sel, H](const char* lbl, std::string* slot, const char* v) {
             return leaf_sel(lbl,
-                [slot, v]{ if (slot) *slot = v; },
+                [slot, v, H]{ if (slot) { *slot = v; pf_hub75_apply_defaults(*H); } },
                 [slot, v]{ return slot && *slot == v; });
         };
-        auto hub_pick_int = [&leaf_sel](const char* lbl, int* slot, int v) {
+        auto hub_pick_int = [&leaf_sel, H](const char* lbl, int* slot, int v) {
             return leaf_sel(lbl,
-                [slot, v]{ if (slot) *slot = v; },
+                [slot, v, H]{ if (slot) { *slot = v; pf_hub75_apply_defaults(*H); } },
                 [slot, v]{ return slot && *slot == v; });
         };
         std::vector<MenuItem> size_items = {
@@ -4234,10 +4283,23 @@ static std::vector<MenuItem> build_menu(
         // entries pin this slot to that physical size regardless of the
         // global. Visible only when the panel index is within the active
         // count.
+        // Per-slot Size pickers also reapply defaults — sizing a panel up
+        // can grow the canvas, which shifts what "centre" means.
         auto size_pick = [&leaf_sel, H](const char* lbl, int i, const char* v) {
             return leaf_sel(lbl,
-                [H, i, v]{ H->panel_size_per[i] = v; },
+                [H, i, v]{ H->panel_size_per[i] = v; pf_hub75_apply_defaults(*H); },
                 [H, i, v]{ return H->panel_size_per[i] == v; });
+        };
+        // Slider range: ±canvas/2 so each panel can be moved to either
+        // edge of the canvas (centre-offset model). Capped at ±512 for
+        // very large layouts so the encoder stays usable.
+        auto nudge_x_max = [H]() -> float {
+            int cw = 0, ch = 0; pf_hub75_canvas(*H, cw, ch);
+            return static_cast<float>(std::min(512, std::max(64, cw / 2)));
+        };
+        auto nudge_y_max = [H]() -> float {
+            int cw = 0, ch = 0; pf_hub75_canvas(*H, cw, ch);
+            return static_cast<float>(std::min(512, std::max(64, ch / 2)));
         };
         std::vector<MenuItem> nudge_items;
         for (int i = 0; i < 4; ++i) {
@@ -4250,16 +4312,25 @@ static std::vector<MenuItem> build_menu(
                 size_pick("128x32",      i, "128x32"),
                 size_pick("128x64",      i, "128x64"),
             };
+            const float xmax = nudge_x_max();
+            const float ymax = nudge_y_max();
             std::vector<MenuItem> axis_items = {
                 submenu("Size", std::move(size_items)),
-                slider("Nudge X", -32.f, 32.f, 1.f, " px",
+                slider("Offset X (from centre)", -xmax, xmax, 1.f, " px",
                     [H, i]{ return static_cast<float>(H->nudge_dx[i]); },
                     [H, i](float v){ H->nudge_dx[i] = static_cast<int>(v); }),
-                slider("Nudge Y", -32.f, 32.f, 1.f, " px",
+                slider("Offset Y (from centre)", -ymax, ymax, 1.f, " px",
                     [H, i]{ return static_cast<float>(H->nudge_dy[i]); },
                     [H, i](float v){ H->nudge_dy[i] = static_cast<int>(v); }),
-                leaf("Reset Nudge",
-                     [H, i]{ H->nudge_dx[i] = 0; H->nudge_dy[i] = 0; }),
+                leaf("Reset to Default Position",
+                     [H, i]{
+                         // Reset just this slot by reapplying defaults to a
+                         // scratch copy and copying the slot's values back.
+                         PfHub75Layout tmp = *H;
+                         pf_hub75_apply_defaults(tmp);
+                         H->nudge_dx[i] = tmp.nudge_dx[i];
+                         H->nudge_dy[i] = tmp.nudge_dy[i];
+                     }),
             };
             char nm[32]; std::snprintf(nm, sizeof(nm), "Panel %d", i + 1);
             MenuItem m = submenu(nm, std::move(axis_items));
@@ -4333,6 +4404,11 @@ static std::vector<MenuItem> build_menu(
             submenu("Arrangement", std::move(arr_items)),
         };
         for (auto& it : nudge_items) hub_items.push_back(std::move(it));
+        hub_items.push_back(with_desc(
+            leaf("Reset All Positions",
+                 [H]{ pf_hub75_apply_defaults(*H); }),
+            "Re-seed every panel's Offset X/Y to the auto-placed positions "
+            "for the current size + count + arrangement."));
 
         pf_hub75_layout_item = with_desc(
             with_panel(submenu("HUB75 Layout", std::move(hub_items)),
@@ -7691,6 +7767,7 @@ int main(int argc, char* argv[]) {
             if (jh.contains("nudge_dy") && jh["nudge_dy"].is_array())
                 for (size_t i = 0; i < jh["nudge_dy"].size() && i < 4; ++i)
                     pf_hub75.nudge_dy[i] = jh["nudge_dy"][i].get<int>();
+            pf_hub75.defaults_applied = jval(jh, "defaults_applied", false);
         }
         if (jpf.contains("animation") && jpf["animation"].is_object()) {
             auto& ja = jpf["animation"];
@@ -7710,6 +7787,10 @@ int main(int argc, char* argv[]) {
             protoface_preview_view         = jval(jpv, "view",     protoface_preview_view);
         }
     }
+    // Centre-offset model needs an initial seed when cfg didn't carry one
+    // (first run, or upgrading from the old "delta from base" schema
+    // where all-zero nudges would now stack panels at the centre).
+    if (!pf_hub75.defaults_applied) pf_hub75_apply_defaults(pf_hub75);
 
     // Scheduler / reminders. Networking lives in the scheduler_daemon companion;
     // ProtoHUD only reads the merged events.json + scheduler_status.json it writes.
@@ -9713,6 +9794,7 @@ int main(int argc, char* argv[]) {
         cfg["protoface"]["hub75"]["panel_size_per"] = json::array({
             pf_hub75.panel_size_per[0], pf_hub75.panel_size_per[1],
             pf_hub75.panel_size_per[2], pf_hub75.panel_size_per[3]});
+        cfg["protoface"]["hub75"]["defaults_applied"] = pf_hub75.defaults_applied;
         cfg["protoface"]["hub75"]["nudge_dx"]    =
             json::array({pf_hub75.nudge_dx[0], pf_hub75.nudge_dx[1],
                          pf_hub75.nudge_dx[2], pf_hub75.nudge_dx[3]});

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -268,7 +268,8 @@ static std::unique_ptr<face::PanelOutput>
 pf_build_panel_output(const json& cfg, const face::RenderConfig& rc,
                       const std::string& pf_eye_layout   = "1x2",
                       const std::string& pf_mouth_layout = "1x3",
-                      const std::string& pf_nose_layout  = "1x1") {
+                      const std::string& pf_nose_layout  = "1x1",
+                      const PfHub75Layout* hub75         = nullptr) {
     const json* jpf = cfg.contains("protoface") ? &cfg["protoface"] : nullptr;
     const std::string backend = jpf ? jpf->value("backend", std::string("hub75"))
                                     : std::string("hub75");
@@ -413,7 +414,73 @@ pf_build_panel_output(const json& cfg, const face::RenderConfig& rc,
         }
         return std::make_unique<face::NeoPixelMatrixOutput>(std::move(nc));
     }
-    return std::make_unique<face::ShmPusherOutput>(rc.canvas_w, rc.canvas_h);
+    // HUB75 / daemon path — pass the layout-derived panel inventory through
+    // so the in-HUD face editor knows which regions to outline. When the
+    // user hasn't picked a HUB75 layout, panels stays empty and the editor
+    // stays hidden (legacy daemon-mode behaviour preserved).
+    std::vector<face::ShmPusherOutput::Panel> hub75_panels;
+    if (hub75) hub75_panels = pf_hub75_panels(*hub75);
+    return std::make_unique<face::ShmPusherOutput>(
+        rc.canvas_w, rc.canvas_h, std::move(hub75_panels));
+}
+
+// ── HUB75 panel layout (presets + per-panel nudge) ───────────────────────────
+// User-facing config for the HUB75 face editor: pick a panel size from the
+// presets, how many panels, how they're arranged, then nudge each one ±32 px
+// to compensate for tiny mounting offsets between physical panels. All four
+// nudge slots exist regardless of count; values above count are ignored.
+struct PfHub75Layout {
+    std::string panel_size  = "64x32";      // 32x16 / 64x32 / 64x64 / 96x48 / 128x32 / 128x64
+    std::string arrangement = "horizontal"; // horizontal / vertical / grid2x2
+    int         panel_count = 1;            // 1..4
+    int         nudge_dx[4] = {0, 0, 0, 0};
+    int         nudge_dy[4] = {0, 0, 0, 0};
+};
+
+static void pf_hub75_panel_dims(const std::string& sz, int& w, int& h) {
+    if      (sz == "32x16")  { w = 32;  h = 16; }
+    else if (sz == "64x64")  { w = 64;  h = 64; }
+    else if (sz == "96x48")  { w = 96;  h = 48; }
+    else if (sz == "128x32") { w = 128; h = 32; }
+    else if (sz == "128x64") { w = 128; h = 64; }
+    else                     { w = 64;  h = 32; }   // "64x32" default
+}
+
+// Returns each panel's (x, y, panel_w, panel_h) with the user's nudge applied
+// and a canonical name ("panel_0" .. "panel_N"). The first panel always
+// anchors at (0, 0) + nudge[0]; subsequent panels lay out per arrangement.
+static std::vector<face::ShmPusherOutput::Panel>
+pf_hub75_panels(const PfHub75Layout& L) {
+    int pw, ph; pf_hub75_panel_dims(L.panel_size, pw, ph);
+    const int n = std::clamp(L.panel_count, 1, 4);
+    std::vector<face::ShmPusherOutput::Panel> out;
+    out.reserve(static_cast<size_t>(n));
+    auto push = [&](int i, int x, int y) {
+        face::ShmPusherOutput::Panel p;
+        p.name = "panel_" + std::to_string(i);
+        p.rect = cv::Rect(x + L.nudge_dx[i], y + L.nudge_dy[i], pw, ph);
+        out.push_back(std::move(p));
+    };
+    if (L.arrangement == "vertical") {
+        for (int i = 0; i < n; ++i) push(i, 0, i * ph);
+    } else if (L.arrangement == "grid2x2") {
+        for (int i = 0; i < n; ++i) push(i, (i % 2) * pw, (i / 2) * ph);
+    } else { // horizontal default
+        for (int i = 0; i < n; ++i) push(i, i * pw, 0);
+    }
+    return out;
+}
+
+// Total canvas size needed to fit the laid-out panels (after nudges).
+static void pf_hub75_canvas(const PfHub75Layout& L, int& cw, int& ch) {
+    const auto panels = pf_hub75_panels(L);
+    cw = ch = 0;
+    for (const auto& p : panels) {
+        cw = std::max(cw, p.rect.x + p.rect.width);
+        ch = std::max(ch, p.rect.y + p.rect.height);
+    }
+    if (cw <= 0) cw = 64;
+    if (ch <= 0) ch = 32;
 }
 
 // ── Chain layout → named zone rects ───────────────────────────────────────────
@@ -601,7 +668,8 @@ static PfFaceZones pf_compute_face_zones(
     return out;
 }
 
-static face::RenderConfig pf_build_render_config(const json& cfg) {
+static face::RenderConfig pf_build_render_config(const json& cfg,
+                                                 const PfHub75Layout* hub75 = nullptr) {
     face::RenderConfig rc;
     const json* jpf = cfg.contains("protoface") ? &cfg["protoface"] : nullptr;
 
@@ -665,6 +733,22 @@ static face::RenderConfig pf_build_render_config(const json& cfg) {
     if (jpf && jpf->contains("panels") && (*jpf)["panels"].is_array() &&
         !(*jpf)["panels"].empty()) {
         for (const auto& jp : (*jpf)["panels"]) rc.panels.push_back(parse_panel(jp));
+    } else if (hub75 && hub75->panel_count > 0) {
+        // HUB75 picker mode — one PanelCfg per laid-out physical panel.
+        // Canvas grows to fit the laid-out + nudged set so the renderer
+        // composes onto exactly the same surface the editor paints into.
+        const auto plist = pf_hub75_panels(*hub75);
+        int cw = 0, ch = 0;
+        pf_hub75_canvas(*hub75, cw, ch);
+        rc.canvas_w = cw;
+        rc.canvas_h = ch;
+        for (const auto& p : plist) {
+            face::PanelCfg pc;
+            pc.name = p.name;
+            pc.x = p.rect.x; pc.y = p.rect.y;
+            pc.w = p.rect.width; pc.h = p.rect.height;
+            rc.panels.push_back(std::move(pc));
+        }
     } else {
         face::PanelCfg left;  left.name  = "face_left";  left.x = 0;  left.w = 64; left.h = 32;
         face::PanelCfg right; right.name = "face_right"; right.x = 64; right.w = 64; right.h = 32;
@@ -999,6 +1083,11 @@ static std::vector<MenuItem> build_menu(
         std::string* pf_eye_layout_p   = nullptr,
         std::string* pf_mouth_layout_p = nullptr,
         std::string* pf_nose_layout_p  = nullptr,
+        // HUB75 panel layout (pickers + nudges). Owned by main, mutated by
+        // the menu; main rebuilds the renderer when the user backs out of
+        // the HUB75 Layout submenu (Phase 3) — for now changes take effect
+        // on the next backend hot-swap.
+        PfHub75Layout* pf_hub75_p = nullptr,
         // Face animation tunables — pointers + a "push live" callback that
         // forwards the current values into native_ctrl after a slider/toggle
         // change. Caller owns the slots and the persistence to config.json.
@@ -4033,6 +4122,132 @@ static std::vector<MenuItem> build_menu(
         "display. Persisted to config.json.");
     pf_chain_layout_item.visible_fn = visible_for_native;
 
+    // ── HUB75 Panel Layout (presets + per-panel pixel nudge) ─────────────────
+    // Visible only on the hub75 backend. Picks panel size + count + arrangement
+    // and exposes a per-panel Nudge X/Y so the user can shift any single panel
+    // ±32 px to compensate for tiny mounting offsets between physical panels.
+    MenuItem pf_hub75_layout_item;
+    if (pf_hub75_p) {
+        auto* H = pf_hub75_p;
+        auto hub_pick_str = [&leaf_sel](const char* lbl, std::string* slot, const char* v) {
+            return leaf_sel(lbl,
+                [slot, v]{ if (slot) *slot = v; },
+                [slot, v]{ return slot && *slot == v; });
+        };
+        auto hub_pick_int = [&leaf_sel](const char* lbl, int* slot, int v) {
+            return leaf_sel(lbl,
+                [slot, v]{ if (slot) *slot = v; },
+                [slot, v]{ return slot && *slot == v; });
+        };
+        std::vector<MenuItem> size_items = {
+            hub_pick_str("32x16",  &H->panel_size, "32x16"),
+            hub_pick_str("64x32",  &H->panel_size, "64x32"),
+            hub_pick_str("64x64",  &H->panel_size, "64x64"),
+            hub_pick_str("96x48",  &H->panel_size, "96x48"),
+            hub_pick_str("128x32", &H->panel_size, "128x32"),
+            hub_pick_str("128x64", &H->panel_size, "128x64"),
+        };
+        std::vector<MenuItem> count_items = {
+            hub_pick_int("1 panel",  &H->panel_count, 1),
+            hub_pick_int("2 panels", &H->panel_count, 2),
+            hub_pick_int("3 panels", &H->panel_count, 3),
+            hub_pick_int("4 panels", &H->panel_count, 4),
+        };
+        std::vector<MenuItem> arr_items = {
+            hub_pick_str("Horizontal Chain", &H->arrangement, "horizontal"),
+            hub_pick_str("Vertical Stack",   &H->arrangement, "vertical"),
+            hub_pick_str("2x2 Grid",         &H->arrangement, "grid2x2"),
+        };
+
+        // Per-panel nudge submenus (X / Y, ±32 px integer). Visible only when
+        // the panel index is within the active count.
+        std::vector<MenuItem> nudge_items;
+        for (int i = 0; i < 4; ++i) {
+            std::vector<MenuItem> axis_items = {
+                slider("Nudge X", -32.f, 32.f, 1.f, " px",
+                    [H, i]{ return static_cast<float>(H->nudge_dx[i]); },
+                    [H, i](float v){ H->nudge_dx[i] = static_cast<int>(v); }),
+                slider("Nudge Y", -32.f, 32.f, 1.f, " px",
+                    [H, i]{ return static_cast<float>(H->nudge_dy[i]); },
+                    [H, i](float v){ H->nudge_dy[i] = static_cast<int>(v); }),
+                leaf("Reset", [H, i]{ H->nudge_dx[i] = 0; H->nudge_dy[i] = 0; }),
+            };
+            char nm[24]; std::snprintf(nm, sizeof(nm), "Panel %d Nudge", i + 1);
+            MenuItem m = submenu(nm, std::move(axis_items));
+            m.visible_fn = [H, i]{ return i < H->panel_count; };
+            nudge_items.push_back(std::move(m));
+        }
+
+        // Schematic preview — draws all panels at their canvas positions
+        // (after nudge) so the user sees the whole-set arrangement update
+        // live as they tweak picker rows or nudge sliders.
+        auto hub_preview = [H](ImDrawList* dl, ImVec2 o, ImVec2 sz) {
+            ImFont* font = ImGui::GetFont();
+            const float fs = ImGui::GetFontSize();
+            dl->AddText(font, fs * 1.1f, {o.x, o.y},
+                        IM_COL32(230, 235, 240, 255), "HUB75 Panel Layout");
+            const auto panels = pf_hub75_panels(*H);
+            int cw = 0, ch = 0; pf_hub75_canvas(*H, cw, ch);
+            char sub[96];
+            std::snprintf(sub, sizeof(sub),
+                          "%d × %s   %s   canvas %dx%d",
+                          H->panel_count, H->panel_size.c_str(),
+                          H->arrangement.c_str(), cw, ch);
+            dl->AddText(font, fs * 0.85f, {o.x, o.y + fs * 1.2f},
+                        IM_COL32(170, 180, 190, 220), sub);
+
+            const float top = o.y + fs * 2.6f;
+            const float pad = 8.f;
+            const float avail_w = std::max(40.f, sz.x - pad * 2.f);
+            const float avail_h = std::max(40.f, o.y + sz.y - top - pad);
+            if (cw <= 0 || ch <= 0) return;
+            const float scale = std::min(avail_w / cw, avail_h / ch);
+            const float gw = cw * scale, gh = ch * scale;
+            const float ox = o.x + (sz.x - gw) * 0.5f;
+            const float oy = top + (avail_h - gh) * 0.5f;
+            const ImU32 bg   = IM_COL32(20, 24, 32, 255);
+            const ImU32 pcol = IM_COL32(255, 220, 60, 255);
+            const ImU32 ptxt = IM_COL32(20, 24, 28, 255);
+            dl->AddRectFilled({ox, oy}, {ox + gw, oy + gh}, bg);
+            for (size_t i = 0; i < panels.size(); ++i) {
+                const auto& r = panels[i].rect;
+                const float x0 = ox + r.x * scale;
+                const float y0 = oy + r.y * scale;
+                const float x1 = x0 + r.width  * scale;
+                const float y1 = y0 + r.height * scale;
+                dl->AddRectFilled({x0, y0}, {x1, y1},
+                                  IM_COL32(255, 220, 60, 60));
+                dl->AddRect({x0, y0}, {x1, y1}, pcol, 2.f, 0, 2.f);
+                char lab[16];
+                std::snprintf(lab, sizeof(lab), "P%zu", i + 1);
+                const ImVec2 ts = font->CalcTextSizeA(fs, FLT_MAX, 0.f, lab);
+                dl->AddText(font, fs,
+                    {x0 + ((x1 - x0) - ts.x) * 0.5f,
+                     y0 + ((y1 - y0) - ts.y) * 0.5f},
+                    ptxt, lab);
+            }
+        };
+
+        std::vector<MenuItem> hub_items = {
+            submenu("Panel Size",  std::move(size_items)),
+            submenu("Panel Count", std::move(count_items)),
+            submenu("Arrangement", std::move(arr_items)),
+        };
+        for (auto& it : nudge_items) hub_items.push_back(std::move(it));
+
+        pf_hub75_layout_item = with_desc(
+            with_panel(submenu("HUB75 Layout", std::move(hub_items)),
+                       "HUB75 Panel Layout", hub_preview),
+            "Panel size + count + arrangement for the HUB75 backend. "
+            "Each panel exposes a Nudge X/Y slider (±32 px integer) so you "
+            "can align the editor canvas to physical mounting offsets. "
+            "Persisted to cfg[\"protoface\"][\"hub75\"]; takes effect on the "
+            "next backend (re)start.");
+        pf_hub75_layout_item.visible_fn = [pf_backend_p]{
+            return pf_backend_p && *pf_backend_p == "hub75";
+        };
+    }
+
     std::vector<MenuItem> pf_hardware_menu = {
         with_desc(submenu("Backend", std::move(pf_backend_items)),
                   "What LED hardware Protoface paints. Switching tears down "
@@ -4045,6 +4260,7 @@ static std::vector<MenuItem> build_menu(
     // face-authoring concern (it shapes the editor's bbox guides), so it now
     // sits inside Face Options alongside the per-expression slots.
     face_files_menu.push_back(std::move(pf_chain_layout_item));
+    if (pf_hub75_p) face_files_menu.push_back(std::move(pf_hub75_layout_item));
 
     // Visibility predicates — Effects / Face Color / Material Color /
     // Animations / Save Face Config / Release Control are concepts from
@@ -7336,6 +7552,11 @@ int main(int argc, char* argv[]) {
     std::string pf_eye_layout   = "1x2";
     std::string pf_mouth_layout = "1x3";
     std::string pf_nose_layout  = "1x1";
+    // HUB75 panel layout — picker state for users on the HUB75 backend.
+    // Empty (count == 0) keeps the legacy face_left/face_right pair so old
+    // configs are unchanged. Once the user picks a layout it persists to
+    // cfg["protoface"]["hub75"].
+    PfHub75Layout pf_hub75;
     // Face animation tunables — forwarded to every panel's FaceState live
     // and persisted to cfg["protoface"]["animation"] on save.
     bool   pf_blink_enabled   = true;
@@ -7354,6 +7575,18 @@ int main(int argc, char* argv[]) {
             pf_eye_layout   = jl.value("eye",   pf_eye_layout);
             pf_mouth_layout = jl.value("mouth", pf_mouth_layout);
             pf_nose_layout  = jl.value("nose",  pf_nose_layout);
+        }
+        if (jpf.contains("hub75") && jpf["hub75"].is_object()) {
+            auto& jh = jpf["hub75"];
+            pf_hub75.panel_size  = jh.value("panel_size",  pf_hub75.panel_size);
+            pf_hub75.arrangement = jh.value("arrangement", pf_hub75.arrangement);
+            pf_hub75.panel_count = jval(jh, "panel_count", pf_hub75.panel_count);
+            if (jh.contains("nudge_dx") && jh["nudge_dx"].is_array())
+                for (size_t i = 0; i < jh["nudge_dx"].size() && i < 4; ++i)
+                    pf_hub75.nudge_dx[i] = jh["nudge_dx"][i].get<int>();
+            if (jh.contains("nudge_dy") && jh["nudge_dy"].is_array())
+                for (size_t i = 0; i < jh["nudge_dy"].size() && i < 4; ++i)
+                    pf_hub75.nudge_dy[i] = jh["nudge_dy"][i].get<int>();
         }
         if (jpf.contains("animation") && jpf["animation"].is_object()) {
             auto& ja = jpf["animation"];
@@ -8214,7 +8447,7 @@ int main(int argc, char* argv[]) {
                 std::cerr << "[main] warning: could not claim /tmp/protoface.lock — "
                              "a daemon may still be running and double-writing the panel\n";
         }
-        face::RenderConfig rc = pf_build_render_config(cfg);
+        face::RenderConfig rc = pf_build_render_config(cfg, &pf_hub75);
         // Per-backend face folder — HUB75 keeps the legacy "main" folder
         // for back-compat; MAX7219 / RGB-matrix get their own "main_max7219"
         // / "main_rgb_matrix" subfolders so users can author distinct art
@@ -8284,7 +8517,8 @@ int main(int argc, char* argv[]) {
         rc.state_path = (fs::path(cfg_path).parent_path() / "protoface_state.json").string();
         native_ctrl = std::make_unique<face::NativeFaceController>(
             rc, pf_build_panel_output(cfg, rc,
-                                      pf_eye_layout, pf_mouth_layout, pf_nose_layout));
+                                      pf_eye_layout, pf_mouth_layout, pf_nose_layout,
+                                      &pf_hub75));
         native_ctrl->start();
         // Push the user's saved animation tunables into every panel's
         // FaceState. The defaults in FaceState/FaceCfg apply otherwise.
@@ -8405,7 +8639,7 @@ int main(int argc, char* argv[]) {
         native_ctrl->stop();
         ctrl_graveyard.push_back(std::move(native_ctrl));
 
-        face::RenderConfig rc = pf_build_render_config(cfg);
+        face::RenderConfig rc = pf_build_render_config(cfg, &pf_hub75);
         // Per-backend face folder (see startup-path comment above).
         if (pf_backend != "hub75") {
             const std::string suffix = "_" + pf_backend;
@@ -8471,7 +8705,8 @@ int main(int argc, char* argv[]) {
         auto new_output = pf_build_panel_output(cfg, rc,
                                                 pf_eye_layout,
                                                 pf_mouth_layout,
-                                                pf_nose_layout);
+                                                pf_nose_layout,
+                                                &pf_hub75);
         native_ctrl = std::make_unique<face::NativeFaceController>(
             rc, std::move(new_output));
         active_face = native_ctrl.get();
@@ -8497,26 +8732,31 @@ int main(int argc, char* argv[]) {
     // menu's visible_fn hides the leaf so this never runs.
     auto edit_face = [&](const std::string& expression) {
         if (!native_ctrl || !menu_ptr) return;
-        // Editor canvas width tracks the live chain layouts (so changing
-        // a picker takes effect on the next "Edit…" without a backend
-        // rebuild). Height stays at the renderer's current canvas height.
-        // If the new layouts require a wider canvas than the renderer is
-        // currently using, we still author the PNG at the layout-width;
-        // it round-trips correctly once the backend is rebuilt.
-        const int cw = std::max(native_ctrl->canvas_width(),
-            pf_canvas_w_for_layout(pf_eye_layout,
-                                   pf_mouth_layout,
-                                   pf_nose_layout));
-        const int ch = native_ctrl->canvas_height();
-        // The Chain Layout pickers are the source of truth for the
-        // editor's per-zone bounding boxes (Left/Right Eye, Nose, Mouth
-        // halves). The helper also returns the canvas mirror axis (nose
-        // centre, or canvas_w/2 when there's no nose) so the editor's
-        // mirror brush respects the face's actual symmetry line.
-        auto zones = pf_compute_face_zones(pf_eye_layout,
-                                           pf_mouth_layout,
-                                           pf_nose_layout,
-                                           cw, ch);
+        // HUB75 backend: editor uses the picked panel inventory directly.
+        // Native backends (MAX7219 / RGB matrix): use the chain layout
+        // pickers as the source of truth for per-zone bboxes. Picker
+        // changes take effect on the next Edit... without a backend rebuild.
+        int cw, ch;
+        PfFaceZones zones;
+        if (pf_backend == "hub75" && pf_hub75.panel_count > 0) {
+            pf_hub75_canvas(pf_hub75, cw, ch);
+            cw = std::max(native_ctrl->canvas_width(), cw);
+            ch = std::max(native_ctrl->canvas_height(), ch);
+            const auto plist = pf_hub75_panels(pf_hub75);
+            for (const auto& p : plist)
+                zones.regions.push_back({p.name, p.rect});
+            zones.mirror_x = cw / 2;
+        } else {
+            cw = std::max(native_ctrl->canvas_width(),
+                pf_canvas_w_for_layout(pf_eye_layout,
+                                       pf_mouth_layout,
+                                       pf_nose_layout));
+            ch = native_ctrl->canvas_height();
+            zones = pf_compute_face_zones(pf_eye_layout,
+                                          pf_mouth_layout,
+                                          pf_nose_layout,
+                                          cw, ch);
+        }
         std::vector<cv::Rect> covered;
         covered.reserve(zones.regions.size());
         for (const auto& nr : zones.regions) covered.push_back(nr.rect);
@@ -8673,6 +8913,7 @@ int main(int argc, char* argv[]) {
                                swap_backend, &pf_backend,
                                edit_face,
                                &pf_eye_layout, &pf_mouth_layout, &pf_nose_layout,
+                               &pf_hub75,
                                &pf_blink_enabled, &pf_blink_min, &pf_blink_max,
                                &pf_blink_duration, &pf_expr_fade,
                                /* pf_anim_push */ [&]{
@@ -9349,6 +9590,15 @@ int main(int argc, char* argv[]) {
         cfg["protoface"]["layout"]["eye"]       = pf_eye_layout;
         cfg["protoface"]["layout"]["mouth"]     = pf_mouth_layout;
         cfg["protoface"]["layout"]["nose"]      = pf_nose_layout;
+        cfg["protoface"]["hub75"]["panel_size"]  = pf_hub75.panel_size;
+        cfg["protoface"]["hub75"]["arrangement"] = pf_hub75.arrangement;
+        cfg["protoface"]["hub75"]["panel_count"] = pf_hub75.panel_count;
+        cfg["protoface"]["hub75"]["nudge_dx"]    =
+            json::array({pf_hub75.nudge_dx[0], pf_hub75.nudge_dx[1],
+                         pf_hub75.nudge_dx[2], pf_hub75.nudge_dx[3]});
+        cfg["protoface"]["hub75"]["nudge_dy"]    =
+            json::array({pf_hub75.nudge_dy[0], pf_hub75.nudge_dy[1],
+                         pf_hub75.nudge_dy[2], pf_hub75.nudge_dy[3]});
         cfg["protoface"]["animation"]["blink_enabled"]   = pf_blink_enabled;
         cfg["protoface"]["animation"]["blink_min"]       = pf_blink_min;
         cfg["protoface"]["animation"]["blink_max"]       = pf_blink_max;

--- a/src/menu/face_editor.cpp
+++ b/src/menu/face_editor.cpp
@@ -41,7 +41,10 @@ void FaceEditor::open(std::string title,
                      Mode mode,
                      std::vector<uint32_t> palette,
                      CommitFn on_commit,
-                     CancelFn on_cancel) {
+                     CancelFn on_cancel,
+                     PreviewFn on_preview,
+                     LiveFrameFn live_frame,
+                     double preview_duration_s) {
     if (canvas_w <= 0 || canvas_h <= 0) return;
 
     title_           = std::move(title);
@@ -55,8 +58,12 @@ void FaceEditor::open(std::string title,
     mode_      = mode;
     tool_      = Tool::Pencil;
     mirror_    = false;
-    on_commit_ = std::move(on_commit);
-    on_cancel_ = std::move(on_cancel);
+    on_commit_  = std::move(on_commit);
+    on_cancel_  = std::move(on_cancel);
+    on_preview_ = std::move(on_preview);
+    live_frame_ = std::move(live_frame);
+    preview_duration_s_ = (preview_duration_s > 0.0) ? preview_duration_s : 10.0;
+    live_mode_  = false;
 
     // Default palette fallback for color mode.
     palette_.clear();
@@ -120,10 +127,13 @@ void FaceEditor::open(std::string title,
 }
 
 void FaceEditor::close() {
-    open_      = false;
-    on_commit_ = nullptr;
-    on_cancel_ = nullptr;
-    canvas_    = cv::Mat();
+    open_       = false;
+    on_commit_  = nullptr;
+    on_cancel_  = nullptr;
+    on_preview_ = nullptr;
+    live_frame_ = nullptr;
+    live_mode_  = false;
+    canvas_     = cv::Mat();
     undo_stack_.clear();
     covered_.clear();
     covered_labels_.clear();
@@ -372,6 +382,20 @@ void FaceEditor::cycle_palette(int dir) {
     palette_idx_ = ((palette_idx_ + dir) % n + n) % n;
 }
 
+void FaceEditor::preview() {
+    if (!open_ || !on_preview_ || canvas_.empty()) return;
+    on_preview_(canvas_, preview_duration_s_);
+}
+
+void FaceEditor::toggle_live() {
+    if (!open_ || !live_frame_) return;
+    live_mode_ = !live_mode_;
+    // When entering live mode, also push the current canvas so the next
+    // few rendered frames already reflect the user's in-progress work.
+    if (live_mode_ && on_preview_)
+        on_preview_(canvas_, std::max(1.5, preview_duration_s_));
+}
+
 void FaceEditor::undo() {
     if (!open_) return;
     // Z while a shape anchor is set just cancels it (no canvas change to
@@ -431,12 +455,13 @@ void FaceEditor::draw(ImDrawList* dl, ImFont* font, float fs,
     }
     const int brush_side = 1 + brush_size_ * 2;
     std::snprintf(sub, sizeof(sub),
-        "%dx%d  cursor (%d,%d)  %s  brush %dx%d%s%s",
+        "%dx%d  cursor (%d,%d)  %s  brush %dx%d%s%s%s",
         bbox_.width, bbox_.height,
         cursor_x_, cursor_y_,
         tool_str, brush_side, brush_side,
         mirror_ ? "  Mirror" : "",
-        mode_ == Mode::Color ? "  Color" : "  Mono");
+        mode_ == Mode::Color ? "  Color" : "  Mono",
+        live_mode_ ? "  Live" : "");
     dl->AddText(font, fs * 0.9f, {cx0, cy}, IM_COL32(170, 180, 190, 230), sub);
     cy += fs * 0.9f + 10.f;
     dl->AddLine({cx0, cy}, {cx1, cy}, IM_COL32(255, 255, 255, 60), 1.f);
@@ -446,7 +471,7 @@ void FaceEditor::draw(ImDrawList* dl, ImFont* font, float fs,
     // readability. Two columns: general controls on the left, the six
     // numbered tools on the right. Height tracks the taller column.
     const float footer_line_h = fs * 0.95f + 2.f;
-    const int   left_lines    = (mode_ == Mode::Color) ? 8 : 7;
+    const int   left_lines    = (mode_ == Mode::Color) ? 10 : 9;
     const int   right_lines   = 6;   // 1..6 tool bindings
     const int   footer_lines  = std::max(left_lines, right_lines);
     const float footer_h      = footer_line_h * footer_lines + 12.f;
@@ -481,17 +506,45 @@ void FaceEditor::draw(ImDrawList* dl, ImFont* font, float fs,
                               IM_COL32(24, 32, 44, 255));
         }
 
-        // Per-pixel cells.
+        // Live overlay — when enabled, keep pushing the user's in-progress
+        // canvas to the controller as a transient face so its renderer
+        // composites material + effects on top, then pull the rendered
+        // (RGB) frame back for display in place of the per-pixel cells.
+        // Falls through to the painted-canvas path if the controller hasn't
+        // produced a frame yet.
+        cv::Mat live;
+        bool have_live = false;
+        if (live_mode_) {
+            if (on_preview_) on_preview_(canvas_, 1.5);   // refresh deadline
+            if (live_frame_) have_live = live_frame_(live);
+            if (have_live && live.type() != CV_8UC3) {
+                cv::Mat tmp;
+                live.convertTo(tmp, CV_8UC3);
+                live = std::move(tmp);
+            }
+        }
+
+        // Per-pixel cells. In live mode we draw every covered cell from the
+        // rendered (RGB) frame; otherwise we draw the painted RGBA pixels and
+        // skip transparency so the bbox tint shows through.
         for (int py = 0; py < bbox_.height; ++py) {
             for (int px = 0; px < bbox_.width; ++px) {
                 const int cx_canvas = bbox_.x + px;
                 const int cy_canvas = bbox_.y + py;
                 if (!inside_covered(cx_canvas, cy_canvas)) continue;
-                const cv::Vec4b& pix = canvas_.at<cv::Vec4b>(cy_canvas, cx_canvas);
-                if (pix[3] == 0) continue;   // transparent — skip
+                ImU32 col;
+                if (have_live &&
+                    cx_canvas >= 0 && cx_canvas < live.cols &&
+                    cy_canvas >= 0 && cy_canvas < live.rows) {
+                    const cv::Vec3b& p = live.at<cv::Vec3b>(cy_canvas, cx_canvas);
+                    col = IM_COL32(p[0], p[1], p[2], 255);
+                } else {
+                    const cv::Vec4b& pix = canvas_.at<cv::Vec4b>(cy_canvas, cx_canvas);
+                    if (pix[3] == 0) continue;   // transparent — skip
+                    col = IM_COL32(pix[0], pix[1], pix[2], pix[3]);
+                }
                 const float rx = grid_origin_x_ + px * cell_size_;
                 const float ry = grid_origin_y_ + py * cell_size_;
-                const ImU32 col = IM_COL32(pix[0], pix[1], pix[2], pix[3]);
                 dl->AddRectFilled({rx, ry},
                                   {rx + cell_size_, ry + cell_size_}, col);
             }
@@ -649,6 +702,8 @@ void FaceEditor::draw(ImDrawList* dl, ImFont* font, float fs,
         "Y / M        mirror",
         "[ / ]        palette colour",   // skipped in mono mode
         "Z            undo",
+        "V            preview to panels",
+        "T            show live (effects)",
         "S            save",
         "Back         cancel",
     };

--- a/src/menu/face_editor.h
+++ b/src/menu/face_editor.h
@@ -34,6 +34,15 @@ public:
     using CommitFn = std::function<void(const cv::Mat& rgba_canvas,
                                         const std::string& abs_path)>;
     using CancelFn = std::function<void()>;
+    // Push the current canvas onto the physical panels as a transient face
+    // for `duration_s` seconds — main.cpp wires this to
+    // NativeFaceController::push_transient_face on the active expression.
+    using PreviewFn = std::function<void(const cv::Mat& rgba_canvas,
+                                          double duration_s)>;
+    // Pull the latest rendered (face + material + effects) canvas from the
+    // controller for the in-editor "Show Live" overlay. Returns false until
+    // the first frame exists.
+    using LiveFrameFn = std::function<bool(cv::Mat& out)>;
 
     // Open the editor for the PNG at abs_path. canvas_w/h are the full
     // renderer canvas dimensions. covered_regions describes the addressable
@@ -48,7 +57,10 @@ public:
               Mode mode,
               std::vector<uint32_t> palette,    // 0xRRGGBB
               CommitFn on_commit,
-              CancelFn on_cancel = {});
+              CancelFn on_cancel = {},
+              PreviewFn on_preview = {},
+              LiveFrameFn live_frame = {},
+              double preview_duration_s = 10.0);
     void close();
     bool is_open() const { return open_; }
 
@@ -66,6 +78,14 @@ public:
     void set_brush_size(int radius);     // 0 = 1px, 1 = 3x3, 2 = 5x5
     int  brush_size()   const { return brush_size_; }
     void undo();
+    // V key — push the current canvas onto the physical panels via on_preview
+    // for the configured duration. No-op if no preview callback was supplied.
+    void preview();
+    // T key — toggle live-effects overlay (renders the controller's latest
+    // composited frame in the editor pane instead of just the painted PNG).
+    // No-op if no live_frame callback was supplied at open().
+    void toggle_live();
+    bool live_mode() const { return live_mode_; }
 
     // Full-screen overlay drawn in place of the deep menu while open.
     void draw(ImDrawList* dl, ImFont* font, float fs,
@@ -131,6 +151,10 @@ private:
 
     CommitFn               on_commit_;
     CancelFn               on_cancel_;
+    PreviewFn              on_preview_;
+    LiveFrameFn            live_frame_;
+    double                 preview_duration_s_ = 10.0;
+    bool                   live_mode_ = false;
 };
 
 } // namespace menu

--- a/src/menu/menu_system.cpp
+++ b/src/menu/menu_system.cpp
@@ -317,7 +317,10 @@ void MenuSystem::open_face_editor(std::string title,
                                   menu::FaceEditor::Mode mode,
                                   std::vector<uint32_t> palette,
                                   menu::FaceEditor::CommitFn on_commit,
-                                  menu::FaceEditor::CancelFn on_cancel) {
+                                  menu::FaceEditor::CancelFn on_cancel,
+                                  menu::FaceEditor::PreviewFn on_preview,
+                                  menu::FaceEditor::LiveFrameFn live_frame,
+                                  double preview_duration_s) {
     // Mutually-exclusive overlays — bring others down first.
     if (osk_active_)              close_keyboard();
     if (file_picker_.is_open())   file_picker_.cancel();
@@ -327,7 +330,9 @@ void MenuSystem::open_face_editor(std::string title,
                       std::move(covered_labels),
                       mirror_axis_x,
                       mode, std::move(palette),
-                      std::move(on_commit), std::move(on_cancel));
+                      std::move(on_commit), std::move(on_cancel),
+                      std::move(on_preview), std::move(live_frame),
+                      preview_duration_s);
 }
 
 void MenuSystem::close_face_editor() {
@@ -1196,6 +1201,8 @@ void MenuSystem::draw_fullscreen(int screen_w, int screen_h) {
         if (ImGui::IsKeyPressed(ImGuiKey_Y) ||
             ImGui::IsKeyPressed(ImGuiKey_M))          face_editor_.tertiary();
         if (ImGui::IsKeyPressed(ImGuiKey_Z))          face_editor_.undo();
+        if (ImGui::IsKeyPressed(ImGuiKey_V))          face_editor_.preview();
+        if (ImGui::IsKeyPressed(ImGuiKey_T))          face_editor_.toggle_live();
         if (ImGui::IsKeyPressed(ImGuiKey_S))          face_editor_.save();
         // Direct tool selection. Number keys 1-6 map to the six tools in
         // declaration order (Pencil/Eraser/Bucket/Eyedrop/Line/Rect); the

--- a/src/menu/menu_system.h
+++ b/src/menu/menu_system.h
@@ -280,7 +280,10 @@ public:
                           menu::FaceEditor::Mode mode,
                           std::vector<uint32_t> palette,
                           menu::FaceEditor::CommitFn on_commit,
-                          menu::FaceEditor::CancelFn on_cancel = {});
+                          menu::FaceEditor::CancelFn on_cancel = {},
+                          menu::FaceEditor::PreviewFn on_preview = {},
+                          menu::FaceEditor::LiveFrameFn live_frame = {},
+                          double preview_duration_s = 10.0);
     void close_face_editor();
     bool is_face_editor_open() const { return face_editor_.is_open(); }
     menu::FaceEditor& face_editor() { return face_editor_; }

--- a/src/serial/face_controller.h
+++ b/src/serial/face_controller.h
@@ -91,6 +91,16 @@ public:
     // output). False for HUB75 + daemon + Teensy. Drives the visibility
     // of Files > Faces > <slot> > Edit… in the menu.
     virtual bool        has_led_face_editor() const { return false; }
+
+    // HUB75 named-layout binding. When the user has saved multiple panel
+    // layouts ("Default", "MyCM5Setup", …), each face PNG is stamped with
+    // the layout that was active when it was created so the menu can flag
+    // mismatches at slot-listing time. set_active_layout_name lets main
+    // tell the backend which name to stamp on import; face_image_layout
+    // reads back the tag for a face folder (empty = untagged / legacy).
+    // No-op on non-native backends.
+    virtual void        set_active_layout_name(const std::string& /*name*/) {}
+    virtual std::string face_image_layout(const std::string& /*expression*/) const { return {}; }
 };
 
 /**
@@ -143,6 +153,12 @@ public:
     void set_audio_drive(double v, double m) override { (*active_)->set_audio_drive(v, m); }
     void set_mouth_shape(const std::string& s) override { (*active_)->set_mouth_shape(s); }
     bool has_led_face_editor() const override { return (*active_)->has_led_face_editor(); }
+    void set_active_layout_name(const std::string& n) override {
+        (*active_)->set_active_layout_name(n);
+    }
+    std::string face_image_layout(const std::string& e) const override {
+        return (*active_)->face_image_layout(e);
+    }
 
     IFaceController* backend() const { return *active_; }
 


### PR DESCRIPTION
## Summary

Phone-integration stack — three phases shipped over this PR:

### Phase 1 — Notifications RX (`KdeConnectBridge`)
- New `src/integrations/kdeconnect_bridge.{h,cpp}` — worker thread owns a private DBus session-bus connection, rediscovers the paired device every 5 s, subscribes to `notificationPosted` and runs `Properties.Get` for `appName / title / text / ticker` per notification.
- Pushes into `AppState::notifs` so messages surface through the same toast + notification-log pipeline as scheduler reminders.
- Per-id dedup; CSV app blocklist (default `"KDE Connect"` so daemon status pings don't loop).
- Build gated by `pkg_check_modules(DBUS dbus-1)` + `HAVE_DBUS`. No-op when missing.
- Runtime: `cfg["kdeconnect"]` block (`enabled`, `device_id`, `auto_dismiss_s`, `app_blocklist`).

### Phase 2 — Phone Inbox (file transfer)
- New `src/integrations/phone_inbox.{h,cpp}` — 2 Hz directory watcher (default `$XDG_DOWNLOAD_DIR` / `~/Downloads`, KDE Connect's share destination).
- New face PNG → toast `"Got <name>.png — import as '<expr>'?"` with `[IMPORT]` / `[DISMISS]` actions. Routes through `face_proxy.import_face_image` so the layout-tag stamping from the HUB75 PR kicks in for free.
- New GIF → copies into `cfg_gifs_dir` and binds the first empty gif slot via `bind_gif_slot` so it's instantly playable.
- After import the file moves to `<watch_dir>/.processed/`; after dismiss it moves to `<watch_dir>/.dismissed/`. No data loss either way.
- mtime settle gating so half-transferred files don't fire early.
- Action lambdas keep filesystem work only — pushing a follow-up toast from inside the action would invalidate the toast renderer's for-loop iterators.

### Phase 3 — Phone battery indicator
- `SystemHealth` gains `phone_battery_pct` (-1 = unknown) and `phone_charging`.
- Bridge polls the device's `org.kde.kdeconnect.device.battery` sub-object (path `/modules/kdeconnect/devices/<id>/battery`) each 5 s discovery cycle; writes results under `state.mtx`.
- Minimap battery gauge grows a second outer arc carrying the phone percentage alongside the controller's inner arc when a phone is bound. Same colour ramp, `P` / `P+` label prefix (the latter when charging). Single-arc controller-only behaviour preserved when no phone is paired.
- Battery state clears to -1 / false on `stop()` so the arc disappears immediately when the bridge is torn down.
- Diagnostic log emits once on first read and only when values change.

## Deployment notes

Three setup steps on the Pi:

1. `sudo apt install libdbus-1-dev kdeconnect`
2. Pair the phone via the KDE Connect Android/iOS app (LAN or USB tether — tested on USB tethering after `sudo nmcli device set usb0 managed yes && sudo nmcli device connect usb0`).
3. **DBus session-bus environment** — system-level systemd services don't inherit `DBUS_SESSION_BUS_ADDRESS`, which made the bridge autolaunch its own bus. Drop-in `/etc/systemd/system/protohud.service.d/override.conf`:

   ```
   [Service]
   Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus
   ```

   Then `sudo systemctl daemon-reload && sudo systemctl restart protohud.service`.

## Verified

- Bridge starts and binds to the paired device.
- Phone notifications arrive as App-type toasts in the HUD.
- File transfer round-trips (face PNG and GIF, with layout-tag stamping intact).
- Phone battery arc renders (84%, charging indicator visible).

## Follow-ups (deferred)

- **Run command**: phone-side widget (Tasker / MacroDroid) triggers shell commands on the Pi for face / effect / profile changes.
- **Media control + metadata**: MPRIS plugin → now-playing in the HUD + transport via the knob.

https://claude.ai/code/session_016Shy65EG8rEG8ttucJJXzW