### PR TITLE
firmware: buildable Pico 2 W button coprocessor

### DIFF
--- a/firmware/button_coproc/README.md
+++ b/firmware/button_coproc/README.md
@@ -20,63 +20,47 @@ PING                               # heartbeat ~1 Hz
 Pi → MCU (optional): `PONG` (heartbeat ack). The Pi maps `<id>` → function via
 `inputs.coprocessor.buttons`, so the firmware stays "dumb about meaning".
 
-## USB identity
+## Buildable firmware: [`pico/`](pico/)
 
-Set the USB **serial string** (and ideally product = `ProtoHUD_Buttons`) so the
-Pi can bind a stable `/dev/serial/by-id/usb-ProtoHUD_Buttons-if00` path instead
-of a racing `/dev/ttyACMn`. In Arduino-Pico: `Serial` is USB CDC by default; set
-the board's USB product/serial in the IDE or via `TinyUSB`.
+A complete PlatformIO project (RP2350 / **Raspberry Pi Pico 2 W**, earlephilhower
+`arduino-pico` core — same toolchain as `firmware/mp3_player/pico`):
 
-## Reference sketch (Arduino — RP2040/RP2350 "arduino-pico" core)
+```
+pico/
+  platformio.ini      # board=rpipico2w, USB identity, build/flash notes
+  include/config.h     # button pin map + LED pins + debounce/long/ping timing
+  src/main.cpp         # debounce → SHORT/LONG, HELLO, PING, CFG/LED handling
+```
 
-```cpp
-// button_coproc.ino — debounce N switches, stream SHORT/LONG over USB CDC.
-#include <Arduino.h>
+Build & flash:
 
-constexpr uint8_t  PINS[]    = {2, 3, 4};        // GPIOs wired to switches (to GND)
-constexpr size_t   N         = sizeof(PINS);
-constexpr uint32_t DEBOUNCE  = 15;               // ms
-constexpr uint32_t LONG_MS   = 600;              // short/long threshold
-constexpr uint32_t HEARTBEAT = 1000;             // ms between PINGs
+```bash
+cd firmware/button_coproc/pico
+pio run -t upload        # hold BOOTSEL on the first flash; it auto-resets after
+pio device monitor       # watch the HELLO / BTN / PING stream (115200)
+```
 
-bool     stable[N], lastRaw[N], longSent[N];
-uint32_t tEdge[N], tDown[N], tPing;
+Edit **`include/config.h`** to set your switch GPIOs (the button **id** is the
+index in `kButtonPins`), optional per-switch LED pins, and the debounce / long-
+press / heartbeat timing. `src/main.cpp` handles the protocol; you usually don't
+need to touch it. It also accepts `CFG long_ms=<n>` (retune the threshold live)
+and `LED <id> <0|1>` (drive a switch backlight) from the Pi.
 
-void setup() {
-  Serial.begin(115200);                          // USB CDC
-  for (size_t i = 0; i < N; ++i) {
-    pinMode(PINS[i], INPUT_PULLUP);              // pressed = LOW
-    stable[i] = lastRaw[i] = true;               // released (HIGH)
-    longSent[i] = false;
-  }
-  uint32_t t0 = millis();
-  while (!Serial && millis() - t0 < 2000) {}     // wait briefly for host
-  Serial.print("HELLO proto-buttons v1 n="); Serial.println(N);
-  tPing = millis();
-}
+Other RP2040/RP2350 boards work too — swap `board` in `platformio.ini`
+(`rpipico2`, `rpipicow`, `rpipico`).
 
-void loop() {
-  const uint32_t now = millis();
-  for (size_t i = 0; i < N; ++i) {
-    const bool raw = digitalRead(PINS[i]);       // HIGH=released, LOW=pressed
-    if (raw != lastRaw[i]) { lastRaw[i] = raw; tEdge[i] = now; }   // bounce timer
-    if (now - tEdge[i] >= DEBOUNCE && raw != stable[i]) {
-      stable[i] = raw;
-      if (!raw) {                                // pressed (falling edge)
-        tDown[i] = now; longSent[i] = false;
-      } else {                                   // released (rising edge)
-        if (!longSent[i]) { Serial.print("BTN "); Serial.print(i); Serial.println(" SHORT"); }
-      }
-    }
-    if (!stable[i] && !longSent[i] && now - tDown[i] >= LONG_MS) {
-      longSent[i] = true;                        // fire LONG once while held
-      Serial.print("BTN "); Serial.print(i); Serial.println(" LONG");
-    }
-  }
-  if (now - tPing >= HEARTBEAT) { tPing = now; Serial.println("PING"); }
+## USB identity (stable serial path)
 
-  while (Serial.available()) Serial.read();      // drain PONG/etc.
-}
+`platformio.ini` sets the USB manufacturer/product so udev exposes a stable
+`/dev/serial/by-id/usb-ProtoHUD_Buttons-if00`-style path instead of a racing
+`/dev/ttyACMn` (the Teensy / SmartKnob / RAK4631 also enumerate as `ACM*`).
+
+After flashing, confirm the actual path and point the HUD config at it — the
+board's unique serial may be appended, so use whatever appears:
+
+```bash
+ls -l /dev/serial/by-id/
+# inputs.coprocessor.device = the matching ...ProtoHUD_Buttons...-if00 path
 ```
 
 ## Wiring notes

--- a/firmware/button_coproc/pico/.gitignore
+++ b/firmware/button_coproc/pico/.gitignore
@@ -1,0 +1,2 @@
+.pio/
+.vscode/

--- a/firmware/button_coproc/pico/include/config.h
+++ b/firmware/button_coproc/pico/include/config.h
@@ -1,0 +1,31 @@
+#pragma once
+// ── config.h ─────────────────────────────────────────────────────────────────
+// Pin map + timing for the ProtoHUD button coprocessor firmware. Edit this file
+// to match your wiring; nothing else needs changing for a basic build.
+//
+// The button id reported to the Pi is the INDEX in kButtonPins (0..N-1). The Pi
+// maps id → GpioFunc in inputs.coprocessor.buttons, so the ORDER here is your id
+// assignment — keep it stable once you've configured the HUD.
+
+#include <Arduino.h>
+
+// Switches wired between the listed GP pin and GND. We use INPUT_PULLUP, so a
+// pressed switch reads LOW (active-low). Add/remove entries freely — kLedPins
+// must stay the same length.
+static constexpr uint8_t kButtonPins[] = { 2, 3, 4, 5, 6, 7, 8, 9 };
+
+// Optional per-button LED / switch-backlight pins, parallel to kButtonPins.
+// -1 = none. Driven HIGH/LOW by the Pi via "LED <id> <0|1>".
+static constexpr int8_t  kLedPins[]    = { -1, -1, -1, -1, -1, -1, -1, -1 };
+
+// ── Timing ────────────────────────────────────────────────────────────────────
+static constexpr uint32_t kDebounceMs   = 15;    // ignore contact bounce shorter than this
+static constexpr uint32_t kLongMsInit   = 600;   // initial short/long threshold (CFG-tunable)
+static constexpr uint32_t kPingMs       = 1000;  // heartbeat period (~1 Hz)
+
+// Emit advisory "BTN <id> DOWN/UP" raw edges too. The Pi ignores them in v1, so
+// leave false unless you're debugging with a serial terminal.
+static constexpr bool     kEmitDownUp   = false;
+
+static_assert(sizeof(kButtonPins) == sizeof(kLedPins),
+              "kButtonPins and kLedPins must have the same number of entries");

--- a/firmware/button_coproc/pico/platformio.ini
+++ b/firmware/button_coproc/pico/platformio.ini
@@ -1,0 +1,31 @@
+; ── ProtoHUD button coprocessor — Raspberry Pi Pico 2 W (RP2350) ─────────────
+; Build/flash with PlatformIO (matches firmware/mp3_player/pico's toolchain):
+;   cd firmware/button_coproc/pico
+;   pio run -t upload           # hold BOOTSEL on first flash, then it auto-resets
+;   pio device monitor          # watch the HELLO / BTN / PING stream
+;
+; After flashing, find the stable serial path and put it in the HUD config under
+; inputs.coprocessor.device:
+;   ls -l /dev/serial/by-id/    # e.g. usb-ProtoHUD_Buttons-if00 (a board serial
+;                               #      may be appended — use whatever appears)
+
+[env:rpipico2w]
+platform  = https://github.com/earlephilhower/arduino-pico/releases/download/global/package_rp2040_index.json
+board     = rpipico2w
+framework = arduino
+board_build.core = earlephilhower
+monitor_speed    = 115200
+
+; USB identity so udev gives a stable /dev/serial/by-id/ path instead of a
+; racing /dev/ttyACMn (Teensy/SmartKnob/RAK4631 also enumerate as ACM*). The
+; udev by-id path is usb-<manufacturer>_<product>[_<serial>]-if00, so these
+; produce ...ProtoHUD_Buttons... If your core ignores these macros, just read
+; the real path from `ls /dev/serial/by-id/` and set the HUD config to match.
+build_flags =
+    -DUSB_MANUFACTURER="\"ProtoHUD\""
+    -DUSB_PRODUCT="\"Buttons\""
+
+; ── Other RP2040/RP2350 boards work too — swap `board` above ──────────────────
+;   board = rpipico2     ; RP2350, no WiFi
+;   board = rpipicow     ; RP2040 + WiFi
+;   board = rpipico      ; RP2040, no WiFi

--- a/firmware/button_coproc/pico/src/main.cpp
+++ b/firmware/button_coproc/pico/src/main.cpp
@@ -1,0 +1,145 @@
+// ── ProtoHUD button coprocessor — RP2350 / Raspberry Pi Pico 2 W ─────────────
+// Debounces N physical switches, classifies short vs long press, and streams the
+// events to the Pi over USB CDC. ProtoHUD's input::CoprocInputs (host side)
+// dispatches them through the SAME input::GpioFunc path as on-board GPIO, so the
+// coprocessor is never required — it just offloads debounce/long-press timing
+// and frees the scarce GPIO that HUB75 leaves on the Pi.
+//
+// Protocol v1 (newline-delimited ASCII — see docs/coprocessor-input.md):
+//   coproc → Pi : "HELLO proto-buttons v1 n=<N>"   (on connect)
+//                 "BTN <id> SHORT" | "BTN <id> LONG"
+//                 "BTN <id> DOWN"  | "BTN <id> UP"  (advisory; off by default)
+//                 "PING"                            (heartbeat ~1 Hz)
+//   Pi → coproc : "PONG"             (ack — ignored)
+//                 "CFG long_ms=<n>"  (push the short/long threshold)
+//                 "LED <id> <0|1>"   (drive a switch backlight, if wired)
+//
+// The firmware is "dumb about meaning": it reports button id + SHORT/LONG; the
+// Pi decides what each id does (remappable in the HUD config). Bytes from the
+// host are treated as untrusted: line length is bounded and unknown lines are
+// ignored.
+
+#include <Arduino.h>
+#include "config.h"
+
+namespace {
+
+constexpr size_t kNumButtons = sizeof(kButtonPins) / sizeof(kButtonPins[0]);
+
+// Tunable at runtime via "CFG long_ms=<n>"; starts at the configured default.
+uint32_t g_long_ms = kLongMsInit;
+
+// Per-button debounce + press state.
+struct Button {
+    bool     raw        = true;   // last raw read (true = released, INPUT_PULLUP HIGH)
+    bool     stable     = true;   // debounced state (true = released)
+    uint32_t edge_ms    = 0;      // time of last raw change (debounce timer)
+    uint32_t down_ms    = 0;      // when the debounced press began
+    bool     long_fired = false;  // LONG already emitted for the current hold
+};
+Button   g_btn[kNumButtons];
+
+uint32_t g_last_ping = 0;
+bool     g_was_connected = false;   // tracks the USB CDC (DTR) edge for re-HELLO
+
+// One message per line. `value` is appended unsigned-decimal where used.
+void emit(const char* verb, size_t id, const char* evt) {
+    Serial.print(verb); Serial.print(' '); Serial.print(id);
+    Serial.print(' ');  Serial.println(evt);
+}
+
+void send_hello() {
+    Serial.print("HELLO proto-buttons v1 n=");
+    Serial.println(kNumButtons);
+}
+
+void poll_button(size_t i, uint32_t now) {
+    Button& b = g_btn[i];
+    const bool raw = (digitalRead(kButtonPins[i]) == HIGH);   // HIGH = released
+    if (raw != b.raw) { b.raw = raw; b.edge_ms = now; }       // bounce → restart timer
+    if ((now - b.edge_ms) < kDebounceMs) return;              // still settling
+
+    if (raw != b.stable) {                                    // debounced edge
+        b.stable = raw;
+        if (!raw) {                                           // pressed (falling)
+            b.down_ms = now; b.long_fired = false;
+            if (kEmitDownUp) emit("BTN", i, "DOWN");
+        } else {                                              // released (rising)
+            if (kEmitDownUp) emit("BTN", i, "UP");
+            if (!b.long_fired) emit("BTN", i, "SHORT");       // released before LONG
+        }
+        return;
+    }
+
+    // Steady held state: fire LONG exactly once at the threshold.
+    if (!b.stable && !b.long_fired && (now - b.down_ms) >= g_long_ms) {
+        b.long_fired = true;
+        emit("BTN", i, "LONG");
+    }
+}
+
+// Parse one inbound line from the Pi. Everything optional / forward-compatible.
+void handle_line(const String& line) {
+    if (line.startsWith("CFG long_ms=")) {
+        long v = line.substring(12).toInt();
+        if (v >= 100 && v <= 5000) g_long_ms = static_cast<uint32_t>(v);
+    } else if (line.startsWith("LED ")) {
+        int sp = line.indexOf(' ', 4);
+        if (sp > 0) {
+            int id = line.substring(4, sp).toInt();
+            int on = line.substring(sp + 1).toInt();
+            if (id >= 0 && id < static_cast<int>(kNumButtons) && kLedPins[id] >= 0)
+                digitalWrite(kLedPins[id], on ? HIGH : LOW);
+        }
+    }
+    // "PONG" and any unknown line: ignore.
+}
+
+void drain_input() {
+    static String rx;
+    while (Serial.available()) {
+        const char c = static_cast<char>(Serial.read());
+        if (c == '\n' || c == '\r') {
+            if (rx.length()) { handle_line(rx); rx = ""; }
+        } else if (rx.length() < 64) {
+            rx += c;
+        } else {
+            rx = "";   // overflow → resync on next newline
+        }
+    }
+}
+
+}  // namespace
+
+void setup() {
+    Serial.begin(115200);                       // USB CDC (baud is nominal for CDC)
+    for (size_t i = 0; i < kNumButtons; ++i) {
+        pinMode(kButtonPins[i], INPUT_PULLUP);  // pressed = LOW
+        if (kLedPins[i] >= 0) {
+            pinMode(kLedPins[i], OUTPUT);
+            digitalWrite(kLedPins[i], LOW);
+        }
+    }
+}
+
+void loop() {
+    const uint32_t now = millis();
+
+    // (Re)greet whenever the host opens the CDC port (DTR asserted). Re-arming on
+    // the disconnect→connect edge means a HUD restart re-reads our button count.
+    const bool connected = static_cast<bool>(Serial);
+    if (connected && !g_was_connected) {
+        send_hello();
+        g_last_ping = now;
+    }
+    g_was_connected = connected;
+
+    for (size_t i = 0; i < kNumButtons; ++i) poll_button(i, now);
+
+    if (connected && (now - g_last_ping) >= kPingMs) {
+        g_last_ping = now;
+        Serial.println("PING");
+    }
+
+    drain_input();
+}


### PR DESCRIPTION
## What

Adds a complete, flashable **PlatformIO firmware project** for the optional button coprocessor — the "GPIO code processor" that runs on a **Raspberry Pi Pico 2 W (RP2350)**. The Pi side (`input::CoprocInputs`), the protocol spec (`docs/coprocessor-input.md`), and a README already existed; what was missing was a buildable MCU project. This fills that gap.

```
firmware/button_coproc/pico/
  platformio.ini      # board=rpipico2w, earlephilhower arduino-pico core, USB identity
  include/config.h     # button GPIO map (index = button id) + LED pins + timing
  src/main.cpp         # debounce → SHORT/LONG, HELLO, PING, CFG/LED handling
  .gitignore
```

## How it ties in

The firmware is **"dumb about meaning"**: it debounces N switches and streams `BTN <id> SHORT|LONG` (+ `HELLO`, `PING`) over **USB CDC**, protocol v1 per `docs/coprocessor-input.md`. The Pi's `input::CoprocInputs` reads those lines and maps `id → GpioFunc` from `inputs.coprocessor.buttons`, dispatching through the **same path as on-board GPIO** — so remapping stays in the HUD and the coprocessor is never required.

- `coproc → Pi`: `HELLO proto-buttons v1 n=<N>`, `BTN <id> SHORT|LONG` (`DOWN/UP` optional/advisory), `PING` ~1 Hz
- `Pi → coproc`: `CFG long_ms=<n>` (retune threshold live), `LED <id> <0|1>` (switch backlight), `PONG` (ignored)
- Inbound bytes treated as **untrusted** (bounded lines, unknown lines ignored).

`platformio.ini` sets the USB manufacturer/product so udev exposes a stable `/dev/serial/by-id/...ProtoHUD_Buttons...-if00` path (no `ttyACMn` race with the Teensy/SmartKnob/RAK4631).

## Usage

```bash
cd firmware/button_coproc/pico
pio run -t upload        # hold BOOTSEL on first flash
pio device monitor       # watch HELLO / BTN / PING
ls -l /dev/serial/by-id/ # → set inputs.coprocessor.device to the matching path
```
Edit `include/config.h` for your switch GPIOs; `src/main.cpp` rarely needs touching. Other RP2040/RP2350 boards work by swapping `board` in `platformio.ini`.

## Notes / caveats

- **Firmware only** — not part of the CMake build; flashed to the MCU with PlatformIO. **Untested**: this environment has no PlatformIO/RP2350 toolchain, so it hasn't been compiled or run on hardware.
- The host-side `input::CoprocInputs` is present but (per its header) **not yet wired into CMake `SOURCES` / `main.cpp` / config**. This PR is firmware-only; wiring the host source + the `System → GPIO Buttons → Button Coprocessor` toggle can be a follow-up.
- If the earlephilhower core ignores the USB descriptor macros, the by-id path may differ — the README documents reading the real path from `ls /dev/serial/by-id/`.

https://claude.ai/code/session_01HKncJZX3hDhPTdnbGvWvSq

---
_Generated by [Claude Code](https://claude.ai/code/session_01HKncJZX3hDhPTdnbGvWvSq)_