### PR TITLE
docs: optical mouth tracking → HUB75 blendshape driver design

### DIFF
--- a/docs/mouth-blendshape-faces.md
+++ b/docs/mouth-blendshape-faces.md
@@ -1,0 +1,107 @@
+# Authoring blendshape mouth layers for a face
+
+This is the art/config spec for the **blendshape mouth stack** added in Phase 1
+of the optical mouth-tracking work (see
+`docs/mouth-tracking-blendshape-design.md`). Follow it when creating the
+reference faces that ship with ProtoHUD.
+
+A face that provides these layers gains **asymmetric, multi-shape** mouth
+animation driven by the optical tracker (or, until the Pi Zero is wired, by the
+**Face Display ▸ Mouth Tracker (Test)** sliders). Faces *without* these layers
+keep working exactly as before on the audio-driven `mouth_open` path — the
+blendshape stack is purely additive and opt-in.
+
+## Where layers live
+
+Inside a face folder `faces/<name>/`, alongside the expression PNGs
+(`neutral.png`, `happy.png`, …), `blink.png`, and the existing viseme overlays
+(`mouth_open.png`, …):
+
+```
+faces/<name>/
+  neutral.png            ← expression (full canvas, RGBA)
+  happy.png
+  blink.png
+  mouth_open.png         ← legacy audio viseme overlays (still supported)
+  blend_jawOpen.png      ← NEW blendshape layers (all optional)
+  blend_mouthSmileLeft.png
+  blend_mouthSmileRight.png
+  ...
+  config.json
+```
+
+## Layer files
+
+Each layer is a **full-canvas RGBA PNG** sized like every other sprite (it gets
+scaled to the panel canvas). Author it as an **additive delta from neutral**:
+only the part of the mouth that this shape moves should be **opaque**; everything
+else must be **fully transparent**. Layers are alpha-stacked, so transparent
+pixels never disturb the base face or other layers.
+
+The filename stems are fixed by the contract in
+`src/face/mouth_blendshapes.h` (index order is shared with the coprocessor
+protocol — do not rename). The full set, in order:
+
+| Layer file | MediaPipe coeff | Clipped to region | Suggested look |
+|---|---|---|---|
+| `blend_jawOpen.png` | `jawOpen` | `mouth` | overall open mouth |
+| `blend_mouthSmileLeft.png` | `mouthSmileLeft` | `mouth_left` | left corner up |
+| `blend_mouthSmileRight.png` | `mouthSmileRight` | `mouth_right` | right corner up |
+| `blend_mouthFrownLeft.png` | `mouthFrownLeft` | `mouth_left` | left corner down |
+| `blend_mouthFrownRight.png` | `mouthFrownRight` | `mouth_right` | right corner down |
+| `blend_mouthPucker.png` | `mouthPucker` | `mouth` | tight rounded "OO" |
+| `blend_mouthFunnel.png` | `mouthFunnel` | `mouth` | open round "OH" |
+| `blend_mouthLeft.png` | `mouthLeft` | `mouth` | mouth shifted left |
+| `blend_mouthRight.png` | `mouthRight` | `mouth` | mouth shifted right |
+| `blend_mouthUpperUpLeft.png` | `mouthUpperUpLeft` | `mouth_left` | left upper-lip raise |
+| `blend_mouthUpperUpRight.png` | `mouthUpperUpRight` | `mouth_right` | right upper-lip raise |
+| `blend_mouthClose.png` | `mouthClose` | `mouth` | pressed/sealed lips |
+
+**Start small:** a strong first set is `blend_jawOpen` + the four
+smile/frown L/R layers + `blend_mouthPucker` + `blend_mouthFunnel` (indices 0–6).
+Add the rest later — missing layers simply contribute nothing.
+
+## config.json regions
+
+The compositor clips each layer to a mouth region. Reuse the existing `mouth`
+box; optionally add `mouth_left` / `mouth_right` for sharper per-side clipping
+(Left/Right layers fall back to `mouth` when these are absent):
+
+```jsonc
+{
+  "draw_size": [64, 32],          // author-space size; regions scale to panel px
+  "eye_left":  { "x": 8,  "y": 6,  "w": 16, "h": 12 },
+  "eye_right": { "x": 40, "y": 6,  "w": 16, "h": 12 },
+  "mouth":       { "x": 20, "y": 22, "w": 24, "h": 8 },
+  "mouth_left":  { "x": 20, "y": 22, "w": 12, "h": 8 },   // optional
+  "mouth_right": { "x": 32, "y": 22, "w": 12, "h": 8 }    // optional
+}
+```
+
+If you omit `mouth` entirely, layers composite across the whole canvas — which is
+fine because each layer's own alpha already masks it to the mouth area. Defining
+the region just bounds the work and sharpens per-side asymmetry.
+
+## How the stack composites (what to expect)
+
+Per frame, after the expression crossfade and blink:
+
+1. The renderer reads the tracker's weight per layer (`0..1`) × global
+   confidence (`0..1`).
+2. Each present layer is alpha-blended **over** the face at its region with
+   `opacity = layer_alpha × weight × confidence`.
+3. Base shapes (jawOpen, funnel/pucker) are listed first; corner/asymmetry
+   layers stack on top.
+
+Because it's alpha-over (not cross-fade), multiple layers combine cleanly —
+e.g. `jawOpen=0.6` + `mouthSmileLeft=0.9` reads as an open mouth with the left
+corner pulled up. Design the opaque regions so overlapping layers reinforce
+rather than fight (keep each layer's ink mostly to its own area).
+
+## Testing without the Pi Zero
+
+1. Select the native Protoface backend and a face that has `blend_*` layers.
+2. Open **Face Display ▸ Mouth Tracker (Test)**, turn **Enabled** on.
+3. Push individual coefficient sliders (and **Confidence**) and watch the panels
+   / in-HUD preview. Asymmetric combinations should be visible.
+4. Turn **Enabled** off to release the mouth back to the audio (Voice) path.

--- a/docs/mouth-tracking-blendshape-design.md
+++ b/docs/mouth-tracking-blendshape-design.md
@@ -1,0 +1,462 @@
+# Optical Mouth Tracking → HUB75 Blendshape Mouth Driver
+
+**Status:** Design / not yet implemented
+**Target branch:** `claude/mouth-tracking-hub75-BRRTn`
+**Author context:** design doc requested before any code
+
+---
+
+## 1. Goal & locked decisions
+
+Drive the HUB75 LED face's mouth from the wearer's **actual mouth**, with enough
+fidelity for **asymmetrical** shapes (smirk, one-sided "O", lopsided smile),
+while leaving the CM5's CPU/GPU headroom free for camera compositing + HUD.
+
+Decisions already made in design discussion:
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Signal source | Optical (camera on the real mouth) | True 1:1 tracking, works when silent |
+| Topology | **Satellite coprocessor** at front of head, CM5 on back | Offload vision; single thin cable run |
+| Coprocessor | **Raspberry Pi Zero 2 W** | Quad A53 can run MediaPipe FaceLandmarker at low res; small/low power |
+| Vision model | **MediaPipe FaceLandmarker** w/ blendshape coefficients | Emits ARKit-style mouth/jaw weights directly; pose-normalized |
+| Render model | **Blendshape stack** on the CM5 | Asymmetry, keeps PNG art pipeline, plugs 1:1 into tracker output |
+| Link | **UART** (primary) or USB-serial gadget | Tiny payload; reuses existing serial framing |
+| Audio role | **Fallback** when optical confidence is low / tracker offline | Mouth still moves if camera drops out |
+
+The key architectural insight that justifies "blendshape stack": MediaPipe's
+blendshape coefficients are **per-expression weights that are already largely
+decoupled from head pose**, so the tracker output *is* the render input — no
+landmark-to-screen mapping or heavy per-user calibration required to get usable
+asymmetry.
+
+---
+
+## 2. End-to-end architecture
+
+```
+┌──────────────────────── FRONT OF HEAD (snout) ───────────────────────┐
+│ Raspberry Pi Zero 2 W                                                 │
+│                                                                       │
+│  NoIR CSI camera ──► MediaPipe FaceLandmarker (Tasks API)             │
+│  + IR LEDs           │  • 478 landmarks + 52 blendshape coeffs        │
+│  (mouth-lit)         ▼                                                 │
+│              select mouth/jaw subset (~10–12 coeffs)                   │
+│                      │                                                 │
+│                      ▼                                                 │
+│              one-euro smoothing + neutral offset + gain               │
+│                      │                                                 │
+│                      ▼                                                 │
+│              frame: {seq, conf, w[0..N]}  (binary, ~30 B)             │
+└──────────────────────────────────┬───────────────────────────────────┘
+                                    │  UART (3 wire) @ 115200–460800
+                                    │  or USB-serial gadget
+┌──────────────────────────────────┼──── BACK OF HEAD ──────────────────┐
+│ Raspberry Pi CM5                  ▼                                     │
+│   MouthTracker (new)  ── parses frames on its own thread               │
+│        │                                                               │
+│        │  face_proxy.set_mouth_blendshapes(weights, confidence)        │
+│        ▼                                                               │
+│   FaceProxy ──► NativeFaceController ──► FaceState (per panel)         │
+│        ▲                                     │                          │
+│   VoiceAnalyzer ─ set_audio_drive (fallback) │                         │
+│                                              ▼                          │
+│                                   FaceLoader::get_frame                 │
+│                                   • expression crossfade               │
+│                                   • blink                              │
+│                                   • MOUTH: weighted blendshape stack   │ ◄── new
+│                                              │                          │
+│                                              ▼                          │
+│                          ShmPusherOutput → /dev/shm/protoface_frame    │
+└──────────────────────────────────┬───────────────────────────────────┘
+                                    ▼
+                       scripts/panel_driver.py (Piomatter) ──► HUB75
+```
+
+Nothing downstream of `FaceLoader` changes: the canvas still lands in
+`/dev/shm/protoface_frame` and `panel_driver.py` still bridges to Piomatter.
+
+---
+
+## 3. Coprocessor (Pi Zero 2 W) software
+
+A standalone Python service, e.g. `coproc/mouth_tracker_zero/tracker.py`, kept
+in this repo so it ships and versions with ProtoHUD.
+
+### 3.1 Camera + illumination
+- **NoIR CSI camera** (e.g. Pi Camera v2 NoIR / IMX219). The snout interior is
+  dark; IR removes dependence on ambient light and gives the landmarker a
+  consistent image.
+- **2–4 IR LEDs (850 nm)** aimed at the mouth, diffused to avoid hotspots. Keep
+  them off-axis from the eyes.
+- Capture at **low resolution** (e.g. 320×240 or a mouth-region crop). The
+  landmarker downscales internally anyway; lower res = higher fps on the Zero 2 W.
+
+### 3.2 Inference
+- **MediaPipe Tasks `FaceLandmarker`** with `output_face_blendshapes=True`,
+  `num_faces=1`, running in `LIVE_STREAM` (or `VIDEO`) mode.
+- Realistic throughput on a Zero 2 W: **~10–15 fps** at small input sizes. This
+  is acceptable because (a) the mouth is heavily smoothed and (b) the CM5 render
+  loop interpolates between updates. If 15 fps proves too coarse, drop input
+  resolution / crop to the mouth ROI before inference.
+- Extract only the mouth/jaw subset of the 52 coefficients (see §5.2).
+
+### 3.3 Conditioning (on the Zero, before sending)
+- **Neutral offset:** subtract a captured "resting face" baseline per coefficient
+  so a closed, relaxed mouth maps to ~0.
+- **Per-coefficient gain + clamp** to [0,1]; lets you exaggerate subtle motion to
+  read on a 64-px stylized mouth.
+- **One-euro filter** per coefficient: low latency *and* low jitter, adaptive to
+  motion speed. Strongly preferred over a fixed EMA here.
+- **Confidence:** derive from FaceLandmarker presence/tracking (and a simple
+  "face detected this frame" flag). Sent with every frame so the CM5 can
+  arbitrate vs. audio.
+
+### 3.4 Service behavior
+- systemd unit on the Zero; auto-start, auto-restart.
+- If no face is detected for N frames, keep streaming `conf=0` (don't go silent)
+  so the CM5 can deterministically fall back to audio.
+- Boots independently of the CM5; the link is hot-pluggable.
+
+---
+
+## 4. The link (Zero 2 W ↔ CM5)
+
+Payload is tiny (~30 B/frame at ≤30 Hz ≈ <1 kB/s), so choose for reliability and
+code fit, not bandwidth.
+
+### Primary: UART (recommended)
+- 3 wires (TX, RX, GND) from the Zero's UART to a CM5 UART. RX-on-CM5 is the only
+  strictly required direction; keep TX→Zero for future commands (e.g. "recapture
+  neutral").
+- **115200** is ample; **460800** gives headroom. Level-matched (both 3.3 V).
+- Reuses ProtoHUD's existing framing in `src/serial/serial_port.{h,cpp}` (the
+  same infra behind `smartknob` and `lora_radio`).
+
+### Alternate: USB-serial gadget
+- Zero in OTG peripheral mode presents `/dev/ttyACMx` (or g_ether) to the CM5.
+- One USB cable carries **power + data** — attractive for a single front-cable run.
+- Slightly more setup; same parsing code on the CM5 side.
+
+**Recommendation:** UART for the cleanest fit with existing serial code; switch to
+USB-gadget if you'd rather power the Zero down the same cable.
+
+---
+
+## 5. Wire protocol
+
+A small, versioned, framed binary message. Reuse `SerialPort`'s framing +
+checksum; the body below is the payload.
+
+### 5.1 Frame layout
+```
+magic   : u8  = 0xMF
+version : u8  = 0x01
+seq     : u8           // wraps; CM5 detects drops
+conf    : u8           // 0..255 tracking confidence
+count   : u8  = N      // number of blendshape weights
+w[0..N] : u8 each      // each coefficient quantized 0..255  (→ /255 on CM5)
+crc16   : u16          // over the payload (or rely on SerialPort framing CRC)
+```
+~6 + N bytes. With N≈12 → ~18 B body. Quantizing to u8 is plenty for a 64-px
+mouth; switch to f16/f32 only if banding ever shows.
+
+### 5.2 Blendshape subset (the contract)
+Order is fixed by index so both sides agree without sending names. Practical
+mouth/jaw set for a stylized protogen:
+
+| idx | MediaPipe coeff | Drives |
+|----:|-----------------|--------|
+| 0 | `jawOpen` | overall openness (replaces today's `mouth_open` scalar) |
+| 1 | `mouthSmileLeft` | left corner up |
+| 2 | `mouthSmileRight` | right corner up |
+| 3 | `mouthFrownLeft` | left corner down |
+| 4 | `mouthFrownRight` | right corner down |
+| 5 | `mouthPucker` | rounded / "OOH" |
+| 6 | `mouthFunnel` | open-round / "OH" |
+| 7 | `mouthLeft` | mouth slid left |
+| 8 | `mouthRight` | mouth slid right |
+| 9 | `mouthUpperUpLeft` | upper-lip raise L (snarl) |
+| 10 | `mouthUpperUpRight` | upper-lip raise R |
+| 11 | `mouthClose` | press/seal (optional) |
+
+Start with 0–6 (openness + L/R smile + L/R frown + pucker + funnel) for a strong
+asymmetric MVP; add the rest as art is authored.
+
+---
+
+## 6. CM5 receiver — `MouthTracker` module
+
+New files: `src/serial/mouth_tracker.h` / `.cpp` (mirrors `lora_radio` /
+`smartknob`).
+
+- Owns a `SerialPort`, runs a reader thread, parses §5 frames.
+- On each valid frame: dequantize to `float w[N]`, normalize confidence, and call
+  the new seam (below) on the `FaceProxy`.
+- Detects `seq` gaps (log/metric only) and a staleness timeout: if no frame for
+  `T_stale` (e.g. 250 ms), report `confidence = 0` so the renderer falls back.
+- Config-driven device path, baud, N, and the index→meaning map (so the contract
+  can evolve without code edits).
+- Wired up in `main.cpp` next to the other serial devices; pushed into the same
+  `face_proxy` already used by the audio callback (`main.cpp:9539`).
+
+### 6.1 New seam on `IFaceController`
+Add alongside `set_audio_drive` / `set_mouth_shape` in
+`src/serial/face_controller.h`:
+
+```cpp
+// Optical mouth tracker: weighted blendshape coefficients in [0,1], indexed
+// by the agreed mouth-blendshape order, plus tracking confidence in [0,1].
+// Native Protoface forwards to each panel's FaceState; non-native backends
+// no-op (they run their own / no mouth tracking).
+virtual void set_mouth_blendshapes(const std::vector<float>& weights,
+                                   float confidence) {}
+```
+- Add the matching override to `FaceProxy` (forward to `*active_`).
+- Implement in `NativeFaceController` (forward to each non-mirror panel's
+  `FaceState`).
+- Default no-op keeps Teensy/daemon backends compiling and behaving unchanged.
+
+---
+
+## 7. Render-side upgrade (the bulk of the work)
+
+Today the mouth is **one** region, **one** selected overlay, **one** scalar
+(`face_loader.cpp:145-153`, `face_state.h:104-106`). That cannot express
+asymmetry. The blendshape stack replaces "pick one overlay" with "blend N
+weighted overlays."
+
+### 7.1 `FaceState` additions
+- New field: `std::vector<float> mouth_weights_;` and `float mouth_conf_ = 0.f;`.
+- New setter `set_mouth_blendshapes(const std::vector<float>&, float conf)`.
+- Read accessors for the compositor.
+- **Backward compatibility:** keep `mouth_open_` / `mouth_shape_`. When optical
+  confidence is high, the stack drives the mouth; when low, fall back to the
+  legacy audio path (see §8). The old viseme path remains fully functional for
+  backends/users without a tracker.
+
+### 7.2 Asset / naming convention
+Per face folder `faces/<name>/`, add optional blendshape layer PNGs (RGBA, sized
+to the panel like existing overlays):
+
+```
+blend_jawOpen.png
+blend_mouthSmileLeft.png
+blend_mouthSmileRight.png
+blend_mouthFrownLeft.png
+blend_mouthFrownRight.png
+blend_mouthPucker.png
+blend_mouthFunnel.png
+...
+```
+- All optional. A missing layer = that coefficient contributes nothing (graceful
+  degradation; you can ship openness-only first).
+- `config.json` mouth region(s): keep the single `mouth` region for symmetric
+  layers; optionally add `mouth_left` / `mouth_right` regions so corner layers
+  are clipped to their side (sharper asymmetry on a small grid).
+- These import through the **same Files > Faces flow** (`import_face_image` /
+  `face_image_path`), extending the canonical stem list in
+  `face_loader.cpp:71` to include the `blend_*` stems.
+
+### 7.3 Compositing math (`FaceLoader::get_frame`)
+Replace step 3 ("Mouth open") with a stack:
+
+1. Start from the post-blink `frame`.
+2. For each loaded blendshape layer `i` with weight `w_i = state.mouth_weights_[i]`
+   (× any per-layer gain), composite it **over** the frame at its region with
+   opacity `clamp(w_i, 0, 1)`.
+3. Order matters: composite base-shape layers (jawOpen, funnel/pucker) first,
+   then corner/asymmetry layers (smile/frown L/R) on top.
+
+**Avoid double-darkening:** the current `blend_region` uses `cv::addWeighted`
+(`face_loader.cpp:109`), which cross-fades base↔overlay. Stacking several of
+those sequentially washes the base out. For the stack, composite each layer with
+**alpha-over using the layer's own RGBA alpha × weight** (premultiplied), so
+transparent areas of a layer never touch the base. This is a small, well-contained
+new helper (`blend_over_region`) next to `blend_region`.
+
+- Layers should be authored as **additive deltas from neutral** (only the moving
+  region is opaque), which makes "blend several at once" behave intuitively.
+- The legacy single-overlay path stays as a fallback branch when no `blend_*`
+  layers exist (so existing faces keep working untouched).
+
+### 7.4 Resolution realism
+At ~24–40 px mouth width the effective DOF is a handful of control points, so a
+**12-layer set is plenty** — fidelity is bounded by the panel and the stylized
+art, not the tracker. Author layers chunky and palette-aware (they go through the
+existing material colorizer downstream).
+
+---
+
+## 8. Optical ↔ audio arbitration
+
+Both producers feed `FaceState`. Policy (in `FaceState::update` or the
+controller, single source of truth):
+
+```
+if mouth_conf >= conf_hi:        use blendshape stack fully
+elif mouth_conf <= conf_lo:      use audio fallback (legacy mouth_open + viseme)
+else:                            crossfade between the two by confidence
+```
+- `jawOpen` and the audio `mouth_open` scalar are directly comparable, so the
+  crossfade is smooth.
+- When falling back to audio, the viseme classifier (`VoiceAnalyzer::mouth_shape`)
+  still picks round/open/small/smile as it does today.
+- Thresholds + hysteresis exposed in config/menu.
+
+This *is* the "hybrid" graceful-degradation behavior, achieved for free once both
+inputs exist.
+
+---
+
+## 9. Calibration
+
+Minimal, because MediaPipe blendshapes are pose-decoupled:
+- **Neutral capture** (on the Zero): a "hold a relaxed face" button/command
+  records the baseline offset. Triggerable over the link's CM5→Zero direction or
+  a physical button on the daughterboard.
+- **Per-coefficient gain** (Zero or CM5): tune how far real motion pushes the
+  stylized mouth. Live-adjustable from the ProtoHUD menu (sent back over UART, or
+  applied CM5-side before compositing).
+- Optional **per-user profiles** saved on the Zero.
+
+---
+
+## 10. Configuration additions
+
+`config.json` (consumed in `main.cpp`):
+```jsonc
+"mouth_tracker": {
+  "enabled": true,
+  "device": "/dev/ttyAMA0",      // or /dev/ttyACM0 for USB gadget
+  "baud": 460800,
+  "blendshape_count": 7,
+  "conf_hi": 0.6,
+  "conf_lo": 0.2,
+  "stale_timeout_ms": 250,
+  "layer_gain": { "mouthSmileLeft": 1.4, "mouthSmileRight": 1.4 }
+}
+```
+Plus optional `mouth_left` / `mouth_right` regions in each face's `config.json`.
+No change to `RenderConfig` canvas/output fields.
+
+---
+
+## 11. Menu / UI
+
+Under the existing Face/Audio menu tree (`src/menu/menu_system.*`):
+- Toggle: optical tracking on/off (falls back to audio when off).
+- Confidence thresholds + hysteresis sliders.
+- Per-layer gain sliders.
+- "Recapture neutral" action (sends command to the Zero).
+- Live readout: current confidence + per-coefficient weights (debugging aid).
+- The in-HUD face preview (`latest_frame`) already shows the result.
+
+---
+
+## 12. Latency budget
+
+| Stage | Approx |
+|---|---|
+| Camera exposure + read | ~33 ms @30fps capture |
+| FaceLandmarker on Zero 2 W | ~66–100 ms (10–15 fps) |
+| One-euro smoothing | adds ~0 (chosen for low lag) |
+| UART frame | <1 ms |
+| CM5 render tick | ~33 ms (30 fps) |
+| panel_driver poll + HUB75 refresh | ~16–33 ms |
+| **End-to-end** | **~150–200 ms** |
+
+Costume-acceptable, but mitigations if it feels laggy: crop-to-mouth before
+inference (raises fps), tighten one-euro `min_cutoff`, and let the CM5 interpolate
+weights between tracker updates.
+
+---
+
+## 13. Failure modes
+
+| Failure | Behavior |
+|---|---|
+| Zero offline / cable unplugged | stale timeout → `conf=0` → audio fallback |
+| Face not detected (fogged lens, look-away) | Zero streams `conf=0` → audio fallback |
+| Dropped/corrupt frames | `SerialPort` CRC rejects; seq-gap logged; last-good held briefly then stale |
+| Missing `blend_*` art | that layer contributes nothing; openness still works |
+| Tracker enabled but no audio either | mouth rests at neutral (safe) |
+
+---
+
+## 14. Phased implementation plan
+
+**Phase 0 — Plumbing (no behavior change, no hardware)**
+1. Add `set_mouth_blendshapes` to `IFaceController` + `FaceProxy` (no-op default).
+2. Implement forward in `NativeFaceController` → new `FaceState` fields/setter.
+3. Add a dev/test injector (menu "manual blendshape sliders" or a replay file) so
+   the render path is testable on the CM5 **with no Zero attached**.
+
+**Phase 1 — Render: blendshape stack**
+4. `blend_over_region` helper + stacked compositing in `FaceLoader::get_frame`.
+5. Extend canonical stem list + Files>Faces import for `blend_*` layers.
+6. Author a starter layer set for one face (openness + L/R smile + L/R frown +
+   pucker). Verify asymmetry on panels via the slider injector.
+
+**Phase 2 — Link + receiver**
+7. `MouthTracker` module (`SerialPort` reader, parse, push to `face_proxy`).
+8. Protocol encode/decode shared constants; wire into `main.cpp`.
+9. Arbitration + stale timeout + menu toggles.
+
+**Phase 3 — Coprocessor**
+10. Zero 2 W service: camera + FaceLandmarker + subset + one-euro + neutral +
+    framed UART output. systemd unit. NoIR + IR LED bring-up.
+11. Calibration UX (recapture neutral, gains).
+
+**Phase 4 — Polish**
+12. Per-side mouth regions, more layers, latency tuning, profiles, docs.
+
+Each phase is independently testable; Phases 0–1 need no new hardware.
+
+---
+
+## 15. Testing & validation
+
+- **No-hardware render test:** manual blendshape sliders / replay file → confirm
+  asymmetric shapes on panels (or the in-HUD preview).
+- **Loopback link test:** a host script emits synthetic §5 frames over a serial
+  pair → exercises `MouthTracker` parsing, seq-gap, stale timeout, arbitration.
+- **Coproc bench test:** run the Zero service against recorded IR video; verify
+  coefficient stability + latency before mounting in the helmet.
+- **Integration:** end-to-end with audio fallback forced (cover the lens) to
+  confirm graceful degradation.
+
+---
+
+## 16. File-by-file change list
+
+| File | Change |
+|---|---|
+| `src/serial/face_controller.h` | + `set_mouth_blendshapes()` on `IFaceController` and `FaceProxy` |
+| `src/face/native_face_controller.{h,cpp}` | implement forward to per-panel `FaceState` |
+| `src/face/face_state.{h,cpp}` | mouth weights + confidence fields, setter, accessors |
+| `src/face/face_loader.{h,cpp}` | load `blend_*` layers; `blend_over_region`; stacked compositing; keep legacy fallback |
+| `src/serial/mouth_tracker.{h,cpp}` | **new** — UART receiver, parse, push to `face_proxy` |
+| `src/serial/serial_port.{h,cpp}` | reuse as-is (framing/CRC) |
+| `src/main.cpp` | instantiate `MouthTracker`; arbitration alongside audio cb (`~:9539`); config load |
+| `src/menu/menu_system.*` | toggles, thresholds, gains, recapture-neutral |
+| `src/app_state.h` | `MouthTrackerConfig` struct |
+| `config/config.example.json` | `mouth_tracker` section + per-face region notes |
+| `coproc/mouth_tracker_zero/` | **new** — Zero 2 W Python service + systemd unit + README |
+| `docs/mouth-tracking-blendshape-design.md` | this document |
+
+---
+
+## 17. Open questions
+
+1. **Power for the Zero:** down the UART cable run separately, or commit to the
+   USB-serial gadget so one cable does power+data?
+2. **Per-side regions now or later?** Single `mouth` region (corner layers
+   overlap) is simpler; `mouth_left`/`mouth_right` clipping is sharper. Start
+   single, add if needed.
+3. **Quantization:** u8 per coefficient assumed sufficient; revisit if banding
+   appears on slow opens.
+4. **Layer authoring owner:** who draws the `blend_*` set, and do we ship a
+   reference set for the default face?
+5. **IR safety/comfort:** LED placement/intensity validated against eye exposure
+   and lens fogging.

--- a/docs/mouth-tracking-blendshape-design.md
+++ b/docs/mouth-tracking-blendshape-design.md
@@ -1,8 +1,17 @@
 # Optical Mouth Tracking → HUB75 Blendshape Mouth Driver
 
-**Status:** Design / not yet implemented
+**Status:** Phases 0–1 implemented (render path + test injector); Phases 2–4 pending
 **Target branch:** `claude/mouth-tracking-hub75-BRRTn`
-**Author context:** design doc requested before any code
+**Author context:** design doc, then incremental implementation
+
+> **Implemented so far (Phases 0–1):** the `set_mouth_blendshapes` seam through
+> `IFaceController`/`FaceProxy`/`NativeFaceController`/`FaceState`, the weighted
+> blendshape **stack** in `FaceLoader` (alpha-over `blend_*` layers with optional
+> per-side `mouth_left`/`mouth_right` regions), the shared contract in
+> `src/face/mouth_blendshapes.h`, and a **Face Display ▸ Mouth Tracker (Test)**
+> menu that drives the stack with no hardware. Authoring guide:
+> `docs/mouth-blendshape-faces.md`. Still pending: the UART `MouthTracker`
+> receiver (Phase 2), the Pi Zero 2 W service (Phase 3), and polish (Phase 4).
 
 ---
 
@@ -386,17 +395,18 @@ weights between tracker updates.
 
 ## 14. Phased implementation plan
 
-**Phase 0 — Plumbing (no behavior change, no hardware)**
-1. Add `set_mouth_blendshapes` to `IFaceController` + `FaceProxy` (no-op default).
-2. Implement forward in `NativeFaceController` → new `FaceState` fields/setter.
-3. Add a dev/test injector (menu "manual blendshape sliders" or a replay file) so
+**Phase 0 — Plumbing (no behavior change, no hardware)** ✅ done
+1. ✅ Add `set_mouth_blendshapes` to `IFaceController` + `FaceProxy` (no-op default).
+2. ✅ Implement forward in `NativeFaceController` → new `FaceState` fields/setter.
+3. ✅ Add a dev/test injector (**Face Display ▸ Mouth Tracker (Test)** sliders) so
    the render path is testable on the CM5 **with no Zero attached**.
 
-**Phase 1 — Render: blendshape stack**
-4. `blend_over_region` helper + stacked compositing in `FaceLoader::get_frame`.
-5. Extend canonical stem list + Files>Faces import for `blend_*` layers.
-6. Author a starter layer set for one face (openness + L/R smile + L/R frown +
-   pucker). Verify asymmetry on panels via the slider injector.
+**Phase 1 — Render: blendshape stack** ✅ done (art pending)
+4. ✅ `blend_over_region` helper + stacked compositing in `FaceLoader::get_frame`.
+5. ✅ Shared contract `mouth_blendshapes.h`; `blend_*` layers loaded + excluded
+   from the scanned expression list; optional per-side regions.
+6. ⏳ Author a starter layer set for one face (openness + L/R smile + L/R frown +
+   pucker) — **owner: user**. Verify asymmetry on panels via the slider injector.
 
 **Phase 2 — Link + receiver**
 7. `MouthTracker` module (`SerialPort` reader, parse, push to `face_proxy`).

--- a/src/app_state.h
+++ b/src/app_state.h
@@ -171,6 +171,17 @@ struct VoiceMouthConfig {
     float  viseme_small_max_hz = 2000.f;
 };
 
+// Manual driver for the optical mouth blendshape stack — exercises the render
+// path (FaceState::set_mouth_blendshapes → FaceLoader stack) with no Pi Zero
+// tracker attached. The future MouthTracker UART module replaces this as the
+// live source. weights are indexed by face::mouth_blendshapes(); sized lazily
+// when the menu is built.
+struct MouthTrackerTestConfig {
+    bool               enabled    = false;   // push weights at confidence below
+    float              confidence = 1.0f;    // [0,1]; 0 = renderer uses audio path
+    std::vector<float> weights;              // [0,1] per blendshape, contract order
+};
+
 // One boop-sensor zone's user-visible behaviour. The sensor reports zone
 // touches (no expression knowledge); main.cpp's on_boop callback reads this
 // to call IFaceController::trigger_boop with the per-zone expression. Indexed
@@ -785,6 +796,7 @@ struct AppState {
     float                boop_coalesce_window_s = 0.10f;
     LightSquintConfig    light_squint;
     VoiceMouthConfig     voice_mouth;
+    MouthTrackerTestConfig mouth_test;
     ClockConfig          clock_cfg;
     CameraResolutionState camera_resolution;
     ZoomCropState        zoom_left, zoom_right;

--- a/src/face/face_loader.cpp
+++ b/src/face/face_loader.cpp
@@ -43,7 +43,12 @@ void FaceLoader::load() {
         for (auto& p : pngs) {
             std::string stem = fs::path(p).stem().string();
             std::transform(stem.begin(), stem.end(), stem.begin(), ::tolower);
-            if (stem != "blink" && stem != "mouth_open") expr_map.emplace_back(stem, p);
+            // Skip non-expression sprites: blink, the audio mouth overlay, and
+            // optical blendshape layers (blend_*) — these are composited
+            // separately, not selectable as expressions.
+            if (stem == "blink" || stem == "mouth_open") continue;
+            if (stem.rfind("blend_", 0) == 0) continue;
+            expr_map.emplace_back(stem, p);
         }
     }
 
@@ -76,6 +81,18 @@ void FaceLoader::load() {
         }
     }
 
+    // Optical mouth blendshape layers — all optional. Each present <stem>.png
+    // becomes a weighted layer in the blendshape stack (see get_frame). Authored
+    // as additive deltas from neutral (only the moving region opaque) so several
+    // can be alpha-stacked at once.
+    for (const auto& def : mouth_blendshapes()) {
+        fs::path p = fs::path(folder_) / (std::string(def.stem) + ".png");
+        if (fs::exists(p)) {
+            cv::Mat img = load_png_rgba(p.string(), w_, h_);
+            if (!img.empty()) blend_layers_[def.stem] = std::move(img);
+        }
+    }
+
     // Region scaling: boxes may be authored at draw_size and scaled to panel px.
     double sx = 1.0, sy = 1.0;
     if (cfg.contains("draw_size") && cfg["draw_size"].is_array() &&
@@ -93,9 +110,45 @@ void FaceLoader::load() {
         r.set = true;
         return r;
     };
-    if (cfg.contains("eye_left"))  eye_left_  = parse_region(cfg["eye_left"]);
-    if (cfg.contains("eye_right")) eye_right_ = parse_region(cfg["eye_right"]);
-    if (cfg.contains("mouth"))     mouth_     = parse_region(cfg["mouth"]);
+    if (cfg.contains("eye_left"))   eye_left_   = parse_region(cfg["eye_left"]);
+    if (cfg.contains("eye_right"))  eye_right_  = parse_region(cfg["eye_right"]);
+    if (cfg.contains("mouth"))      mouth_      = parse_region(cfg["mouth"]);
+    // Optional per-side mouth regions for sharper asymmetry. Left/Right
+    // blendshape layers clip to these when present; otherwise they fall back
+    // to the single mouth region.
+    if (cfg.contains("mouth_left"))  mouth_left_  = parse_region(cfg["mouth_left"]);
+    if (cfg.contains("mouth_right")) mouth_right_ = parse_region(cfg["mouth_right"]);
+}
+
+const FaceLoader::Region& FaceLoader::region_for_side(MouthSide side) const {
+    if (side == MouthSide::Left  && mouth_left_.set)  return mouth_left_;
+    if (side == MouthSide::Right && mouth_right_.set) return mouth_right_;
+    return mouth_;
+}
+
+void FaceLoader::blend_over_region(cv::Mat& base, const cv::Mat& overlay,
+                                   const Region& region, double weight) const {
+    if (overlay.empty() || weight <= 0.0) return;
+    const double wc = std::clamp(weight, 0.0, 1.0);
+    int x  = region.set ? region.x : 0;
+    int y  = region.set ? region.y : 0;
+    int x2 = region.set ? std::min(region.x + region.w, w_) : w_;
+    int y2 = region.set ? std::min(region.y + region.h, h_) : h_;
+    x = std::max(0, x); y = std::max(0, y);
+    if (x2 <= x || y2 <= y) return;
+    for (int j = y; j < y2; ++j) {
+        cv::Vec4b*       brow = base.ptr<cv::Vec4b>(j);
+        const cv::Vec4b* orow = overlay.ptr<cv::Vec4b>(j);
+        for (int i = x; i < x2; ++i) {
+            const double a = (orow[i][3] / 255.0) * wc;
+            if (a <= 0.0) continue;
+            for (int c = 0; c < 3; ++c)
+                brow[i][c] = cv::saturate_cast<uchar>(brow[i][c] * (1.0 - a) +
+                                                      orow[i][c] * a);
+            brow[i][3] = std::max<uchar>(brow[i][3],
+                                         cv::saturate_cast<uchar>(orow[i][3] * wc));
+        }
+    }
 }
 
 cv::Mat FaceLoader::blend_region(const cv::Mat& base, const cv::Mat& overlay,
@@ -142,14 +195,32 @@ cv::Mat FaceLoader::get_frame(const FaceState& state) {
         }
     }
 
-    // 3. Mouth open.
-    double mo = std::clamp(state.mouth_open(), 0.0, 1.0);
-    if (mo > 0.0 && mouth_.set) {
-        auto it = mouth_shapes_.find(state.mouth_shape());
-        if (it == mouth_shapes_.end())
-            it = mouth_shapes_.find("mouth_open");   // fallback to AH
-        if (it != mouth_shapes_.end() && !it->second.empty())
-            frame = blend_region(frame, it->second, mouth_, mo);
+    // 3. Mouth. Optical blendshape stack takes precedence when the tracker is
+    // confident and the face provides blend_* layers; otherwise fall back to
+    // the legacy audio-driven single-overlay path (unchanged behaviour for
+    // faces without blendshape art).
+    const std::vector<float>& weights = state.mouth_weights();
+    const double conf = std::clamp(state.mouth_conf(), 0.0, 1.0);
+    const bool use_stack = conf > 0.0 && !blend_layers_.empty() && !weights.empty();
+    if (use_stack) {
+        const auto& defs = mouth_blendshapes();
+        const size_t n = std::min(defs.size(), weights.size());
+        for (size_t i = 0; i < n; ++i) {
+            auto it = blend_layers_.find(defs[i].stem);
+            if (it == blend_layers_.end() || it->second.empty()) continue;
+            const double wv = std::clamp(static_cast<double>(weights[i]), 0.0, 1.0) * conf;
+            if (wv <= 0.0) continue;
+            blend_over_region(frame, it->second, region_for_side(defs[i].side), wv);
+        }
+    } else {
+        double mo = std::clamp(state.mouth_open(), 0.0, 1.0);
+        if (mo > 0.0 && mouth_.set) {
+            auto it = mouth_shapes_.find(state.mouth_shape());
+            if (it == mouth_shapes_.end())
+                it = mouth_shapes_.find("mouth_open");   // fallback to AH
+            if (it != mouth_shapes_.end() && !it->second.empty())
+                frame = blend_region(frame, it->second, mouth_, mo);
+        }
     }
 
     // 4. Wiggle + gyro sub-pixel shift (edge-clamped, no wrap).

--- a/src/face/face_loader.h
+++ b/src/face/face_loader.h
@@ -10,6 +10,8 @@
 #include <vector>
 #include <opencv2/core.hpp>
 
+#include "mouth_blendshapes.h"
+
 namespace face {
 
 class FaceState;   // fwd
@@ -38,6 +40,15 @@ private:
     void load();
     cv::Mat blend_region(const cv::Mat& base, const cv::Mat& overlay,
                          const Region& region, double t) const;
+    // Alpha-over composite of overlay onto base, in place, clipped to region,
+    // with effective alpha = overlay_alpha * weight. Unlike blend_region's
+    // cross-fade this never washes out the base where the overlay is
+    // transparent, so several layers can be stacked (blendshape mouth).
+    void blend_over_region(cv::Mat& base, const cv::Mat& overlay,
+                           const Region& region, double weight) const;
+    // Region that clips a blendshape layer for the given side (Left/Right
+    // prefer mouth_left_/mouth_right_ when set, else fall back to mouth_).
+    const Region& region_for_side(MouthSide side) const;
 
     std::string folder_;
     int w_, h_;
@@ -48,7 +59,11 @@ private:
     // Viseme overlays keyed by stem (mouth_open / mouth_small / mouth_smile /
     // mouth_round). All optional — missing entries fall back to mouth_open.
     std::map<std::string, cv::Mat> mouth_shapes_;
+    // Optical blendshape layers keyed by face::MouthBlendshapeDef::stem. All
+    // optional — a missing layer contributes nothing to the stack.
+    std::map<std::string, cv::Mat> blend_layers_;
     Region   eye_left_, eye_right_, mouth_;
+    Region   mouth_left_, mouth_right_;   // optional per-side clip regions
 };
 
 } // namespace face

--- a/src/face/face_state.h
+++ b/src/face/face_state.h
@@ -38,6 +38,14 @@ public:
     // Selects which viseme overlay the FaceLoader blends at the mouth region
     // when mouth_open > 0. Default "mouth_open" matches the pre-viseme path.
     void set_mouth_shape(const std::string& s)       { if (!s.empty()) mouth_shape_ = s; }
+    // Optical mouth-tracker drive: blendshape weights indexed by
+    // face::mouth_blendshapes() plus a tracking confidence. When confidence
+    // > 0 and the face has blend_* layers, FaceLoader composites the weighted
+    // stack instead of the single audio-driven overlay (see get_frame).
+    void set_mouth_blendshapes(const std::vector<float>& w, double conf) {
+        mouth_weights_ = w;
+        mouth_conf_    = conf < 0.0 ? 0.0 : (conf > 1.0 ? 1.0 : conf);
+    }
 
     // ── Animation tuning (live; no rebuild required) ─────────────────────────
     // Setting blink_enabled = false freezes the blink state-machine open
@@ -64,6 +72,8 @@ public:
     double blink_weight() const { return blink_weight_; }
     double mouth_open()   const { return mouth_open_; }
     const std::string& mouth_shape() const { return mouth_shape_; }
+    const std::vector<float>& mouth_weights() const { return mouth_weights_; }
+    double mouth_conf()   const { return mouth_conf_; }
     double gyro_dx()      const { return gyro_dx_; }
     double gyro_dy()      const { return gyro_dy_; }
     double time()         const { return time_; }
@@ -104,6 +114,8 @@ private:
     double audio_volume_ = 0.0;
     double mouth_open_   = 0.0;
     std::string mouth_shape_ = "mouth_open";   // viseme overlay name
+    std::vector<float> mouth_weights_;          // optical blendshape coeffs
+    double      mouth_conf_  = 0.0;             // optical tracking confidence
     double gyro_dx_      = 0.0;
     double gyro_dy_      = 0.0;
 

--- a/src/face/mouth_blendshapes.h
+++ b/src/face/mouth_blendshapes.h
@@ -1,0 +1,55 @@
+#pragma once
+// ── mouth_blendshapes.h ────────────────────────────────────────────────────────
+// Single source of truth for the mouth blendshape contract shared by:
+//   • the coprocessor wire protocol (Pi Zero 2 W → CM5),
+//   • the FaceLoader blendshape-stack compositor,
+//   • the menu test injector,
+//   • (future) the MouthTracker UART receiver.
+//
+// The index order is STABLE and APPEND-ONLY — both ends of the link address
+// coefficients positionally, never by name. Each entry maps a MediaPipe
+// FaceLandmarker blendshape coefficient to the PNG layer stem the FaceLoader
+// looks for in a face folder (<stem>.png), and to which mouth sub-region clips
+// the layer when the face provides per-side regions.
+//
+// See docs/mouth-tracking-blendshape-design.md.
+
+#include <cstddef>
+#include <vector>
+
+namespace face {
+
+// Which mouth region a layer is clipped to. Center uses the single "mouth"
+// region; Left/Right prefer "mouth_left"/"mouth_right" when the face folder
+// defines them, falling back to "mouth" otherwise.
+enum class MouthSide { Center, Left, Right };
+
+struct MouthBlendshapeDef {
+    const char* coeff;   // MediaPipe coefficient name (contract label)
+    const char* stem;    // PNG layer file stem: faces/<face>/<stem>.png
+    MouthSide   side;    // region that clips this layer
+};
+
+// Fixed, index-stable ordering. Append new entries only at the end so existing
+// coprocessor builds stay wire-compatible.
+inline const std::vector<MouthBlendshapeDef>& mouth_blendshapes() {
+    static const std::vector<MouthBlendshapeDef> defs = {
+        { "jawOpen",           "blend_jawOpen",           MouthSide::Center },
+        { "mouthSmileLeft",    "blend_mouthSmileLeft",    MouthSide::Left   },
+        { "mouthSmileRight",   "blend_mouthSmileRight",   MouthSide::Right  },
+        { "mouthFrownLeft",    "blend_mouthFrownLeft",    MouthSide::Left   },
+        { "mouthFrownRight",   "blend_mouthFrownRight",   MouthSide::Right  },
+        { "mouthPucker",       "blend_mouthPucker",       MouthSide::Center },
+        { "mouthFunnel",       "blend_mouthFunnel",       MouthSide::Center },
+        { "mouthLeft",         "blend_mouthLeft",         MouthSide::Center },
+        { "mouthRight",        "blend_mouthRight",        MouthSide::Center },
+        { "mouthUpperUpLeft",  "blend_mouthUpperUpLeft",  MouthSide::Left   },
+        { "mouthUpperUpRight", "blend_mouthUpperUpRight", MouthSide::Right  },
+        { "mouthClose",        "blend_mouthClose",        MouthSide::Center },
+    };
+    return defs;
+}
+
+inline std::size_t mouth_blendshape_count() { return mouth_blendshapes().size(); }
+
+} // namespace face

--- a/src/face/native_face_controller.cpp
+++ b/src/face/native_face_controller.cpp
@@ -668,6 +668,14 @@ void NativeFaceController::set_mouth_shape(const std::string& shape) {
         if (pn.state) pn.state->set_mouth_shape(shape);
 }
 
+void NativeFaceController::set_mouth_blendshapes(const std::vector<float>& weights,
+                                                 float confidence) {
+    std::lock_guard<std::mutex> lk(state_mtx_);
+    for (auto& pn : panels_)
+        if (pn.state) pn.state->set_mouth_blendshapes(weights, confidence);
+    // Transient — no persistence on every tracker frame.
+}
+
 std::vector<cv::Rect> NativeFaceController::led_covered_regions() const {
     std::lock_guard<std::mutex> lk(state_mtx_);
     if (!output_) return {};

--- a/src/face/native_face_controller.h
+++ b/src/face/native_face_controller.h
@@ -77,6 +77,8 @@ public:
     void        trigger_boop(const std::string& expression, double duration_s) override;
     void        set_audio_drive(double volume, double mouth_open) override;
     void        set_mouth_shape(const std::string& shape) override;
+    void        set_mouth_blendshapes(const std::vector<float>& weights,
+                                      float confidence) override;
 
     // Face editor support: what the active PanelOutput addresses (so the
     // editor can pick the editable region), and a way to force a face

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -64,6 +64,7 @@
 #include "profile_manager.h"
 #include "face/face_config.h"
 #include "face/face_image.h"
+#include "face/mouth_blendshapes.h"
 #include "face/gif_player.h"
 #include "face/native_face_controller.h"
 #include "face/panel_output.h"
@@ -5107,6 +5108,63 @@ static std::vector<MenuItem> build_menu(
                   "Mic-driven mouth_open. FFT-based: speech-band RMS feeds an "
                   "envelope follower whose output drives face::set_audio() each "
                   "audio period (~5 ms)."));
+
+    // ── Mouth Tracker (Test) ─────────────────────────────────────────────────
+    // Manual driver for the optical mouth blendshape stack — proves the render
+    // path (set_mouth_blendshapes → FaceLoader stack) with no Pi Zero attached.
+    // The future MouthTracker UART module replaces these sliders as the live
+    // source. teensy is the active FaceProxy; only the native backend honours
+    // the blendshape stack (others no-op).
+    {
+        const size_t nbs = face::mouth_blendshape_count();
+        if (state.mouth_test.weights.size() != nbs)
+            state.mouth_test.weights.assign(nbs, 0.f);
+
+        // Push the current test vector to the face. When disabled, confidence 0
+        // makes the renderer fall back to the audio-driven mouth path.
+        auto push_mouth_test = [teensy, &state]() {
+            if (!teensy) return;
+            const float conf = state.mouth_test.enabled ? state.mouth_test.confidence : 0.f;
+            teensy->set_mouth_blendshapes(state.mouth_test.weights, conf);
+        };
+
+        std::vector<MenuItem> mt_menu = {
+            with_desc(toggle("Enabled",
+                [&state]{ return state.mouth_test.enabled; },
+                [&state, push_mouth_test](bool v){
+                    state.mouth_test.enabled = v;
+                    push_mouth_test();
+                }),
+                "Drive the mouth from these sliders instead of the mic. Turn "
+                "off to release the mouth back to the Voice (audio) path."),
+            with_desc(slider("Confidence", 0.f, 1.f, 0.05f, "",
+                [&state]{ return state.mouth_test.confidence; },
+                [&state, push_mouth_test](float v){
+                    state.mouth_test.confidence = v;
+                    push_mouth_test();
+                }),
+                "Global tracking confidence. Scales every layer; mirrors what "
+                "the real tracker sends per frame."),
+        };
+        const auto& defs = face::mouth_blendshapes();
+        for (size_t i = 0; i < defs.size(); ++i) {
+            mt_menu.push_back(slider(defs[i].coeff, 0.f, 1.f, 0.05f, "",
+                [&state, i]{
+                    return i < state.mouth_test.weights.size()
+                               ? state.mouth_test.weights[i] : 0.f;
+                },
+                [&state, i, push_mouth_test](float v){
+                    if (i < state.mouth_test.weights.size())
+                        state.mouth_test.weights[i] = v;
+                    push_mouth_test();
+                }));
+        }
+        face_display_menu.push_back(
+            with_desc(submenu("Mouth Tracker (Test)", std::move(mt_menu)),
+                      "Manual blendshape sliders to exercise the asymmetric "
+                      "mouth stack with no Pi Zero tracker. Needs blend_*.png "
+                      "layers in the active face folder to show."));
+    }
 
     // ── Accessory LEDs (cheekhubs + fins) ────────────────────────────────────
     // Per-zone pattern / color / breathe rate live in the AccessoryLeds

--- a/src/serial/face_controller.h
+++ b/src/serial/face_controller.h
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <string>
+#include <vector>
 
 /**
  * Abstract interface for face display backends.
@@ -86,6 +87,16 @@ public:
     // are enabled.
     virtual void        set_mouth_shape(const std::string& /*shape*/) {}
 
+    // Optical mouth tracker drive. weights are blendshape coefficients in
+    // [0, 1] indexed by face::mouth_blendshapes() (the shared contract), and
+    // confidence ∈ [0, 1] is the tracker's per-frame tracking confidence.
+    // Native Protoface forwards to each panel's FaceState, where FaceLoader
+    // composites a weighted blendshape stack at the mouth region (enabling
+    // asymmetric shapes). When confidence is low the renderer falls back to
+    // the audio-driven mouth_open path. No-op on non-native backends.
+    virtual void        set_mouth_blendshapes(const std::vector<float>& /*weights*/,
+                                              float /*confidence*/) {}
+
     // True when the backend has addressable LED regions the face editor
     // can target (today: NativeFaceController with MAX7219 or RGB matrix
     // output). False for HUB75 + daemon + Teensy. Drives the visibility
@@ -152,6 +163,9 @@ public:
     void trigger_boop(const std::string& e, double d) override { (*active_)->trigger_boop(e, d); }
     void set_audio_drive(double v, double m) override { (*active_)->set_audio_drive(v, m); }
     void set_mouth_shape(const std::string& s) override { (*active_)->set_mouth_shape(s); }
+    void set_mouth_blendshapes(const std::vector<float>& w, float conf) override {
+        (*active_)->set_mouth_blendshapes(w, conf);
+    }
     bool has_led_face_editor() const override { return (*active_)->has_led_face_editor(); }
     void set_active_layout_name(const std::string& n) override {
         (*active_)->set_active_layout_name(n);


### PR DESCRIPTION
## Summary

Design doc (no code yet) for driving the LED face's **mouth from the wearer's real mouth**, with enough fidelity for **asymmetrical** shapes, while keeping the CM5 free of per-frame vision work.

Locked decisions captured in the doc:
- **Satellite Pi Zero 2 W** at the front of the head running **MediaPipe FaceLandmarker**, emitting ARKit-style mouth/jaw **blendshape coefficients**.
- **UART** (or USB-serial gadget) link to the CM5 carrying a tiny framed weight vector.
- **Blendshape stack** render model on the CM5 — replaces today's single-overlay symmetric mouth so asymmetric shapes (smirk, one-sided "O") become representable.
- **Audio `VoiceAnalyzer` as low-confidence fallback** (graceful degradation if the camera drops out).

## What's in the doc

- End-to-end architecture diagram and data flow, grounded in the existing seam (`IFaceController` / `FaceProxy` → `NativeFaceController` → `FaceState` / `FaceLoader` → `/dev/shm/protoface_frame` → `panel_driver.py` → Piomatter).
- Why the current mouth model can't do asymmetry (one region, one overlay, one scalar) and the exact `FaceLoader::get_frame` compositing change (alpha-over weighted stack vs the current `addWeighted` cross-fade).
- New `set_mouth_blendshapes()` seam, a `MouthTracker` UART receiver module, wire protocol, arbitration policy, calibration, config + menu additions.
- Latency budget, failure modes, a **phased plan** (Phases 0–1 need no new hardware), testing strategy, and a file-by-file change list.

## Open questions (see §17)

1. Power for the Zero down the cable vs USB-gadget power+data.
2. Per-side mouth regions now or later.
3. u8 quantization sufficiency.
4. Who authors the `blend_*` layer art / ship a reference set?
5. IR LED placement safety + lens fogging.

Draft for review of the approach before implementation begins.

https://claude.ai/code/session_01JVszu781HPZK9KJ6smkpvb

---
_Generated by [Claude Code](https://claude.ai/code/session_01JVszu781HPZK9KJ6smkpvb)_