### PR TITLE
Companion-app control server (REST over AP / USB tether)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,6 +138,16 @@ FetchContent_MakeAvailable(qrcodegen)
 add_library(qrcodegen_cpp STATIC "${qrcodegen_SOURCE_DIR}/cpp/qrcodegen.cpp")
 target_include_directories(qrcodegen_cpp PUBLIC "${qrcodegen_SOURCE_DIR}/cpp")
 
+# cpp-httplib (yhirose, MIT) — single-header HTTP server powering the companion
+# app's REST control API (src/net/remote_control_server.cpp). Header-only, so we
+# only need its include dir; no library to compile.
+FetchContent_Declare(httplib
+    GIT_REPOSITORY https://github.com/yhirose/cpp-httplib.git
+    GIT_TAG        v0.15.3
+    GIT_SHALLOW    TRUE
+)
+FetchContent_MakeAvailable(httplib)
+
 
 # ImGui has no CMakeLists — build it as a static library here.
 add_library(imgui STATIC
@@ -212,6 +222,7 @@ set(SOURCES
     src/net/ping_monitor.cpp
     src/net/bt_monitor.cpp
     src/net/weather_monitor.cpp
+    src/net/remote_control_server.cpp
     src/crash_reporter.cpp
     src/capture.cpp
     src/video_recorder.cpp
@@ -228,6 +239,7 @@ target_include_directories(protohud PRIVATE
     ${imgui_SOURCE_DIR}
     ${imgui_SOURCE_DIR}/backends
     ${stb_SOURCE_DIR}
+    ${httplib_SOURCE_DIR}
     ${nanovg_SOURCE_DIR}/src
     ${VITURE_INCLUDE}
     ${OpenCV_INCLUDE_DIRS}

--- a/README.md
+++ b/README.md
@@ -619,6 +619,35 @@ Or set `"android"."enabled": true` in `config.json` to auto-start on launch.
 
 ---
 
+## Companion App
+
+A cross-platform **companion app** (Flutter — see the `protohud-companion-` repo)
+controls the helmet from a phone over IP: **face control** (color, brightness, GIF
+slots, palette, effect) and a **remote control pad** (D-pad + select/back/menu,
+autofocus, capture) that mirrors the in-paw wireless controller.
+
+It talks to a small REST server hosted *inside* `protohud` (it must be in-process —
+`protohud` owns the LED serial ports). Enable it in `config/config.json`:
+
+```jsonc
+"network_control": { "enabled": true, "host": "0.0.0.0", "port": 8780, "token": "" }
+```
+
+Reach it two ways (both bind the same socket):
+
+| Transport | Setup | App connects to |
+|-----------|-------|-----------------|
+| **Pi broadcast Wi-Fi (AP)** | `sudo ./scripts/setup_companion_ap.sh` — Pi serves SSID `ProtoHUD` | `192.168.50.1:8780` |
+| **USB tether** | `sudo ./scripts/setup_companion_usb.sh` — USB-ethernet gadget | `192.168.42.1:8780` |
+
+`token: ""` disables auth (fine for the isolated AP/USB link); set a string to
+require an `X-ProtoHUD-Token` header. The full wire contract is in
+[`docs/COMPANION_API.md`](docs/COMPANION_API.md). The pad fires the exact same
+menu/HUD actions as the `WirelessController`, so behaviour is identical across
+serial, ESP-NOW, and the phone.
+
+---
+
 ## Overlay Position & Size
 
 Both the USB camera PiP and the Android mirror overlay use the same anchor system.

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -108,6 +108,13 @@
       "_note": "ESP32-C3 USB-serial bridge for ESP-NOW in-paw controller. Set enabled:true and adjust port once the bridge is connected."
     }
   },
+  "network_control": {
+    "enabled": false,
+    "host": "0.0.0.0",
+    "port": 8780,
+    "token": "",
+    "_note": "REST control server for the ProtoHUD companion app (Flutter). Reach it over the Pi's broadcast Wi-Fi (scripts/setup_companion_ap.sh) or a USB tether (scripts/setup_companion_usb.sh). Set enabled:true. token=\"\" disables auth (fine for the isolated AP/USB link); set a string to require an X-ProtoHUD-Token header. See docs/COMPANION_API.md."
+  },
   "vitrue": {
     "product_id": 0,
     "monitor_index": -1,

--- a/docs/COMPANION_API.md
+++ b/docs/COMPANION_API.md
@@ -1,0 +1,108 @@
+# ProtoHUD Companion App API (v1)
+
+The companion app (a Flutter app — see the **ProtoHUD-companion-** repo) controls
+the helmet over a small REST + JSON HTTP server that runs *inside* the `protohud`
+process (`src/net/remote_control_server.{h,cpp}`). The server has to live in-process
+because `protohud` exclusively owns the serial ports that drive the face LEDs.
+
+The same socket is reachable two ways, both selected by the companion app's
+connection screen:
+
+| Transport | How the phone reaches the Pi | Default host:port |
+|-----------|------------------------------|-------------------|
+| **Pi broadcast Wi-Fi (AP mode)** | Phone joins the `ProtoHUD` network the Pi broadcasts. Set up with `scripts/setup_companion_ap.sh`. | `192.168.50.1:8780` |
+| **USB tether (USB-ethernet gadget)** | Phone (or laptop) is wired to the Pi's USB-C; the gadget exposes a point-to-point link. Set up with `scripts/setup_companion_usb.sh`. | `192.168.42.1:8780` |
+
+Both routes terminate at the same `0.0.0.0:8780` bind, so the API is identical
+regardless of how you connect. A normal LAN/Wi-Fi connection works too if the Pi
+is on a shared network.
+
+## Enabling the server
+
+In `config/config.json`:
+
+```jsonc
+"network_control": {
+  "enabled": true,
+  "host":    "0.0.0.0",   // bind all interfaces (AP + USB + LAN)
+  "port":    8780,
+  "token":   ""           // "" = no auth; set a string to require X-ProtoHUD-Token
+}
+```
+
+## Auth
+
+If `token` is non-empty, **every** request must carry a matching
+`X-ProtoHUD-Token: <token>` header (a `401` is returned otherwise). For the
+isolated AP / USB-tether links the app uses, leaving `token` empty is fine. CORS
+is wide-open (`Access-Control-Allow-Origin: *`) so a browser PWA on the same link
+works too.
+
+## Endpoints
+
+All paths are prefixed `/api/v1`. Request and response bodies are JSON. Every
+response includes `"ok": <bool>`; failures add `"error": "<code>"`.
+
+### `GET /status`
+
+Health + current face look. Poll this (~1 Hz) to keep the app's UI in sync.
+
+```json
+{
+  "ok": true,
+  "name": "ProtoHUD",
+  "api": "1",
+  "face": {
+    "connected": true,
+    "hud_control": true,
+    "r": 0, "g": 220, "b": 180,
+    "brightness": 200,
+    "effect_id": 0,
+    "gif_id": 0,
+    "palette_id": 0,
+    "playing_gif": false,
+    "face_index": 0
+  }
+}
+```
+
+### Face control
+
+| Method & path | Body | Effect (`IFaceController`) |
+|---------------|------|----------------------------|
+| `POST /face/color`      | `{ "r":0-255, "g":0-255, "b":0-255, "layer"?:0-255 }` | `set_color` |
+| `POST /face/effect`     | `{ "effect_id":0-255, "p1"?:0-255, "p2"?:0-255 }`      | `set_effect` |
+| `POST /face/gif`        | `{ "gif_id":0-255 }`                                   | `play_gif` |
+| `POST /face/brightness` | `{ "value":0-255 }`                                    | `set_brightness` |
+| `POST /face/palette`    | `{ "palette_id":0-255 }`                               | `set_palette` |
+| `POST /face/expression` | `{ "index":0-255 }` **or** `{ "name":"happy" }`        | `set_face` / `set_face_by_name` |
+| `POST /face/release`    | _(none)_                                               | `release_control` (return face to autonomous mode) |
+
+All numeric fields are clamped to `0-255`; missing fields default sensibly
+(color components → 0, brightness → 200). Returns `503 {"error":"no_face"}` if no
+face backend is attached.
+
+### `POST /pad`
+
+The remote control pad. Fires the **same** action as the in-paw wireless
+controller / SmartKnob, so behaviour is identical across transports.
+
+```json
+{ "button": "nav_up" }
+```
+
+`button` ∈
+`select` · `back` · `menu` · `nav_up` · `nav_down` · `nav_left` · `nav_right` ·
+`af` (autofocus both OWLsight cameras) · `capture` (stereo photo).
+
+Unknown buttons return `400 {"error":"unknown_button"}`; a missing `button` field
+returns `400 {"error":"missing_button"}`.
+
+> **Note:** PiP-toggle buttons are intentionally not in v1 — in the helmet they are
+> momentary GPIO states sampled by the render loop each frame, not callback
+> actions, so they need a different mechanism. Planned for a later revision.
+
+## Versioning
+
+`api` in `/status` is bumped only on incompatible changes. The app should check it
+on connect and warn if it doesn't recognise the major version.

--- a/scripts/setup_companion_ap.sh
+++ b/scripts/setup_companion_ap.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# setup_companion_ap.sh — make the Raspberry Pi CM5 broadcast its own Wi-Fi
+# network so the ProtoHUD companion app (phone) can join it directly, no
+# infrastructure AP required.
+#
+# After running this, the Pi serves SSID "ProtoHUD" on 192.168.50.1 and the
+# companion control server is reachable at  http://192.168.50.1:8780
+# (set "network_control.enabled": true in config/config.json).
+#
+# Uses NetworkManager (default on Raspberry Pi OS Bookworm/Trixie), which makes
+# an AP a one-liner and coexists with a wired/secondary uplink. Re-runnable.
+#
+# Usage:
+#   sudo ./scripts/setup_companion_ap.sh [SSID] [PASSPHRASE] [IFACE]
+# Defaults:
+#   SSID="ProtoHUD"  PASSPHRASE="protohud24"  IFACE=wlan0
+#
+# To tear down:   sudo nmcli connection down ProtoHUD-AP
+#                 sudo nmcli connection delete ProtoHUD-AP
+# ─────────────────────────────────────────────────────────────────────────────
+set -euo pipefail
+
+SSID="${1:-ProtoHUD}"
+PASS="${2:-protohud24}"
+IFACE="${3:-wlan0}"
+CON="ProtoHUD-AP"
+AP_IP="192.168.50.1/24"
+
+if [[ $EUID -ne 0 ]]; then
+  echo "Run as root (sudo)." >&2; exit 1
+fi
+
+if (( ${#PASS} < 8 )); then
+  echo "WPA passphrase must be at least 8 characters." >&2; exit 1
+fi
+
+if ! command -v nmcli >/dev/null 2>&1; then
+  cat >&2 <<'EOF'
+nmcli (NetworkManager) not found. This script targets Raspberry Pi OS
+Bookworm/Trixie where NetworkManager is the default. On a hostapd-based setup,
+configure hostapd + dnsmasq manually to serve SSID "ProtoHUD" on 192.168.50.1.
+EOF
+  exit 1
+fi
+
+echo "Creating Wi-Fi access point '${SSID}' on ${IFACE} (${AP_IP})…"
+
+# Remove any prior copy so the script is idempotent.
+nmcli connection delete "${CON}" >/dev/null 2>&1 || true
+
+nmcli connection add type wifi ifname "${IFACE}" con-name "${CON}" \
+  autoconnect yes ssid "${SSID}"
+
+nmcli connection modify "${CON}" \
+  802-11-wireless.mode ap \
+  802-11-wireless.band bg \
+  ipv4.method shared \
+  ipv4.addresses "${AP_IP}" \
+  wifi-sec.key-mgmt wpa-psk \
+  wifi-sec.psk "${PASS}"
+
+nmcli connection up "${CON}"
+
+cat <<EOF
+
+✓ Access point is up.
+    SSID:        ${SSID}
+    Passphrase:  ${PASS}
+    Pi address:  ${AP_IP%/*}
+
+Next:
+  1. In config/config.json set  "network_control": { "enabled": true }
+  2. Restart protohud.
+  3. On the phone, join Wi-Fi "${SSID}", open the companion app, and connect to
+     http://${AP_IP%/*}:8780  (this is the app's default AP host).
+
+This AP autostarts on boot. 'ipv4.method shared' also hands out DHCP + NAT, so
+the phone gets an address automatically and (if the Pi has another uplink) can
+still reach the internet.
+EOF

--- a/scripts/setup_companion_usb.sh
+++ b/scripts/setup_companion_usb.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# setup_companion_usb.sh — expose a USB-ethernet gadget on the Pi's USB-C OTG
+# port so a tethered phone/laptop gets a wired, point-to-point link to the
+# helmet. The companion control server is then reachable at
+#   http://192.168.42.1:8780
+#
+# This is the "USB tethering" path the companion app offers alongside the
+# broadcast-Wi-Fi (AP) path. It needs no radios — handy for noisy RF environments
+# or for bench bring-up.
+#
+# Mechanism: the libcomposite / g_ether USB gadget. The CM5's USB-C port must be
+# in peripheral (device) mode for this to work — verify your carrier board routes
+# the OTG port to the phone, not a host hub.
+#
+# Usage:   sudo ./scripts/setup_companion_usb.sh
+# Removes: sudo modprobe -r g_ether   (and delete the dhcp/IP drop-ins below)
+#
+# NOTE: Android does not auto-configure RNDIS/ECM tethered links the way a laptop
+# does. On the phone you typically must accept the "USB ethernet" prompt; some
+# Android builds expose it under Settings → Connections → More → USB. The app's
+# USB-tether help screen walks through this.
+# ─────────────────────────────────────────────────────────────────────────────
+set -euo pipefail
+
+GADGET_IP="192.168.42.1"
+GADGET_CIDR="${GADGET_IP}/24"
+USB_IFACE="usb0"
+
+if [[ $EUID -ne 0 ]]; then
+  echo "Run as root (sudo)." >&2; exit 1
+fi
+
+echo "Loading g_ether USB-ethernet gadget…"
+# g_ether presents both ECM (Linux/macOS) and RNDIS (Windows/Android) configs.
+modprobe g_ether || {
+  echo "Could not load g_ether. Ensure 'dtoverlay=dwc2' is in /boot/firmware/config.txt" >&2
+  echo "and 'modules-load=dwc2' is appended to /boot/firmware/cmdline.txt, then reboot." >&2
+  exit 1
+}
+
+# Give the gadget interface a moment to appear, then assign a static address.
+for _ in $(seq 1 10); do
+  ip link show "${USB_IFACE}" >/dev/null 2>&1 && break
+  sleep 0.5
+done
+
+if ! ip link show "${USB_IFACE}" >/dev/null 2>&1; then
+  echo "Interface ${USB_IFACE} did not appear. Is the OTG port in device mode?" >&2
+  exit 1
+fi
+
+ip addr flush dev "${USB_IFACE}" || true
+ip addr add "${GADGET_CIDR}" dev "${USB_IFACE}"
+ip link set "${USB_IFACE}" up
+
+# Hand the tethered device an address so it needs zero manual config. dnsmasq is
+# the lightest option; fall back to a static-only link if it's not installed.
+if command -v dnsmasq >/dev/null 2>&1; then
+  pkill -f "dnsmasq.*${USB_IFACE}" 2>/dev/null || true
+  dnsmasq \
+    --interface="${USB_IFACE}" \
+    --bind-interfaces \
+    --dhcp-range=192.168.42.10,192.168.42.50,255.255.255.0,1h \
+    --dhcp-option=3 \
+    --dhcp-option=6 \
+    --except-interface=lo \
+    --pid-file=/run/protohud-usb-dnsmasq.pid
+  echo "dnsmasq serving DHCP on ${USB_IFACE}."
+else
+  echo "dnsmasq not installed — link is static-only."
+  echo "On the tethered device set IP 192.168.42.2/24 manually."
+fi
+
+cat <<EOF
+
+✓ USB-ethernet gadget is up on ${USB_IFACE} (${GADGET_IP}).
+
+Next:
+  1. In config/config.json set  "network_control": { "enabled": true }
+  2. Restart protohud.
+  3. Plug the phone into the Pi's USB-C OTG port, accept any "USB ethernet"
+     prompt on the phone, then in the companion app connect to
+     http://${GADGET_IP}:8780  (this is the app's default USB-tether host).
+
+To make this persist across reboots, add 'dtoverlay=dwc2' to
+/boot/firmware/config.txt and run this script from a systemd unit / rc.local.
+EOF

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -28,6 +28,7 @@
 #include "input/gpio_buttons.h"
 #include "input/gamepad_input.h"
 #include "input/wireless_controller.h"
+#include "net/remote_control_server.h"
 #include "serial/face_controller.h"
 #include "serial/protoface_controller.h"
 #include "serial/teensy_controller.h"
@@ -9003,6 +9004,18 @@ int main(int argc, char* argv[]) {
     SmartKnob            knob    (knob_port,     baud, state);
     WirelessController   wireless(wireless_port, baud);
 
+    // Companion-app control server (REST over the Pi's AP / USB-tether link).
+    // Disabled unless config has "network_control": { "enabled": true }.
+    RemoteControlServer::Config remote_cfg;
+    if (cfg.contains("network_control")) {
+        const auto& jnc = cfg["network_control"];
+        remote_cfg.enabled = jnc.value("enabled", false);
+        remote_cfg.host    = jnc.value("host",    remote_cfg.host);
+        remote_cfg.port    = jnc.value("port",    remote_cfg.port);
+        remote_cfg.token   = jnc.value("token",   std::string());
+    }
+    RemoteControlServer  remote(state, &face_proxy, remote_cfg);
+
     // Native in-process face renderer (only constructed in "native" mode). It
     // renders the LED face in C++ and writes the same /dev/shm frame the daemon
     // would, so the existing preview path and panel_driver.py work unchanged.
@@ -9575,6 +9588,44 @@ int main(int argc, char* argv[]) {
         });
         wireless.start();
     }
+
+    // Companion app control server — wire the remote "pad" to the SAME menu/hud
+    // actions as the in-paw wireless controller so both transports behave
+    // identically. Face commands inside the server go straight to face_proxy
+    // (the same path the menu leaf lambdas use). start() is a no-op when the
+    // network_control config block is absent or disabled.
+    remote.on_menu([&menu]{
+        if (menu.is_open()) menu.close(); else menu.open();
+    });
+    remote.on_select([&menu, &hud, &state]{
+        if      (menu.is_open())          menu.select();
+        else if (hud.toast_has_focused()) hud.toast_select(state);
+    });
+    remote.on_back([&menu, &hud]{
+        if      (hud.toast_has_focused()) hud.toast_navigate(-1);
+        else if (menu.is_open())          menu.back();
+    });
+    remote.on_nav_up   ([&menu]{ if (menu.is_open()) menu.navigate(-1); });
+    remote.on_nav_down ([&menu]{ if (menu.is_open()) menu.navigate(+1); });
+    remote.on_nav_left ([&menu, &hud]{
+        if (menu.is_face_editor_open())   return;
+        if      (hud.toast_has_focused()) hud.toast_navigate(-1);
+        else if (menu.is_open())          menu.back();
+    });
+    remote.on_nav_right([&menu, &hud]{
+        if (menu.is_face_editor_open())   return;
+        if      (hud.toast_has_focused()) hud.toast_navigate(+1);
+        else if (menu.is_open())          menu.select();
+    });
+    remote.on_af([&cameras]{
+        if (cameras.owl_left())  cameras.owl_left()->start_autofocus();
+        if (cameras.owl_right()) cameras.owl_right()->start_autofocus();
+    });
+    remote.on_capture([&state]{
+        std::lock_guard<std::mutex> lk(state.mtx);
+        state.capture_request = CaptureRequest::Stereo;
+    });
+    remote.start();
 
     // Restore menu style from a previous session.
     if (cfg.contains("menu_style")) {
@@ -11757,6 +11808,7 @@ int main(int argc, char* argv[]) {
         native_ctrl->stop();                                                        // blanks the shm too
     }
     step("protoface");       protoface_ctrl.shutdown_daemon(); protoface_ctrl.stop();
+    step("remote");          remote.stop();
     step("lora");            lora.stop();
     step("knob");            knob.stop();
     step("textures");

--- a/src/net/remote_control_server.cpp
+++ b/src/net/remote_control_server.cpp
@@ -1,0 +1,214 @@
+#include "remote_control_server.h"
+
+#include <cstdio>
+#include <mutex>
+
+// cpp-httplib is header-only; keep it confined to this translation unit.
+#include <httplib.h>
+#include <nlohmann/json.hpp>
+
+#include "../app_state.h"
+
+using json = nlohmann::json;
+
+namespace {
+// Bumped when the wire contract in docs/COMPANION_API.md changes incompatibly.
+constexpr const char* kApiVersion = "1";
+
+// Clamp a JSON number to a byte, tolerating missing / out-of-range values.
+uint8_t jbyte(const json& j, const char* key, uint8_t def = 0) {
+    if (!j.contains(key) || !j[key].is_number()) return def;
+    long v = j[key].get<long>();
+    if (v < 0)   v = 0;
+    if (v > 255) v = 255;
+    return static_cast<uint8_t>(v);
+}
+}  // namespace
+
+struct RemoteControlServer::Impl {
+    httplib::Server svr;
+};
+
+RemoteControlServer::RemoteControlServer(AppState& state, FaceProxy* face, Config cfg)
+    : state_(state), face_(face), cfg_(std::move(cfg)), impl_(std::make_unique<Impl>()) {}
+
+RemoteControlServer::~RemoteControlServer() { stop(); }
+
+bool RemoteControlServer::start() {
+    if (!cfg_.enabled) return false;
+    if (running_.load()) return true;
+    running_.store(true);
+    thread_ = std::thread([this] { run(); });
+    return true;
+}
+
+void RemoteControlServer::stop() {
+    if (!running_.exchange(false)) return;
+    impl_->svr.stop();
+    if (thread_.joinable()) thread_.join();
+}
+
+bool RemoteControlServer::dispatch_pad(const std::string& button) {
+    // Mirrors WirelessController's button vocabulary. Returns false for unknown
+    // buttons so the handler can reply 400.
+    const Cb* cb = nullptr;
+    if      (button == "select")   cb = &select_cb_;
+    else if (button == "back")     cb = &back_cb_;
+    else if (button == "menu")     cb = &menu_cb_;
+    else if (button == "af")       cb = &af_cb_;
+    else if (button == "capture")  cb = &capture_cb_;
+    else if (button == "nav_up")   cb = &nav_up_cb_;
+    else if (button == "nav_down") cb = &nav_down_cb_;
+    else if (button == "nav_left") cb = &nav_left_cb_;
+    else if (button == "nav_right")cb = &nav_right_cb_;
+    else return false;
+
+    if (*cb) (*cb)();
+    return true;
+}
+
+void RemoteControlServer::run() {
+    auto& svr = impl_->svr;
+
+    // ── CORS — lets a browser PWA on the same AP/USB link talk to us too ──────
+    svr.set_default_headers({
+        {"Access-Control-Allow-Origin",  "*"},
+        {"Access-Control-Allow-Headers", "Content-Type, X-ProtoHUD-Token"},
+        {"Access-Control-Allow-Methods", "GET, POST, OPTIONS"},
+    });
+    svr.Options(R"(/.*)", [](const httplib::Request&, httplib::Response& res) {
+        res.status = 204;
+    });
+
+    // ── Optional shared-secret gate ───────────────────────────────────────────
+    svr.set_pre_routing_handler(
+        [this](const httplib::Request& req, httplib::Response& res) {
+            if (cfg_.token.empty() || req.method == "OPTIONS")
+                return httplib::Server::HandlerResponse::Unhandled;
+            if (req.get_header_value("X-ProtoHUD-Token") == cfg_.token)
+                return httplib::Server::HandlerResponse::Unhandled;
+            res.status = 401;
+            res.set_content(R"({"ok":false,"error":"unauthorized"})", "application/json");
+            return httplib::Server::HandlerResponse::Handled;
+        });
+
+    auto reply = [](httplib::Response& res, const json& j, int status = 200) {
+        res.status = status;
+        res.set_content(j.dump(), "application/json");
+    };
+
+    // Parse a JSON body, tolerating an empty body (returns {}).
+    auto body = [](const httplib::Request& req) -> json {
+        if (req.body.empty()) return json::object();
+        return json::parse(req.body, nullptr, /*allow_exceptions=*/false);
+    };
+
+    // ── GET /api/v1/status ────────────────────────────────────────────────────
+    svr.Get("/api/v1/status", [&](const httplib::Request&, httplib::Response& res) {
+        json face_j;
+        {
+            std::lock_guard<std::mutex> lk(state_.mtx);
+            const auto& f = state_.face;
+            face_j = {
+                {"connected",   f.connected},
+                {"hud_control", f.hud_control},
+                {"r", f.r}, {"g", f.g}, {"b", f.b},
+                {"brightness",  f.brightness},
+                {"effect_id",   f.effect_id},
+                {"gif_id",      f.gif_id},
+                {"palette_id",  f.palette_id},
+                {"playing_gif", f.playing_gif},
+                {"face_index",  f.face_index},
+            };
+        }
+        reply(res, {
+            {"ok", true},
+            {"name", "ProtoHUD"},
+            {"api", kApiVersion},
+            {"face", face_j},
+        });
+    });
+
+    // ── POST /api/v1/face/color  {r,g,b,layer?} ──────────────────────────────
+    svr.Post("/api/v1/face/color", [&](const httplib::Request& req, httplib::Response& res) {
+        json b = body(req);
+        if (!face_) return reply(res, {{"ok", false}, {"error", "no_face"}}, 503);
+        face_->set_color(jbyte(b, "r"), jbyte(b, "g"), jbyte(b, "b"), jbyte(b, "layer", 0));
+        reply(res, {{"ok", true}});
+    });
+
+    // ── POST /api/v1/face/effect {effect_id,p1?,p2?} ─────────────────────────
+    svr.Post("/api/v1/face/effect", [&](const httplib::Request& req, httplib::Response& res) {
+        json b = body(req);
+        if (!face_) return reply(res, {{"ok", false}, {"error", "no_face"}}, 503);
+        face_->set_effect(jbyte(b, "effect_id"), jbyte(b, "p1", 0), jbyte(b, "p2", 0));
+        reply(res, {{"ok", true}});
+    });
+
+    // ── POST /api/v1/face/gif {gif_id} ───────────────────────────────────────
+    svr.Post("/api/v1/face/gif", [&](const httplib::Request& req, httplib::Response& res) {
+        json b = body(req);
+        if (!face_) return reply(res, {{"ok", false}, {"error", "no_face"}}, 503);
+        face_->play_gif(jbyte(b, "gif_id"));
+        reply(res, {{"ok", true}});
+    });
+
+    // ── POST /api/v1/face/brightness {value} ─────────────────────────────────
+    svr.Post("/api/v1/face/brightness", [&](const httplib::Request& req, httplib::Response& res) {
+        json b = body(req);
+        if (!face_) return reply(res, {{"ok", false}, {"error", "no_face"}}, 503);
+        face_->set_brightness(jbyte(b, "value", 200));
+        reply(res, {{"ok", true}});
+    });
+
+    // ── POST /api/v1/face/palette {palette_id} ───────────────────────────────
+    svr.Post("/api/v1/face/palette", [&](const httplib::Request& req, httplib::Response& res) {
+        json b = body(req);
+        if (!face_) return reply(res, {{"ok", false}, {"error", "no_face"}}, 503);
+        face_->set_palette(jbyte(b, "palette_id"));
+        reply(res, {{"ok", true}});
+    });
+
+    // ── POST /api/v1/face/expression {index} | {name} ────────────────────────
+    svr.Post("/api/v1/face/expression", [&](const httplib::Request& req, httplib::Response& res) {
+        json b = body(req);
+        if (!face_) return reply(res, {{"ok", false}, {"error", "no_face"}}, 503);
+        if (b.contains("name") && b["name"].is_string())
+            face_->set_face_by_name(b["name"].get<std::string>());
+        else
+            face_->set_face(jbyte(b, "index"));
+        reply(res, {{"ok", true}});
+    });
+
+    // ── POST /api/v1/face/release ────────────────────────────────────────────
+    // Hand the face back to the backend's autonomous mode.
+    svr.Post("/api/v1/face/release", [&](const httplib::Request&, httplib::Response& res) {
+        if (!face_) return reply(res, {{"ok", false}, {"error", "no_face"}}, 503);
+        face_->release_control();
+        reply(res, {{"ok", true}});
+    });
+
+    // ── POST /api/v1/pad {button} ────────────────────────────────────────────
+    // Remote control pad. button ∈ select|back|menu|af|capture|nav_{up,down,left,right}.
+    svr.Post("/api/v1/pad", [&](const httplib::Request& req, httplib::Response& res) {
+        json b = body(req);
+        if (!b.contains("button") || !b["button"].is_string())
+            return reply(res, {{"ok", false}, {"error", "missing_button"}}, 400);
+        const std::string button = b["button"].get<std::string>();
+        if (!dispatch_pad(button))
+            return reply(res, {{"ok", false}, {"error", "unknown_button"}, {"button", button}}, 400);
+        reply(res, {{"ok", true}, {"button", button}});
+    });
+
+    printf("[remote] companion control server listening on %s:%d%s\n",
+           cfg_.host.c_str(), cfg_.port, cfg_.token.empty() ? "" : " (token required)");
+    fflush(stdout);
+
+    // Blocks until stop() calls svr.stop(). listen() returns false if the bind
+    // fails (e.g. port already in use) — surface that rather than spinning.
+    if (!svr.listen(cfg_.host.c_str(), cfg_.port)) {
+        fprintf(stderr, "[remote] failed to bind %s:%d — companion server disabled\n",
+                cfg_.host.c_str(), cfg_.port);
+    }
+    running_.store(false);
+}

--- a/src/net/remote_control_server.h
+++ b/src/net/remote_control_server.h
@@ -1,0 +1,96 @@
+#pragma once
+
+#include <atomic>
+#include <functional>
+#include <memory>
+#include <string>
+#include <thread>
+
+#include "../serial/face_controller.h"
+
+struct AppState;
+
+// ── ProtoHUD companion-app control server ─────────────────────────────────────
+//
+// A small REST + JSON HTTP server that lets the ProtoHUD companion app (Flutter)
+// drive the helmet over IP. It is reachable two ways, both of which terminate at
+// the same TCP socket bound on the CM5:
+//   (a) the Pi's own broadcast Wi-Fi network (AP mode — see scripts/setup_companion_ap.sh)
+//   (b) a USB tether (USB-ethernet gadget — see scripts/setup_companion_usb.sh)
+//
+// DESIGN — mirrors WirelessController exactly:
+//   • Face commands (color / effect / gif / brightness / palette / expression)
+//     are forwarded straight to the FaceProxy, just like the menu leaf lambdas
+//     and the WirelessController's on_select path already do from non-render
+//     threads. No new locking is introduced.
+//   • "Pad" actions (nav / select / back / menu / af / capture) fire std::function
+//     callbacks on the HTTP worker thread. main.cpp wires these to the SAME
+//     lambdas used for the WirelessController, so behaviour is identical no matter
+//     which transport drove the press.
+//
+// THREADING: handlers run on cpp-httplib worker threads. Pad callbacks must be
+// safe to call off the render thread (the menu/hud lambdas already are — that is
+// how the SmartKnob and WirelessController call them today). Status reads take
+// AppState::mtx.
+//
+// The server is entirely optional: when Config::enabled is false, start() is a
+// no-op and no socket is opened.
+class RemoteControlServer {
+public:
+    using Cb = std::function<void()>;
+
+    struct Config {
+        bool        enabled = false;
+        std::string host    = "0.0.0.0";  // bind all interfaces (AP + USB + LAN)
+        int         port    = 8780;
+        // Optional shared secret. When non-empty, every request must carry a
+        // matching `X-ProtoHUD-Token` header. Empty disables auth — fine for the
+        // isolated AP / USB-tether links the companion app uses.
+        std::string token;
+    };
+
+    RemoteControlServer(AppState& state, FaceProxy* face, Config cfg);
+    ~RemoteControlServer();
+
+    RemoteControlServer(const RemoteControlServer&)            = delete;
+    RemoteControlServer& operator=(const RemoteControlServer&) = delete;
+
+    // Spawns the listener thread. Returns false (and does nothing) when disabled.
+    bool start();
+    void stop();
+
+    bool running() const { return running_.load(); }
+    int  port()    const { return cfg_.port; }
+
+    // ── Pad action callbacks — fire on an HTTP worker thread ──────────────────
+    // (Wire these to the same menu/hud lambdas as WirelessController in main.cpp.)
+    void on_select   (Cb cb) { select_cb_   = std::move(cb); }
+    void on_back     (Cb cb) { back_cb_     = std::move(cb); }
+    void on_menu     (Cb cb) { menu_cb_     = std::move(cb); }
+    void on_af       (Cb cb) { af_cb_       = std::move(cb); }
+    void on_capture  (Cb cb) { capture_cb_  = std::move(cb); }
+    void on_nav_up   (Cb cb) { nav_up_cb_   = std::move(cb); }
+    void on_nav_down (Cb cb) { nav_down_cb_ = std::move(cb); }
+    void on_nav_left (Cb cb) { nav_left_cb_ = std::move(cb); }
+    void on_nav_right(Cb cb) { nav_right_cb_= std::move(cb); }
+
+private:
+    void run();
+    bool dispatch_pad(const std::string& button);
+
+    AppState&   state_;
+    FaceProxy*  face_ = nullptr;
+    Config      cfg_;
+
+    std::thread        thread_;
+    std::atomic<bool>  running_ { false };
+
+    // Opaque httplib::Server, hidden from this header so cpp-httplib only needs
+    // to be included in the .cpp (keeps the heavy single-header out of the build
+    // graph for every other translation unit).
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
+
+    Cb select_cb_, back_cb_, menu_cb_, af_cb_, capture_cb_;
+    Cb nav_up_cb_, nav_down_cb_, nav_left_cb_, nav_right_cb_;
+};


### PR DESCRIPTION
## Helmet-side control server for the companion app

Adds an in-process **REST + JSON** control server so the new ProtoHUD companion app (Flutter — separate repo PR) can drive the helmet over IP. It lives *inside* `protohud` because that process exclusively owns the LED serial ports — a separate daemon couldn't share them.

### What's added
- **`src/net/remote_control_server.{h,cpp}`** — `RemoteControlServer` (cpp-httplib, header-only via `FetchContent`) on its own thread. Designed to mirror `WirelessController`:
  - Face commands → straight to `FaceProxy` (same path the menu leaf lambdas already use off the render thread).
  - "Pad" actions fire `std::function` callbacks wired in `main.cpp` to the **same** menu/hud lambdas as the in-paw wireless controller, so behaviour is identical across serial, ESP-NOW, and the phone.
- **Endpoints** (`/api/v1`): `GET /status`; `POST /face/{color,effect,gif,brightness,palette,expression,release}`; `POST /pad`. Optional `X-ProtoHUD-Token` auth; CORS open for a possible PWA.
- **Config:** new top-level `network_control` block (disabled by default) in `config.example.json`.
- **`scripts/setup_companion_ap.sh`** — Pi broadcasts its own `ProtoHUD` Wi-Fi (NetworkManager AP, `192.168.50.1`).
- **`scripts/setup_companion_usb.sh`** — USB-ethernet gadget for a wired tether (`192.168.42.1`).
- **`docs/COMPANION_API.md`** — the wire contract; README section added.

### Integration footprint (`main.cpp`)
Four small, mechanical edits, all mirroring the existing `WirelessController` wiring: include, construct `remote` next to `wireless`, wire the same pad callbacks + `remote.start()`, and `remote.stop()` in the shutdown sequence. No render-loop changes.

### ⚠️ Verification status
The sandbox lacks the build deps (libcamera/OpenCV/GLES), so this is **not yet compiled**. Before merge:
- [ ] `cmake -B build && cmake --build build` on the Pi (first configure fetches `cpp-httplib v0.15.3`)
- [ ] Enable `network_control`, hit `GET /api/v1/status`, then exercise `/face/*` and `/pad` from the app
- [ ] Confirm AP and USB-tether scripts bring up reachable links

### Notes
- PiP-toggle buttons are intentionally out of v1 (momentary GPIO states sampled per-frame, not callback actions) — documented in the API doc for a later revision.

https://claude.ai/code/session_0116NzTegDTk3dNnSRvaQJoT

---
_Generated by [Claude Code](https://claude.ai/code/session_0116NzTegDTk3dNnSRvaQJoT)_