### PR TITLE
Optional button/switch coprocessor input source (opt-in)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,6 +190,7 @@ set(SOURCES
     src/camera/viture_camera.cpp
     src/input/gpio_buttons.cpp
     src/input/gpio_inputs.cpp
+    src/input/coproc_inputs.cpp
     src/input/gamepad_input.cpp
     src/input/wireless_controller.cpp
     src/serial/serial_port.cpp

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -151,6 +151,29 @@
       { "gpio": 22, "active_low": true, "pull": "up", "short": "cam_pip_left", "long": "system_restart", "long_ms": 1200 }
     ]
   },
+  "inputs": {
+    "coprocessor": {
+      "_about": "OPTIONAL button/switch coprocessor (RP2350/RP2040). When enabled, an external MCU debounces the switches and streams presses to the Pi, dispatched through the same functions as the GPIO map above. Never required — leave disabled to use on-board GPIO only. Toggle live in System > GPIO Buttons > Button Coprocessor. See docs/coprocessor-input.md.",
+      "enabled": false,
+      "transport": "usb_serial",
+      "_transport_note": "'usb_serial' (USB CDC, default) or 'i2c' (specified but not implemented in v1).",
+      "device": "/dev/serial/by-id/usb-ProtoHUD_Buttons-if00",
+      "_device_note": "Use a stable /dev/serial/by-id/... path matched on the coprocessor's USB serial string — NOT /dev/ttyACMn, which races with the Teensy/SmartKnob/RAK4631.",
+      "baud": 115200,
+      "i2c_bus": "/dev/i2c-1",
+      "i2c_addr": 66,
+      "irq_gpio": -1,
+      "replace_local_gpio": false,
+      "_replace_note": "false = additive (GPIO slots + coproc both fire). true = coproc is the only button source (local GPIO poller is not started).",
+      "heartbeat_timeout_ms": 2000,
+      "buttons": [
+        { "id": 0, "short": "menu_select", "long": "menu_back" },
+        { "id": 1, "short": "menu_open",   "long": "system_restart" },
+        { "id": 2, "short": "boop_snout",  "long": "none" }
+      ],
+      "_buttons_note": "Maps the coprocessor's button ids to functions (same function ids as gpio.pins). The MCU reports 'button N, short/long'; the Pi decides what N means, so remapping stays here."
+    }
+  },
   "camera": {
     "autofocus_on_startup": true,
     "autofocus_sync": true,

--- a/docs/coprocessor-input.md
+++ b/docs/coprocessor-input.md
@@ -1,0 +1,159 @@
+# Optional button/switch coprocessor — framework
+
+A toggle that, when enabled, assumes a small MCU (**RP2350**, or an earlier
+**RP2040/Pico**) sits between the physical switches and the Pi: it debounces the
+buttons and streams press events over USB (or I²C), and the Pi dispatches them
+through the **same input path** as on-board GPIO. When the toggle is **off**,
+nothing changes — the existing `input::GpioInputs` GPIO poller runs as today.
+The coprocessor is **never required**.
+
+Why bother (ties into [`../hardware/carrier-board/MULTI-BACKEND.md`](../hardware/carrier-board/MULTI-BACKEND.md)):
+- HUB75 eats most GPIO; only `{7,8,9,10,11,14,15,18,19,25}` stay free, and SPI
+  contends for them. A coproc frees those pins for buses, not buttons.
+- Precise debounce/long-press timing happens on the MCU, not a Linux poll loop.
+- More switches than free GPIO; hot-pluggable; long switch harnesses terminate
+  at the MCU (less EMI into the Pi).
+
+## The one integration seam
+
+The whole design hangs off a single fact: `GpioInputs` doesn't *do* anything
+with a press — it calls a `std::function<void(GpioFunc)> dispatch` callback
+(`src/input/gpio_inputs.h`). In `main.cpp` that callback is `gpio_dispatch`
+(~line 11860), wired into the menu, boop, and camera actions. **A coprocessor
+source just calls the same `dispatch`** — downstream code never knows the press
+came from a different place.
+
+```mermaid
+flowchart LR
+    subgraph SRC["Button sources (additive)"]
+        GPIO["input::GpioInputs<br/>(local GPIO poll)"]
+        COP["input::CoprocInputs<br/>(USB/I²C from MCU)"]
+    end
+    GPIO -- "dispatch(GpioFunc)" --> D{{"gpio_dispatch<br/>(main.cpp)"}}
+    COP  -- "dispatch(GpioFunc)" --> D
+    D --> MENU["Menu open/select/back"]
+    D --> BOOP["Boop snout/cheeks"]
+    D --> CAM["Camera AF / PiP / capture"]
+    D --> SYS["System restart / shutdown"]
+
+    classDef s fill:#d6f5d6,stroke:#2a9d3a,color:#000;
+    classDef d fill:#fff3b0,stroke:#b59000,color:#000;
+    class GPIO,COP s; class D d;
+```
+
+`input::CoprocInputs` (skeleton in [`../src/input/coproc_inputs.h`](../src/input/coproc_inputs.h))
+mirrors `GpioInputs`' lifecycle (`init()` / `shutdown()` / a status getter), so
+`main.cpp` constructs and owns it the same way.
+
+## Division of labor: dumb-meaning, smart-timing
+
+Recommended split (keeps remapping in the HUD, offloads timing to the MCU):
+
+| Job | Where |
+|-----|-------|
+| Debounce, edge detection, short vs long classification | **Coprocessor** (good at precise timing) |
+| Button **id → GpioFunc** mapping (remappable in menu) | **Pi** (`CoprocConfig::short_map`/`long_map`, reusing `gpio_func_from_id`) |
+| Acting on the function (menu/boop/camera) | **Pi** (existing `gpio_dispatch`) |
+
+So the firmware reports *"button 3, long"* — not *"open menu"*. The Pi decides
+what button 3 means, exactly like the GPIO map does today. Unmapped ids resolve
+to `GpioFunc::None` (no-op).
+
+## Wire protocol (v1, USB CDC — newline-delimited ASCII)
+
+Deliberately trivial so it's debuggable with a serial terminal and easy to
+implement on the MCU.
+
+**Coprocessor → Pi**
+```
+HELLO proto-buttons v1 n=8        # on connect: name, version, #buttons
+BTN <id> DOWN                     # optional raw edges (ignored unless needed)
+BTN <id> UP
+BTN <id> SHORT                    # debounced, held < long_ms
+BTN <id> LONG                     # debounced, held >= long_ms (fires once)
+PING                              # heartbeat, ~1 Hz
+```
+
+**Pi → Coprocessor** (optional, v1 can ignore)
+```
+PONG                              # ack heartbeat
+CFG long_ms=600                   # push the long-press threshold
+LED <id> <0|1>                    # drive a switch backlight, if wired
+```
+
+Parsing rules: one message per line; **ignore any malformed/unknown line**
+(forward-compatible); a press is only the `SHORT`/`LONG` events (DOWN/UP are
+advisory). If no line arrives within `heartbeat_timeout_ms`, mark **offline**.
+
+> Treat bytes from the link as **untrusted external input**: bound line length,
+> validate `id` against `n`, never `eval`/format-inject. A flaky cable should
+> degrade to "offline", never crash the reader thread.
+
+## Transports
+
+| | USB CDC (default) | I²C + IRQ |
+|---|---|---|
+| Wiring | one USB cable | SDA/SCL (shared bus 1) + 1 IRQ GPIO |
+| Pros | hot-plug, trivial protocol, no Pi pins | no USB port used; clean on carrier |
+| Cons | uses a USB port; `/dev/ttyACMn` races | Pi-master polling unless IRQ wired |
+| Stable id | `/dev/serial/by-id/...` (match USB serial) | fixed 7-bit addr (e.g. 0x42) |
+
+USB note: Teensy/SmartKnob/RAK4631 already enumerate as ACM0/1/2 — **match the
+coproc by `by-id` path / USB serial string**, never a bare `ttyACMn` index.
+I²C note: the coproc shares bus 1 with the IMUs/boop/light sensors; pick a free
+address and (ideally) a data-ready IRQ on a spare GPIO so the Pi isn't polling.
+
+## Proposed config (`inputs.coprocessor`)
+
+```jsonc
+"inputs": {
+  "coprocessor": {
+    "enabled": false,                 // master toggle — off = local GPIO only
+    "transport": "usb_serial",        // "usb_serial" | "i2c"
+    "device": "/dev/serial/by-id/usb-ProtoHUD_Buttons-if00",
+    "baud": 115200,
+    "i2c_addr": 66,                   // 0x42 (transport=="i2c")
+    "irq_gpio": -1,
+    "replace_local_gpio": false,      // false = additive; true = coproc only
+    "heartbeat_timeout_ms": 2000,
+    "buttons": [                      // id → function (reuses GpioFunc ids)
+      { "id": 0, "short": "menu_select", "long": "menu_back" },
+      { "id": 1, "short": "menu_open",   "long": "system_restart" },
+      { "id": 2, "short": "boop_snout",  "long": "none" }
+    ]
+  }
+}
+```
+
+A live **System → Button Coprocessor** toggle + status ("connected / offline,
+N buttons") fits the existing GPIO Buttons menu, mirroring how other devices
+surface `connected()`.
+
+## Fallback behavior (never required)
+
+- `enabled: false` → exactly today's behavior; `CoprocInputs` not constructed.
+- `enabled: true`, **additive** (`replace_local_gpio: false`) → both sources
+  feed `dispatch`; mix a few on-board buttons with the coproc.
+- `enabled: true`, **replace** → only the coproc drives buttons; if it never
+  connects or drops, log it and (optionally) re-enable the local GPIO poller so
+  the user is never locked out of the menu.
+
+## Implementation checklist
+
+1. **Firmware** (`coproc_inputs.cpp`, add to `CMakeLists.txt` SOURCES): open the
+   transport, reader thread with reconnect, line parser → `handle_button(id,
+   is_long)` → map via `short_map`/`long_map` → `dispatch_(func)`; heartbeat
+   tracking sets `connected_`.
+2. **Config**: parse `inputs.coprocessor` into `CoprocConfig` (button list →
+   `short_map`/`long_map` via `gpio_func_from_id`).
+3. **main.cpp**: after `gpio_dispatch` is built, if enabled construct
+   `CoprocInputs(cfg, gpio_dispatch)`; gate the local `GpioInputs` on
+   `!replace_local_gpio`.
+4. **Menu/status**: add the toggle + `connected()` readout.
+5. **MCU sketch** (RP2350/RP2040): debounce each input, classify short/long,
+   emit `BTN <id> SHORT|LONG`, send `HELLO` on boot + `PING` ~1 Hz. Either a
+   dedicated Pico, or a **second USB interface (composite UAC2 + CDC)** on the
+   RP2350 helmet-audio board if you don't want a separate MCU.
+
+> Ask and I can implement steps 1–4 against this skeleton and add a reference
+> MCU sketch under `firmware/`.

--- a/docs/coprocessor-input.md
+++ b/docs/coprocessor-input.md
@@ -138,22 +138,21 @@ surface `connected()`.
   connects or drops, log it and (optionally) re-enable the local GPIO poller so
   the user is never locked out of the menu.
 
-## Implementation checklist
+## Implementation status — landed
 
-1. **Firmware** (`coproc_inputs.cpp`, add to `CMakeLists.txt` SOURCES): open the
-   transport, reader thread with reconnect, line parser → `handle_button(id,
-   is_long)` → map via `short_map`/`long_map` → `dispatch_(func)`; heartbeat
-   tracking sets `connected_`.
-2. **Config**: parse `inputs.coprocessor` into `CoprocConfig` (button list →
-   `short_map`/`long_map` via `gpio_func_from_id`).
-3. **main.cpp**: after `gpio_dispatch` is built, if enabled construct
-   `CoprocInputs(cfg, gpio_dispatch)`; gate the local `GpioInputs` on
-   `!replace_local_gpio`.
-4. **Menu/status**: add the toggle + `connected()` readout.
-5. **MCU sketch** (RP2350/RP2040): debounce each input, classify short/long,
-   emit `BTN <id> SHORT|LONG`, send `HELLO` on boot + `PING` ~1 Hz. Either a
-   dedicated Pico, or a **second USB interface (composite UAC2 + CDC)** on the
-   RP2350 helmet-audio board if you don't want a separate MCU.
+1. ✅ **Reader** — `src/input/coproc_inputs.cpp` (in `CMakeLists.txt` SOURCES):
+   USB-CDC open + termios raw config, reader thread with reconnect/backoff,
+   length-bounded line parser → `handle_button(id, is_long)` → `short_map`/
+   `long_map` → `dispatch_(func)`; heartbeat tracking drives `connected()`.
+   (I²C transport is parsed but returns a clean "not implemented in v1".)
+2. ✅ **Config** — `main.cpp` parses `inputs.coprocessor` into `CoprocConfig`
+   (button list → `short_map`/`long_map` via `gpio_func_from_id`).
+3. ✅ **Wiring** — `main.cpp` constructs `CoprocInputs(cfg, gpio_dispatch)` when
+   enabled, sharing the dispatch with the GPIO poller; the local `GpioInputs`
+   is gated on `!(coproc enabled && replace_local_gpio)`.
+4. ✅ **Menu** — **System → GPIO Buttons → Button Coprocessor**: live Enabled
+   toggle (applies via reload) + a Status readout (disabled/offline/connected).
+5. ✅ **MCU sketch** — reference Arduino sketch + protocol at
+   [`../firmware/button_coproc/README.md`](../firmware/button_coproc/README.md).
 
-> Ask and I can implement steps 1–4 against this skeleton and add a reference
-> MCU sketch under `firmware/`.
+Example config lives in `config/config.example.json` under `inputs.coprocessor`.

--- a/firmware/button_coproc/README.md
+++ b/firmware/button_coproc/README.md
@@ -1,0 +1,91 @@
+# button_coproc — optional button/switch coprocessor
+
+Reference firmware for the **optional** button coprocessor described in
+[`docs/coprocessor-input.md`](../../docs/coprocessor-input.md). A small MCU
+(**RP2350** or an earlier **RP2040/Pico**) debounces the physical switches,
+classifies short vs long press, and streams events to the Pi over **USB CDC**.
+ProtoHUD dispatches them through the same `input::GpioFunc` path as on-board
+GPIO — so the coprocessor is never required and can be toggled off in
+**System → GPIO Buttons → Button Coprocessor**.
+
+## Protocol (v1, newline-delimited ASCII)
+
+MCU → Pi:
+```
+HELLO proto-buttons v1 n=<count>   # once on boot
+BTN <id> SHORT                     # debounced, held < long_ms
+BTN <id> LONG                      # debounced, held >= long_ms (fires once)
+PING                               # heartbeat ~1 Hz
+```
+Pi → MCU (optional): `PONG` (heartbeat ack). The Pi maps `<id>` → function via
+`inputs.coprocessor.buttons`, so the firmware stays "dumb about meaning".
+
+## USB identity
+
+Set the USB **serial string** (and ideally product = `ProtoHUD_Buttons`) so the
+Pi can bind a stable `/dev/serial/by-id/usb-ProtoHUD_Buttons-if00` path instead
+of a racing `/dev/ttyACMn`. In Arduino-Pico: `Serial` is USB CDC by default; set
+the board's USB product/serial in the IDE or via `TinyUSB`.
+
+## Reference sketch (Arduino — RP2040/RP2350 "arduino-pico" core)
+
+```cpp
+// button_coproc.ino — debounce N switches, stream SHORT/LONG over USB CDC.
+#include <Arduino.h>
+
+constexpr uint8_t  PINS[]    = {2, 3, 4};        // GPIOs wired to switches (to GND)
+constexpr size_t   N         = sizeof(PINS);
+constexpr uint32_t DEBOUNCE  = 15;               // ms
+constexpr uint32_t LONG_MS   = 600;              // short/long threshold
+constexpr uint32_t HEARTBEAT = 1000;             // ms between PINGs
+
+bool     stable[N], lastRaw[N], longSent[N];
+uint32_t tEdge[N], tDown[N], tPing;
+
+void setup() {
+  Serial.begin(115200);                          // USB CDC
+  for (size_t i = 0; i < N; ++i) {
+    pinMode(PINS[i], INPUT_PULLUP);              // pressed = LOW
+    stable[i] = lastRaw[i] = true;               // released (HIGH)
+    longSent[i] = false;
+  }
+  uint32_t t0 = millis();
+  while (!Serial && millis() - t0 < 2000) {}     // wait briefly for host
+  Serial.print("HELLO proto-buttons v1 n="); Serial.println(N);
+  tPing = millis();
+}
+
+void loop() {
+  const uint32_t now = millis();
+  for (size_t i = 0; i < N; ++i) {
+    const bool raw = digitalRead(PINS[i]);       // HIGH=released, LOW=pressed
+    if (raw != lastRaw[i]) { lastRaw[i] = raw; tEdge[i] = now; }   // bounce timer
+    if (now - tEdge[i] >= DEBOUNCE && raw != stable[i]) {
+      stable[i] = raw;
+      if (!raw) {                                // pressed (falling edge)
+        tDown[i] = now; longSent[i] = false;
+      } else {                                   // released (rising edge)
+        if (!longSent[i]) { Serial.print("BTN "); Serial.print(i); Serial.println(" SHORT"); }
+      }
+    }
+    if (!stable[i] && !longSent[i] && now - tDown[i] >= LONG_MS) {
+      longSent[i] = true;                        // fire LONG once while held
+      Serial.print("BTN "); Serial.print(i); Serial.println(" LONG");
+    }
+  }
+  if (now - tPing >= HEARTBEAT) { tPing = now; Serial.println("PING"); }
+
+  while (Serial.available()) Serial.read();      // drain PONG/etc.
+}
+```
+
+## Wiring notes
+
+- Switches to MCU GPIO with `INPUT_PULLUP`, other side to GND (`active_low`).
+- USB-C from the MCU to the Pi/CM5 (consider the carrier's onboard USB hub —
+  `hardware/carrier-board/`).
+- This offloads the scarce GPIO that HUB75 leaves free on the Pi; see
+  [`hardware/carrier-board/MULTI-BACKEND.md`](../../hardware/carrier-board/MULTI-BACKEND.md).
+- If you'd rather not add a board, the same `BTN`/`PING` CDC interface can be a
+  **second USB interface** on the RP2350 helmet-audio processor (composite
+  UAC2 + CDC).

--- a/src/input/coproc_inputs.cpp
+++ b/src/input/coproc_inputs.cpp
@@ -1,0 +1,182 @@
+#include "coproc_inputs.h"
+
+#include <fcntl.h>
+#include <poll.h>
+#include <termios.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <chrono>
+#include <cstring>
+#include <iostream>
+
+// Line-based USB-CDC reader for an optional button coprocessor. Protocol v1
+// (newline-delimited ASCII, see docs/coprocessor-input.md):
+//   coproc → Pi : "HELLO ...", "BTN <id> SHORT|LONG", "PING", (DOWN/UP advisory)
+// The reader thread owns the transport, reconnects on drop, and treats every
+// inbound byte as untrusted: lines are length-bounded and unknown/malformed
+// lines are ignored. Resolved presses go through the shared GpioFunc dispatch.
+
+namespace input {
+
+namespace {
+// Map an integer baud to the matching termios speed constant. Falls back to
+// 115200 (the documented default) for anything unrecognised.
+speed_t baud_constant(int baud) {
+    switch (baud) {
+        case 9600:    return B9600;
+        case 19200:   return B19200;
+        case 38400:   return B38400;
+        case 57600:   return B57600;
+        case 115200:  return B115200;
+        case 230400:  return B230400;
+        case 460800:  return B460800;
+        case 921600:  return B921600;
+        default:      return B115200;
+    }
+}
+constexpr size_t kMaxLine = 256;   // drop pathologically long lines (noise/garbage)
+}  // namespace
+
+CoprocInputs::CoprocInputs(CoprocConfig cfg, std::function<void(GpioFunc)> dispatch)
+    : cfg_(std::move(cfg)), dispatch_(std::move(dispatch)) {}
+
+CoprocInputs::~CoprocInputs() { shutdown(); }
+
+bool CoprocInputs::init() {
+    if (!cfg_.enabled) return false;
+    if (cfg_.transport == "i2c") {
+        // I²C + data-ready IRQ transport is specified in docs/coprocessor-input.md
+        // but not implemented in v1. Report cleanly so the menu shows "offline"
+        // rather than silently doing nothing.
+        std::cerr << "[coproc] i2c transport not implemented in v1; use usb_serial\n";
+        return false;
+    }
+    running_.store(true);
+    thread_ = std::thread(&CoprocInputs::reader_loop, this);
+    std::cout << "[coproc] button coprocessor source started (" << cfg_.device << ")\n";
+    return true;
+}
+
+void CoprocInputs::shutdown() {
+    running_.store(false);
+    if (thread_.joinable()) thread_.join();
+    if (fd_ >= 0) { ::close(fd_); fd_ = -1; }
+    connected_.store(false);
+}
+
+void CoprocInputs::reader_loop() {
+    using clock = std::chrono::steady_clock;
+    std::string buf;
+    auto last_rx = clock::now();
+
+    while (running_.load()) {
+        // (Re)open the serial device if needed.
+        if (fd_ < 0) {
+            fd_ = ::open(cfg_.device.c_str(), O_RDWR | O_NOCTTY | O_NONBLOCK);
+            if (fd_ < 0) {
+                connected_.store(false);
+                std::this_thread::sleep_for(std::chrono::milliseconds(500));  // retry backoff
+                continue;
+            }
+            termios tio{};
+            if (tcgetattr(fd_, &tio) == 0) {
+                cfmakeraw(&tio);
+                const speed_t spd = baud_constant(cfg_.baud);
+                cfsetispeed(&tio, spd);
+                cfsetospeed(&tio, spd);
+                tio.c_cflag |= (CLOCAL | CREAD);
+                tio.c_cc[VMIN]  = 0;
+                tio.c_cc[VTIME] = 0;
+                tcsetattr(fd_, TCSANOW, &tio);
+            }
+            buf.clear();
+            last_rx = clock::now();
+        }
+
+        pollfd pfd{fd_, POLLIN, 0};
+        const int pr = ::poll(&pfd, 1, 200);   // 200 ms — lets us check running_/heartbeat
+        if (pr < 0) {
+            if (errno == EINTR) continue;
+            ::close(fd_); fd_ = -1; connected_.store(false);
+            continue;
+        }
+        if (pr > 0 && (pfd.revents & (POLLERR | POLLHUP | POLLNVAL))) {
+            ::close(fd_); fd_ = -1; connected_.store(false);   // device unplugged
+            continue;
+        }
+        if (pr > 0 && (pfd.revents & POLLIN)) {
+            char chunk[256];
+            const ssize_t n = ::read(fd_, chunk, sizeof chunk);
+            if (n > 0) {
+                last_rx = clock::now();
+                for (ssize_t i = 0; i < n; ++i) {
+                    const char c = chunk[i];
+                    if (c == '\n' || c == '\r') {
+                        if (!buf.empty()) { on_line(buf); buf.clear(); }
+                    } else if (buf.size() < kMaxLine) {
+                        buf.push_back(c);
+                    } else {
+                        buf.clear();   // overflow → resync on next newline
+                    }
+                }
+            } else if (n == 0 || (n < 0 && errno != EAGAIN && errno != EWOULDBLOCK)) {
+                ::close(fd_); fd_ = -1; connected_.store(false);
+                continue;
+            }
+        }
+
+        // Heartbeat: no traffic within the window → treat as offline (but keep
+        // the fd open; a quiet-but-present coproc recovers on the next byte).
+        const auto idle = std::chrono::duration_cast<std::chrono::milliseconds>(
+            clock::now() - last_rx).count();
+        if (idle > cfg_.heartbeat_timeout_ms) connected_.store(false);
+    }
+}
+
+void CoprocInputs::on_line(const std::string& line) {
+    // Tokenise on spaces (cheap, no allocations beyond the substrings).
+    auto next_tok = [](const std::string& s, size_t& pos) -> std::string {
+        while (pos < s.size() && s[pos] == ' ') ++pos;
+        const size_t start = pos;
+        while (pos < s.size() && s[pos] != ' ') ++pos;
+        return s.substr(start, pos - start);
+    };
+    size_t pos = 0;
+    const std::string cmd = next_tok(line, pos);
+    if (cmd.empty()) return;
+
+    if (cmd == "BTN") {
+        const std::string id_s = next_tok(line, pos);
+        const std::string evt  = next_tok(line, pos);
+        if (id_s.empty() || evt.empty()) return;
+        int id = -1;
+        try { id = std::stoi(id_s); } catch (...) { return; }   // malformed id → ignore
+        if (id < 0) return;
+        connected_.store(true);
+        if      (evt == "SHORT") handle_button(id, /*is_long=*/false);
+        else if (evt == "LONG")  handle_button(id, /*is_long=*/true);
+        // DOWN/UP are advisory in v1 — ignored.
+        return;
+    }
+    if (cmd == "HELLO") {
+        connected_.store(true);
+        std::cout << "[coproc] " << line << "\n";
+        return;
+    }
+    if (cmd == "PING") {
+        connected_.store(true);
+        if (fd_ >= 0) { const char* pong = "PONG\n"; (void)::write(fd_, pong, 5); }
+        return;
+    }
+    // Unknown command → ignore (forward-compatible).
+}
+
+void CoprocInputs::handle_button(int id, bool is_long) {
+    const auto& map = is_long ? cfg_.long_map : cfg_.short_map;
+    const auto it = map.find(id);
+    const GpioFunc f = (it != map.end()) ? it->second : GpioFunc::None;
+    if (f != GpioFunc::None && dispatch_) dispatch_(f);
+}
+
+}  // namespace input

--- a/src/input/coproc_inputs.h
+++ b/src/input/coproc_inputs.h
@@ -1,0 +1,92 @@
+#pragma once
+// ── coproc_inputs.h ─────────────────────────────────────────────────────────────
+// OPTIONAL button/switch coprocessor source. A small MCU (RP2350, or an earlier
+// RP2040/Pico) debounces the physical switches and streams button events to the
+// Pi, which dispatches them through the SAME input::GpioFunc path as the local
+// GPIO poller (input::GpioInputs). This offloads debounce timing and frees the
+// scarce free GPIO that HUB75 leaves behind — see
+// hardware/carrier-board/MULTI-BACKEND.md and docs/coprocessor-input.md.
+//
+// This is a FRAMEWORK SKELETON: the interface mirrors GpioInputs so it can be a
+// drop-in additional (or replacement) source. Method bodies are intentionally
+// left for implementation in coproc_inputs.cpp (not yet added to CMake SOURCES,
+// so adding this header alone does not affect the build).
+//
+// Integration seam (main.cpp ~line 11860/11897):
+//   auto gpio_dispatch = [&](input::GpioFunc f){ ... };          // existing
+//   if (coproc_cfg.enabled)
+//       coproc = std::make_unique<input::CoprocInputs>(coproc_cfg, gpio_dispatch);
+//   // local GpioInputs stays unless coproc_cfg.replace_local_gpio == true
+//
+// Both sources call the one dispatch — nothing downstream (menu, boop, camera
+// actions) needs to know where the press came from.
+
+#include <atomic>
+#include <functional>
+#include <map>
+#include <string>
+#include <thread>
+
+#include "gpio_function.h"
+
+namespace input {
+
+struct CoprocConfig {
+    bool        enabled = false;            // master toggle — false = pure local GPIO
+
+    // Transport. "usb_serial" (USB CDC/ACM — default, hot-pluggable) or "i2c"
+    // (carrier-wired, Pi master + a data-ready IRQ line, frees a USB port).
+    std::string transport = "usb_serial";
+
+    // usb_serial: prefer a STABLE path so it doesn't race with the other ACM
+    // devices (Teensy/SmartKnob/RAK4631). Use /dev/serial/by-id/... matched on
+    // the coprocessor's USB serial string, not /dev/ttyACMn.
+    std::string device    = "/dev/serial/by-id/usb-ProtoHUD_Buttons-if00";
+    int         baud      = 115200;
+
+    // i2c: bus + 7-bit address of the coprocessor, plus an interrupt GPIO the
+    // coproc pulls to signal "events queued" (avoids polling the bus).
+    std::string i2c_bus   = "/dev/i2c-1";
+    int         i2c_addr  = 0x42;
+    int         irq_gpio  = -1;             // BCM line; -1 = poll instead
+
+    // When true, the coproc is the only button source (local GpioInputs is not
+    // started). When false (default) the two are ADDITIVE — mix local + coproc.
+    bool        replace_local_gpio = false;
+
+    // Button-id → function map. The coprocessor reports a small integer button
+    // id + a SHORT/LONG classification; the Pi resolves the id to a GpioFunc
+    // here so REMAPPING stays in the HUD config (the coproc firmware is dumb
+    // about meaning, smart about timing). Unmapped ids dispatch GpioFunc::None.
+    std::map<int, GpioFunc> short_map;      // button id → short-press function
+    std::map<int, GpioFunc> long_map;       // button id → long-press function
+
+    // Heartbeat: if no PING/event seen within this window, mark offline (and,
+    // if replace_local_gpio, optionally fall back — see docs).
+    int         heartbeat_timeout_ms = 2000;
+};
+
+// Mirrors GpioInputs' lifecycle so main.cpp treats them the same way.
+class CoprocInputs {
+public:
+    CoprocInputs(CoprocConfig cfg, std::function<void(GpioFunc)> dispatch);
+    ~CoprocInputs();
+
+    bool init();          // open transport + start reader thread; false on failure
+    void shutdown();
+    bool connected() const { return connected_.load(); }   // surfaced to HUD status
+
+private:
+    void reader_loop();                       // transport read + reconnect loop
+    void on_line(const std::string& line);    // parse one framed message → dispatch
+    void handle_button(int id, bool is_long); // map id→GpioFunc, call dispatch_
+
+    CoprocConfig                  cfg_;
+    std::function<void(GpioFunc)> dispatch_;
+    std::atomic<bool>             running_{false};
+    std::atomic<bool>             connected_{false};
+    std::thread                   thread_;
+    int                           fd_ = -1;   // serial or i2c fd
+};
+
+} // namespace input

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,6 +27,7 @@
 #include "camera/viture_camera.h"
 #include "input/gpio_buttons.h"
 #include "input/gpio_inputs.h"
+#include "input/coproc_inputs.h"
 #include "input/gpio_function.h"
 #include "input/gamepad_input.h"
 #include "input/wireless_controller.h"
@@ -1468,7 +1469,14 @@ static std::vector<MenuItem> build_menu(
         std::shared_ptr<std::function<void()>> gpio_reload = nullptr,
         integrations::KdeConnectBridge* kdc_p = nullptr,
         std::vector<std::string>* kdc_ignore_p = nullptr,
-        std::vector<std::string>* kdc_msg_p = nullptr)
+        std::vector<std::string>* kdc_msg_p = nullptr,
+        // Optional button/switch coprocessor (input::CoprocInputs). enabled flag
+        // + a live status string getter + a reload hook, mirroring the GPIO
+        // poller's shared-after-construction pattern. All null when the build
+        // has no coprocessor support wired.
+        bool* coproc_enabled_p = nullptr,
+        std::shared_ptr<std::function<void()>> coproc_reload = nullptr,
+        std::shared_ptr<std::function<std::string()>> coproc_status = nullptr)
 {
     (void)lora; (void)knob;
 
@@ -8048,6 +8056,39 @@ static std::vector<MenuItem> build_menu(
                 "Rebuild the GPIO poller from the current slots so pin / "
                 "function / pull / polarity edits take effect right away."));
 
+        // Optional button/switch coprocessor (RP2350/RP2040). When enabled, an
+        // external MCU debounces the switches and streams presses to the Pi,
+        // dispatched through the same functions as the GPIO slots above. The
+        // slots stay live unless replace_local_gpio is set in config.
+        if (coproc_enabled_p) {
+            std::vector<MenuItem> coproc_menu;
+            coproc_menu.push_back(with_desc(toggle("Enabled",
+                [coproc_enabled_p]{ return *coproc_enabled_p; },
+                [coproc_enabled_p, coproc_reload](bool v){
+                    *coproc_enabled_p = v;
+                    if (coproc_reload && *coproc_reload) (*coproc_reload)();
+                }),
+                "Use an external button coprocessor (USB/I\xC2\xB2""C). Applies "
+                "immediately. GPIO slots above stay active too unless "
+                "replace_local_gpio is set in config.json."));
+            if (coproc_status) {
+                MenuItem st = leaf("Status", []{});
+                st.label_fn = [coproc_status]{
+                    return std::string("Status: ") +
+                           (*coproc_status ? (*coproc_status)() : std::string("n/a"));
+                };
+                coproc_menu.push_back(with_desc(std::move(st),
+                    "Connection state reported by the coprocessor link "
+                    "(connected / offline). Button mapping is edited in "
+                    "config.json under inputs.coprocessor.buttons."));
+            }
+            gpio_btn_menu.push_back(with_desc(
+                submenu("Button Coprocessor", std::move(coproc_menu)),
+                "Optional external MCU (RP2350/RP2040) that handles button "
+                "debounce and streams presses to the Pi \xE2\x80\x94 frees GPIO "
+                "and offloads timing. See docs/coprocessor-input.md."));
+        }
+
         for (int i = 0; i < gpio_slot_count; ++i) {
             input::GpioPinCfg* p = &GP[i];
 
@@ -11507,6 +11548,43 @@ int main(int argc, char* argv[]) {
         }
     }
 
+    // ── Optional button/switch coprocessor (input::CoprocInputs) ──────────────
+    // Opt-in: when inputs.coprocessor.enabled, an external MCU (RP2350/RP2040)
+    // debounces the switches and streams presses to the Pi over USB CDC (or
+    // I²C). Events resolve to the same input::GpioFunc dispatch as the GPIO
+    // slots, so it's additive (or, with replace_local_gpio, the only source).
+    // Reload + status are installed after gpio_dispatch exists (mirrors the
+    // GPIO poller's shared-after-construction pattern).
+    input::CoprocConfig coproc_cfg;
+    auto coproc_reload = std::make_shared<std::function<void()>>();
+    auto coproc_status = std::make_shared<std::function<std::string()>>();
+    if (cfg.contains("inputs") && cfg["inputs"].is_object() &&
+        cfg["inputs"].contains("coprocessor") &&
+        cfg["inputs"]["coprocessor"].is_object()) {
+        const json& jc = cfg["inputs"]["coprocessor"];
+        coproc_cfg.enabled            = jval(jc, "enabled", false);
+        coproc_cfg.transport          = jc.value("transport", coproc_cfg.transport);
+        coproc_cfg.device             = jc.value("device",    coproc_cfg.device);
+        coproc_cfg.baud               = jval(jc, "baud",      coproc_cfg.baud);
+        coproc_cfg.i2c_bus            = jc.value("i2c_bus",   coproc_cfg.i2c_bus);
+        coproc_cfg.i2c_addr           = jval(jc, "i2c_addr",  coproc_cfg.i2c_addr);
+        coproc_cfg.irq_gpio           = jval(jc, "irq_gpio",  coproc_cfg.irq_gpio);
+        coproc_cfg.replace_local_gpio = jval(jc, "replace_local_gpio", false);
+        coproc_cfg.heartbeat_timeout_ms =
+            jval(jc, "heartbeat_timeout_ms", coproc_cfg.heartbeat_timeout_ms);
+        if (jc.contains("buttons") && jc["buttons"].is_array()) {
+            for (const auto& jb : jc["buttons"]) {
+                if (!jb.is_object()) continue;
+                const int id = jval(jb, "id", -1);
+                if (id < 0) continue;
+                coproc_cfg.short_map[id] =
+                    input::gpio_func_from_id(jb.value("short", std::string("none")));
+                coproc_cfg.long_map[id] =
+                    input::gpio_func_from_id(jb.value("long",  std::string("none")));
+            }
+        }
+    }
+
     // KDE Connect lists — editable in the Phone menu, applied live to the bridge
     // and persisted to cfg["kdeconnect"]. ignore_list mutes servers/chats;
     // message_apps picks which apps get the big chat toast.
@@ -11624,7 +11702,8 @@ int main(int argc, char* argv[]) {
                                },
                                /* gpio_pins */ gpio_pins.data(), kGpioSlots,
                                &gpio_inputs_enabled, gpio_reload, kdc_menu_ptr,
-                               &kdc_ignore, &kdc_msgapps));
+                               &kdc_ignore, &kdc_msgapps,
+                               &coproc_cfg.enabled, coproc_reload, coproc_status));
     menu_ptr = &menu;
     menu.set_quick_items(std::move(quick_items));
 
@@ -11894,9 +11973,16 @@ int main(int argc, char* argv[]) {
         }
     };
 
+    // Local GPIO polling runs unless a coprocessor is enabled in replace mode
+    // (then the coproc is the sole button source).
+    auto local_gpio_wanted = [&]{
+        return gpio_inputs_enabled &&
+               !(coproc_cfg.enabled && coproc_cfg.replace_local_gpio);
+    };
+
     auto gpio_inputs = std::make_unique<input::GpioInputs>(
         std::vector<input::GpioPinCfg>(gpio_pins.begin(), gpio_pins.end()), gpio_dispatch);
-    if (gpio_inputs_enabled && !gpio_inputs->init())
+    if (local_gpio_wanted() && !gpio_inputs->init())
         std::cerr << "[main] GPIO input map init failed (no pins assigned or chip busy)\n";
 
     // Live reload: tear down the poll thread + release the lines, then rebuild
@@ -11906,10 +11992,32 @@ int main(int argc, char* argv[]) {
         gpio_inputs.reset();
         gpio_inputs = std::make_unique<input::GpioInputs>(
             std::vector<input::GpioPinCfg>(gpio_pins.begin(), gpio_pins.end()), gpio_dispatch);
-        if (gpio_inputs_enabled && !gpio_inputs->init())
+        if (local_gpio_wanted() && !gpio_inputs->init())
             std::cerr << "[main] GPIO reload: init failed (no pins assigned or chip busy)\n";
         else
             std::cout << "[gpio] input map reloaded\n";
+    };
+
+    // ── Button coprocessor source (optional, opt-in) ─────────────────────────
+    // Shares gpio_dispatch with the GPIO poller. Reload rebuilds it on a menu
+    // toggle; status surfaces the link state to the GPIO Buttons menu.
+    auto coproc_inputs = std::make_unique<input::CoprocInputs>(coproc_cfg, gpio_dispatch);
+    if (coproc_cfg.enabled && !coproc_inputs->init())
+        std::cerr << "[main] button coprocessor init failed (transport unavailable)\n";
+
+    *coproc_reload = [&]{
+        coproc_inputs.reset();
+        coproc_inputs = std::make_unique<input::CoprocInputs>(coproc_cfg, gpio_dispatch);
+        if (coproc_cfg.enabled && !coproc_inputs->init())
+            std::cerr << "[main] coprocessor reload: init failed (transport unavailable)\n";
+        // Re-evaluate the local poller — replace-mode may have just changed
+        // whether GPIO should be running.
+        if (gpio_reload && *gpio_reload) (*gpio_reload)();
+    };
+    *coproc_status = [&]() -> std::string {
+        if (!coproc_cfg.enabled)        return "disabled";
+        if (!coproc_inputs)             return "offline";
+        return coproc_inputs->connected() ? "connected" : "offline";
     };
 
     // ── Gamepad (SDL2, optional) ──────────────────────────────────────────────


### PR DESCRIPTION
## What this adds

An **optional** button/switch coprocessor source: an external MCU (RP2350 / RP2040) debounces switches and streams press events to the Pi, which dispatches them through the **same `input::GpioFunc` path** as on-board GPIO. It's **never required** — defaults off, and when enabled it's additive to (or, optionally, a replacement for) the existing GPIO poller.

Motivated by the Pi GPIO pin budget (HUB75 leaves few free pins) — this offloads buttons and their debounce timing entirely.

## The integration seam

`input::GpioInputs` already dispatches presses via a `std::function<void(GpioFunc)>` callback. The new `CoprocInputs` shares that exact callback (`gpio_dispatch` in `main.cpp`), so nothing downstream (menu / boop / camera actions) changes.

## Changes

- **`src/input/coproc_inputs.{h,cpp}`** — USB-CDC reader thread with reconnect + heartbeat, length-bounded parser for the v1 line protocol (`HELLO` / `BTN <id> SHORT|LONG` / `PING`), button-id → `GpioFunc` mapping, and dispatch. Treats the link as untrusted input. (I²C transport is parsed but returns a clean "not implemented in v1".)
- **`src/main.cpp`** — parses `inputs.coprocessor` → `CoprocConfig`; constructs `CoprocInputs(cfg, gpio_dispatch)`; gates the local `GpioInputs` on `!(coproc enabled && replace_local_gpio)`; reload + status hooks.
- **Menu** — *System → GPIO Buttons → Button Coprocessor*: live Enabled toggle + Status (disabled / offline / connected).
- **`CMakeLists.txt`** — adds `coproc_inputs.cpp` to SOURCES.
- **`config/config.example.json`** — `inputs.coprocessor` block (disabled, documented).
- **`firmware/button_coproc/README.md`** — protocol + reference Arduino (arduino-pico) sketch.
- **`docs/coprocessor-input.md`** — design framework.

## Config behavior

- `enabled: false` (default) → exactly today's GPIO behavior.
- `enabled: true`, additive → GPIO slots + coproc both fire.
- `enabled: true`, `replace_local_gpio: true` → coproc is the sole source.

## Testing

Both new/changed TUs compile (`coproc_inputs.cpp` to object; `main.cpp` full syntax check with real include paths); `config.example.json` is valid JSON. A **full link/build was not run** here (no build dir; CMake would fetch deps) — worth a build + on-hardware check, plus wiring a real MCU to exercise the protocol.

https://claude.ai/code/session_01HKncJZX3hDhPTdnbGvWvSq

---
_Generated by [Claude Code](https://claude.ai/code/session_01HKncJZX3hDhPTdnbGvWvSq)_