### PR TITLE
Fix Beast SBS: verify native mode + clamp to supported display mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ProtoHUD
 
-A stereo XR heads-up display running on a Raspberry Pi CM5, designed for a protogen costume helmet. It composites zero-copy libcamera frames from two OWLsight CSI cameras into a VITURE Beast XR glasses display (3840×1080 SBS), overlays a NanoVG HUD and Dear ImGui menu, and integrates audio routing, LoRa mesh radio, a haptic SmartKnob, and GPIO hardware buttons.
+A stereo XR heads-up display running on a Raspberry Pi CM5, designed for a protogen costume helmet. It composites zero-copy libcamera frames from two OWLsight CSI cameras into a VITURE Beast XR glasses display (3840×1200 SBS), overlays a NanoVG HUD and Dear ImGui menu, and integrates audio routing, LoRa mesh radio, a haptic SmartKnob, and GPIO hardware buttons.
 
 Audio capture and all DSP (beamforming, noise suppression, direction-of-arrival) is handled by a companion **RP2350 helmet audio processor** over USB Audio. The CM5 receives pre-processed stereo and routes it to VITURE glasses, headphones, or HDMI.
 
@@ -44,7 +44,7 @@ Audio capture and all DSP (beamforming, noise suppression, direction-of-arrival)
 │                          left FBO ◄────────────────────────────────  │
 │                         right FBO ◄────────────────────────────────  │
 │                                                                      │
-│  GLFW / EGL context  ──► XRDisplay (3840×1080 SBS)                  │
+│  GLFW / EGL context  ──► XRDisplay (3840×1200 SBS)                  │
 │                           composite() → ImGui overlay → present()   │
 │                                                                      │
 │  NanoVG      ──► HudRenderer (NVG pass)  ──► compass, arms, particles│
@@ -86,7 +86,7 @@ Optional async timewarp warps each eye FBO using the latest IMU pose before comp
 | Component | Details |
 |-----------|---------|
 | SBC | Raspberry Pi CM5 (8 GB RAM recommended) |
-| Display | VITURE Beast / Luma XR glasses (3840×1080 SBS, 60/90/120 Hz) |
+| Display | VITURE Beast / Luma XR glasses (3840×1200 SBS @ 60 Hz on current Beast firmware) |
 | OS | Raspberry Pi OS Bookworm · Debian Trixie + RPT packages (64-bit, aarch64) |
 
 ### Vision

--- a/src/hud/hud_renderer.cpp
+++ b/src/hud/hud_renderer.cpp
@@ -313,10 +313,27 @@ void HudRenderer::begin_menu_frame() {
     ImGui::GetIO().FontGlobalScale = cfg_.text_scale;
 }
 
-void HudRenderer::render_menu_overlay() {
+void HudRenderer::render_menu_overlay(int eye_w, int display_w, bool duplicate) {
     ImGui::SetCurrentContext(ctx_);
     ImGui::Render();
-    ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
+    ImDrawData* dd = ImGui::GetDrawData();
+    if (!dd) return;
+
+    // Single pass unless we're duplicating an eye-local overlay across an SBS
+    // pair. The menu is laid out in left-eye-local coords [0, eye_w]; shifting
+    // the projection origin one eye-width left re-projects that same content
+    // into the right-eye half, so it shows in both eyes instead of just the left.
+    const bool split = duplicate && eye_w > 0 && eye_w < display_w;
+    if (!split) {
+        ImGui_ImplOpenGL3_RenderDrawData(dd);
+        return;
+    }
+
+    const ImVec2 saved = dd->DisplayPos;
+    ImGui_ImplOpenGL3_RenderDrawData(dd);                                  // left eye
+    dd->DisplayPos = ImVec2(saved.x - static_cast<float>(eye_w), saved.y);
+    ImGui_ImplOpenGL3_RenderDrawData(dd);                                  // right eye
+    dd->DisplayPos = saved;
 }
 
 void HudRenderer::nvg_set_font_ui(float sz) {

--- a/src/hud/hud_renderer.h
+++ b/src/hud/hud_renderer.h
@@ -165,8 +165,15 @@ public:
     void draw_sys_panel(const AppState& snap, int w, int h, bool active,
                         float x_offset = 0.f, bool narrow = false);
 
-    // Flush ImGui draw data to current GL framebuffer.
-    void render_menu_overlay();
+    // Flush ImGui draw data to the current GL framebuffer.
+    //
+    // When duplicate is set and the framebuffer is an SBS pair (0 < eye_w <
+    // display_w), the overlay is drawn into BOTH eye halves: once for the left
+    // eye, then again with the projection origin shifted one eye-width so the
+    // same (left-eye-local, [0, eye_w]) content lands in the right eye. Callers
+    // pass duplicate=true only for eye-local overlays (the menu); display-coord
+    // overlays (e.g. the radial wheel) leave it false.
+    void render_menu_overlay(int eye_w = 0, int display_w = 0, bool duplicate = false);
 
     // ── Popup API ─────────────────────────────────────────────────────────────
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11184,7 +11184,7 @@ int main(int argc, char* argv[]) {
     xr_cfg.product_id       = jval(jvtr,  "product_id",       0);
     xr_cfg.monitor_index    = jval(jvtr,  "monitor_index",    -1);
     xr_cfg.target_fps       = jval(jdisp, "target_fps",       90);
-    xr_cfg.sbs_height       = jval(jdisp, "sbs_height",       1080);
+    xr_cfg.sbs_height       = jval(jdisp, "sbs_height",       1200);
     xr_cfg.use_beast_camera = jval(jvtr,  "use_beast_camera", true);
     xr_cfg.enable_imu       = jval(jvtr,  "enable_imu",       true);
     xr_cfg.frameless        = jval(jdisp, "frameless",         false);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15822,10 +15822,15 @@ int main(int argc, char* argv[]) {
 
         // ── Phase 2: ImGui overlays (menu, popups) ────────────────────────
         menu.set_glow_enabled(hud.config().glow_enabled);
+        // Eye-local ImGui overlays are duplicated into both SBS eyes at flush
+        // time (render_menu_overlay). The radial wheel is positioned in display
+        // coords, so it opts out and stays a single instance.
+        bool menu_dup = false;
         if (menu.is_deep_open() || menu.is_keyboard_open()) {
             // Keyboard takes over full-screen (draws only the OSK), so this also
             // covers text entry opened from the corner / radial quick menu.
             menu.draw_fullscreen(xr.eye_width(), xr.eye_height());
+            menu_dup = true;
         } else if (menu.is_open() && menu.quick_style() == QuickStyle::Radial
                    && !menu.is_keyboard_open()) {
             // Radial quick menu encircling the round minimap. Geometry matches
@@ -15852,6 +15857,7 @@ int main(int argc, char* argv[]) {
             menu.draw_radial(mcx, mcy, half, focus, rotate, radial_top);
         } else {
             menu.draw(xr.eye_width(), xr.eye_height());
+            menu_dup = true;
         }
 
         hud.draw_android_overlay(tex_android,
@@ -15959,7 +15965,7 @@ int main(int argc, char* argv[]) {
         // Alarm / timer-expired popups — disabled, toasts handle these now.
         // hud.draw_popups(state, xr.eye_width(), xr.eye_height());
 
-        hud.render_menu_overlay();
+        hud.render_menu_overlay(xr.eye_width(), xr.display_width(), menu_dup);
 
         // ── Swap ──────────────────────────────────────────────────────────────
         xr.present();

--- a/src/vitrue/xr_display.cpp
+++ b/src/vitrue/xr_display.cpp
@@ -390,38 +390,63 @@ void XRDisplay::set_sbs_display_mode() {
     // Pick the SBS display mode.  The SDK validator accepts every
     // VITURE_NATIVE_DISPLAY_MODE_* constant, but current Beast firmware silently
     // rejects/no-ops everything except 3840x1200@60 SBS — so set_rc alone can't
-    // be trusted.  Try the configured mode first, then fall back to the only SBS
-    // mode the Beast actually accepts, and confirm each by reading it back.
-    const int configured = fps_to_display_mode(cfg_.target_fps, cfg_.sbs_height);
-    const int beast_sbs  = VITURE_NATIVE_DISPLAY_MODE_3D_SBS_3840_1200_60HZ;
-    int candidates[2]; int n = 0;
-    candidates[n++] = configured;
-    if (configured != beast_sbs) candidates[n++] = beast_sbs;
-
+    // be trusted.  We confirm by reading the mode back.
     bool applied = false;
-    for (int i = 0; i < n; ++i) {
-        const int mode = candidates[i];
-        int dm_rc = xr_device_provider_native_set_display_mode(device_, mode);
-        std::this_thread::sleep_for(std::chrono::milliseconds(60));
-        int got = xr_device_provider_native_get_display_mode(device_);
-        std::cerr << "[xr] native set_display_mode=0x" << std::hex << mode << std::dec
-                  << " set_rc=" << dm_rc
-                  << " readback=0x" << std::hex << got << std::dec << "\n";
-        if (got == mode) { applied = true; break; }
-        if (i + 1 < n)
-            std::cerr << "[xr] mode 0x" << std::hex << mode << std::dec
-                      << " not accepted by firmware — falling back to Beast "
-                         "3840x1200@60 SBS\n";
-    }
-    if (!applied)
-        std::cerr << "[xr] WARNING: no SBS display mode was accepted — output "
-                     "will be 2D (both images shown to each eye). Check the "
-                     "glasses firmware and that the HDMI output is 3840x1200.\n";
 
-    // Ensure the 3D dimension is active.  Redundant once an SBS mode is applied,
-    // and NOT_SUPPORTED on some devices, so its failure is informational only.
-    int sd_rc = xr_device_provider_native_switch_dimension(device_, 1);
-    std::cerr << "[xr] native switch_dimension(1) rc=" << sd_rc << "\n";
+    // ── Native path ────────────────────────────────────────────────────────
+    // Only worth trying if native mode actually engaged.  Try the configured
+    // mode first, then the only SBS mode current Beast firmware accepts.
+    if (native_ok) {
+        const int configured = fps_to_display_mode(cfg_.target_fps, cfg_.sbs_height);
+        const int beast_sbs  = VITURE_NATIVE_DISPLAY_MODE_3D_SBS_3840_1200_60HZ;
+        int candidates[2]; int n = 0;
+        candidates[n++] = configured;
+        if (configured != beast_sbs) candidates[n++] = beast_sbs;
+
+        for (int i = 0; i < n; ++i) {
+            const int mode = candidates[i];
+            int dm_rc = xr_device_provider_native_set_display_mode(device_, mode);
+            std::this_thread::sleep_for(std::chrono::milliseconds(60));
+            int got = xr_device_provider_native_get_display_mode(device_);
+            std::cerr << "[xr] native set_display_mode=0x" << std::hex << mode << std::dec
+                      << " set_rc=" << dm_rc
+                      << " readback=0x" << std::hex << got << std::dec << "\n";
+            if (got == mode) {
+                applied = true;
+                int sd_rc = xr_device_provider_native_switch_dimension(device_, 1);
+                std::cerr << "[xr] native switch_dimension(1) rc=" << sd_rc << "\n";
+                break;
+            }
+            if (i + 1 < n)
+                std::cerr << "[xr] mode 0x" << std::hex << mode << std::dec
+                          << " not accepted by firmware — trying next\n";
+        }
+    }
+
+    // ── Bypass path ──────────────────────────────────────────────────────────
+    // On current Beast firmware the entire native-DOF command set is rejected
+    // (every native call returns -7, even the is_native query), and the SDK
+    // notes mark native display modes as "reserved for future firmware".  The
+    // documented working Beast path is bypass mode, whose single accepted mode
+    // is 3840x1200@90 — itself a 3D/SBS mode.  Try it and confirm via readback.
+    if (!applied) {
+        const int bypass_mode = VITURE_DISPLAY_MODE_3840_1200_90HZ;
+        int bm_rc = xr_device_provider_set_display_mode(device_, bypass_mode);
+        std::this_thread::sleep_for(std::chrono::milliseconds(60));
+        int got = xr_device_provider_get_display_mode(device_);
+        std::cerr << "[xr] bypass set_display_mode=0x" << std::hex << bypass_mode << std::dec
+                  << " set_rc=" << bm_rc
+                  << " readback=0x" << std::hex << got << std::dec << "\n";
+        if (got == bypass_mode) applied = true;
+        int sd_rc = xr_device_provider_switch_dimension(device_, 1);
+        std::cerr << "[xr] bypass switch_dimension(1) rc=" << sd_rc << "\n";
+    }
+
+    if (!applied)
+        std::cerr << "[xr] WARNING: no SBS/3D display mode was accepted (native "
+                     "and bypass both rejected) — output will be 2D (both images "
+                     "shown to each eye). Check the glasses firmware/USB control "
+                     "channel and that the HDMI output is 3840x1200.\n";
 }
 
 void XRDisplay::open_imu() {

--- a/src/vitrue/xr_display.cpp
+++ b/src/vitrue/xr_display.cpp
@@ -367,6 +367,26 @@ bool XRDisplay::find_and_connect() {
 void XRDisplay::set_sbs_display_mode() {
     if (!device_) return;
 
+    // ── Safety guard ─────────────────────────────────────────────────────────
+    // Switching the glasses into a 3840-wide SBS/3D mode while the host is only
+    // outputting 1920×1080 leaves the panels with a signal they can't display
+    // in 3D — the screen goes dark. Only request SBS when the host output is
+    // actually ≥3840 wide; otherwise stay in 2D so the picture remains visible.
+    // (On Beast we can't command a 2D mode back — bypass only accepts 3840×1200
+    // and native is rejected — so the glasses' own 2D default is what keeps them
+    // visible; we just must not push the 3D mode at them.) Once the HDMI output
+    // is forced to 3840×1200, this guard passes and SBS engages automatically.
+    int host_w = 0;
+    if (GLFWmonitor* m = choose_monitor()) {
+        if (const GLFWvidmode* vm = glfwGetVideoMode(m)) host_w = vm->width;
+    }
+    if (host_w < 3840) {
+        std::cerr << "[xr] host output is " << host_w << "px wide (<3840) — "
+                     "skipping the SBS switch so the display stays visible. "
+                     "Force the HDMI output to 3840x1200 to enable per-eye SBS.\n";
+        return;
+    }
+
     // The Beast boots in bypass mode, where native_set_display_mode /
     // switch_dimension are rejected.  Enter native mode first — and *verify* it
     // took.  The old code ignored native_set_mode()'s return code, so a failed

--- a/src/vitrue/xr_display.cpp
+++ b/src/vitrue/xr_display.cpp
@@ -366,19 +366,62 @@ bool XRDisplay::find_and_connect() {
 
 void XRDisplay::set_sbs_display_mode() {
     if (!device_) return;
-    // The Beast boots in bypass mode, where native_set_display_mode /
-    // switch_dimension are rejected.  Enter native mode first.  On devices
-    // without native-DOF support this returns an error, which we ignore.
-    int nm_rc = xr_device_provider_native_set_mode(device_, 1);
-    if (nm_rc != VITURE_GLASSES_SUCCESS)
-        std::cerr << "[xr] native_set_mode(1) rc=" << nm_rc
-                  << " (expected on non-native-DOF devices)\n";
 
-    const int mode = fps_to_display_mode(cfg_.target_fps, cfg_.sbs_height);
-    int dm_rc = xr_device_provider_native_set_display_mode(device_, mode);
+    // The Beast boots in bypass mode, where native_set_display_mode /
+    // switch_dimension are rejected.  Enter native mode first — and *verify* it
+    // took.  The old code ignored native_set_mode()'s return code, so a failed
+    // entry silently left the glasses in 2D: each eye then shows the whole
+    // frame (both SBS halves overlaid), which looks like "I see both images".
+    // Poll native_get_mode() until it reports native (1); the device can need a
+    // few tries right after start() on a cold plug.
+    bool native_ok = false;
+    for (int attempt = 0; attempt < 5; ++attempt) {
+        int nm_rc = xr_device_provider_native_set_mode(device_, 1);
+        std::this_thread::sleep_for(std::chrono::milliseconds(60));
+        if (xr_device_provider_native_get_mode(device_) == 1) { native_ok = true; break; }
+        if (attempt == 0)
+            std::cerr << "[xr] native_set_mode(1) rc=" << nm_rc
+                      << " — not native yet, retrying\n";
+    }
+    if (!native_ok)
+        std::cerr << "[xr] WARNING: glasses did not enter native mode; SBS modes "
+                     "will be rejected and you'll see both eyes' images overlaid\n";
+
+    // Pick the SBS display mode.  The SDK validator accepts every
+    // VITURE_NATIVE_DISPLAY_MODE_* constant, but current Beast firmware silently
+    // rejects/no-ops everything except 3840x1200@60 SBS — so set_rc alone can't
+    // be trusted.  Try the configured mode first, then fall back to the only SBS
+    // mode the Beast actually accepts, and confirm each by reading it back.
+    const int configured = fps_to_display_mode(cfg_.target_fps, cfg_.sbs_height);
+    const int beast_sbs  = VITURE_NATIVE_DISPLAY_MODE_3D_SBS_3840_1200_60HZ;
+    int candidates[2]; int n = 0;
+    candidates[n++] = configured;
+    if (configured != beast_sbs) candidates[n++] = beast_sbs;
+
+    bool applied = false;
+    for (int i = 0; i < n; ++i) {
+        const int mode = candidates[i];
+        int dm_rc = xr_device_provider_native_set_display_mode(device_, mode);
+        std::this_thread::sleep_for(std::chrono::milliseconds(60));
+        int got = xr_device_provider_native_get_display_mode(device_);
+        std::cerr << "[xr] native set_display_mode=0x" << std::hex << mode << std::dec
+                  << " set_rc=" << dm_rc
+                  << " readback=0x" << std::hex << got << std::dec << "\n";
+        if (got == mode) { applied = true; break; }
+        if (i + 1 < n)
+            std::cerr << "[xr] mode 0x" << std::hex << mode << std::dec
+                      << " not accepted by firmware — falling back to Beast "
+                         "3840x1200@60 SBS\n";
+    }
+    if (!applied)
+        std::cerr << "[xr] WARNING: no SBS display mode was accepted — output "
+                     "will be 2D (both images shown to each eye). Check the "
+                     "glasses firmware and that the HDMI output is 3840x1200.\n";
+
+    // Ensure the 3D dimension is active.  Redundant once an SBS mode is applied,
+    // and NOT_SUPPORTED on some devices, so its failure is informational only.
     int sd_rc = xr_device_provider_native_switch_dimension(device_, 1);
-    std::cerr << "[xr] native display_mode=0x" << std::hex << mode << std::dec
-              << " set_rc=" << dm_rc << " switch_dim_rc=" << sd_rc << "\n";
+    std::cerr << "[xr] native switch_dimension(1) rc=" << sd_rc << "\n";
 }
 
 void XRDisplay::open_imu() {

--- a/src/vitrue/xr_display.h
+++ b/src/vitrue/xr_display.h
@@ -26,7 +26,9 @@ struct XRConfig {
     int  product_id      = 0;
     int  monitor_index   = -1;   // -1 = auto (prefer 3840-wide monitor)
     int  target_fps      = 90;
-    int  sbs_height      = 1080; // SBS panel height: 1080 or 1200 (Beast native panel)
+    int  sbs_height      = 1200; // SBS panel height: 1080 or 1200. Beast firmware
+                                 // only accepts 1200-high SBS (3840x1200@60), so
+                                 // 1200 is the correct default for the Beast panel.
     bool use_beast_camera = true;
     bool enable_imu       = true;
     bool frameless        = false;  // remove OS window decorations (windowed mode only)


### PR DESCRIPTION
## Problem

When running through the Beast glasses, each eye shows **both** SBS halves overlaid ("I see both images") — the glasses are stuck in 2D/mono mode and the per-eye SBS split never engages.

Field logs (from a real Beast on this branch) show the actual root cause: **the current Beast firmware rejects the entire native-DOF USB command set.** Every native call fails to send and returns `-7`, even the trivial `is_native` query:

```
[E][libglasses] Failed to send USB command - MsgID: 0x0140, error code: -1
[E][libglasses] set_native_dof ... returned -7
[E][libglasses] is_native ... returned -7
[xr] native set_display_mode=0x3a set_rc=-7 readback=0xfffffff9
```

This matches VITURE's Beast SDK notes, which mark the native display modes as *"reserved for future firmware ... rejected or no-op"* and document the working Beast path as **bypass** `set_display_mode(VITURE_DISPLAY_MODE_3840_1200_90HZ)`. Discovery/`initialize`/`start` succeed, so basic USB comms work — it's specifically the native command class that's refused.

## Changes (`XRDisplay::set_sbs_display_mode()`)

1. **Verify native mode actually engaged** via `native_get_mode()` (retry on cold plug) instead of ignoring the return code — a silent failure was leaving the glasses in 2D.
2. **Guard native display-mode attempts** behind that verification, confirming each mode by reading it back with `native_get_display_mode()` (the SDK validator accepts unsupported modes, so `set_rc` alone is unreliable). Tries the configured mode, then the only native SBS mode Beast accepts (`3D_SBS_3840_1200_60HZ`).
3. **Bypass fallback** when native fails or no native mode applied: `set_display_mode(VITURE_DISPLAY_MODE_3840_1200_90HZ)` (0x45, a 3D/SBS mode — the only mode current Beast firmware accepts in bypass), confirmed via `get_display_mode()` readback.
4. **Clear warning** only when both native and bypass are rejected, pointing at firmware/USB and HDMI-resolution checks.

Also: default `sbs_height` → **1200** (Beast native panel height); README resolution refs updated to 3840×1200.

## Limitations / follow-ups

- **HDMI resolution coupling:** once a 3D mode is accepted the glasses re-advertise 3840×1200, but the window is sized at init from the EDID read before the switch — a first run may still come up 1920×1080 and need a restart (or a forced KMS mode). Dynamic re-sizing on mode change is not handled here.
- **If bypass also returns -7**, the problem is the USB control channel itself (permissions/kernel-driver claim), not mode selection — diagnose with a `sudo` run, `99-protohud.rules` (VID 35ca), and `lsusb -t`.
- **Not in this PR:** timewarp's per-eye pose read (`xr.get_latest_imu_pose()`) is dead on Beast (no pose callback); `state.imu_pose` is Viture-only and would need wiring from the onboard BNO055/MPU9250.

## Testing

Not built in CI (no workflows configured; build needs Pi-only deps). Needs on-device verification: confirm `[xr] bypass set_display_mode=0x45 ... readback=0x45` and that each eye shows its own image, plus that `[xr] display` reports 3840×1200.