### PR TITLE
Hardware: BNO055 over USB-UART + single-connector RGB Matrix Bonnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -1136,6 +1136,35 @@ You should see `28` (or `29`) in the grid. **An empty grid means the chip isn't 
 | `heading_axes` | Axis remap preset for non-default mounting. Chip calibration survives axis changes |
 | `poll_hz` | Sensor read rate. 50 Hz matches the chip's internal fusion rate; higher just resamples the same value |
 
+### Over a USB-UART adapter
+
+The BNO055 also speaks **UART**, which sidesteps the Pi's I²C clock-stretching entirely. The simplest path is a **USB-UART adapter** (FTDI / CP2102 / CH340) — no `enable_uart`, no disabling the serial console:
+
+1. **PS1 → 3.3 V** on the BNO055 so it boots in UART mode (PS0 stays low). Adafruit's board ties both PS pads low for I²C — lift PS1 high.
+2. Wire to the adapter: **BNO SDA(TX) → adapter RX**, **BNO SCL(RX) → adapter TX**, plus **GND** and **3.3 V**.
+3. Plug the adapter into a CM5 USB port — it enumerates as `/dev/ttyUSB*`.
+
+Point the config at it, preferring the stable **by-id** path so it survives replug / enumeration order:
+
+```bash
+ls -l /dev/serial/by-id/
+# usb-Silicon_Labs_CP2102_USB_to_UART_Bridge_Controller_0001-if00-port0 -> ../../ttyUSB0
+```
+
+```json
+"bno055": {
+  "enabled": true,
+  "transport": "uart",
+  "uart_device": "/dev/serial/by-id/usb-Silicon_Labs_CP2102_USB_to_UART_Bridge_Controller_0001-if00-port0",
+  "uart_baud": 115200,
+  "declination_deg": 0.0
+}
+```
+
+> **CP2102 adapters share their USB id (`10c4:ea60`) with the SmartKnob**, so a plain `/dev/ttyUSB0` can swap between the two across reboots. The by-id path keys on the adapter's serial and stays put. For a fixed `/dev/bno055` symlink instead, see the commented template in `scripts/install.sh` (match on `ATTRS{serial}`).
+
+Everything downstream is identical to I²C — on-chip fusion, the same calibration flow, and **Auto** still prefers BNO055.
+
 ### Menu trail
 
 ```
@@ -1514,6 +1543,7 @@ Faces (PNGs created via the in-HUD pixel editor) are **stamped** with the active
       "panel_size": "64x32",
       "arrangement": "horizontal",
       "panel_count": 2,
+      "pinout": "adafruit_bonnet",
       "panel_size_per": ["", "", "", ""],
       "nudge_dx":  [-64, 64, 0, 0],
       "nudge_dy":  [0, 0, 0, 0],
@@ -1524,6 +1554,19 @@ Faces (PNGs created via the in-HUD pixel editor) are **stamped** with the active
 ```
 
 Legacy single-block configs (`cfg["protoface"]["hub75"]`) migrate to `hub75_layouts["Default"]` on first load.
+
+### Bonnet / pinout
+
+`pinout` selects how the panels are wired to the Pi — it sets both the piomatter pinout **and** the geometry/mapper in `scripts/panel_driver.py`:
+
+| `pinout` | Board | Geometry |
+|----------|-------|----------|
+| `adafruit_bonnet` *(default)* | Single-connector **Adafruit RGB Matrix Bonnet / HAT** | One output; panels daisy-chained (serpentine for multi-row). Plain `Geometry(width, height, n_addr_lines)` |
+| `active3` | Triple-connector **Active-3** board | Up to 3 parallel chains sharing address lines via the multilane mapper |
+
+Append `_bgr` (e.g. `adafruit_bonnet_bgr`) if red and blue come out swapped.
+
+> **Single connector = one chain.** The Adafruit bonnet has a single HUB75 output, so `parallel` collapses to 1 (multi-row builds are wired **serpentine** and the geometry stacks them by height). The Active-3 board is the only one that drives genuine parallel lanes. The `arrangement` / `panel_count` you set above feed the driver's `--chain`/`--parallel` automatically, so just pick the layout and the right `pinout`.
 
 ### Pixel editor extras (MAX7219 / RGB matrix)
 

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -209,6 +209,14 @@
     "_panel_driver_note": "native mode only: auto-launch scripts/panel_driver.py to drive the HUB75 panels. Set false for preview-only or if you run the driver yourself.",
     "_native_about": "native-mode options: assets_dir points at the Protoface checkout holding faces/materials/gifs (default $HOME/protohud/Protoface); panels overrides the default 2-panel mirrored layout.",
     "assets_dir": "",
+    "hub75": {
+      "_about": "HUB75 panel layout (native mode; drives scripts/panel_driver.py). Edit live in Face > HUB75 Layout. panel_size like '64x32'; arrangement 'horizontal'|'vertical'|'grid2x2'; panel_count 1-4.",
+      "panel_size": "64x32",
+      "arrangement": "horizontal",
+      "panel_count": 2,
+      "pinout": "adafruit_bonnet",
+      "_pinout_note": "HUB75 bonnet wiring: 'adafruit_bonnet' (single-connector Adafruit RGB Matrix Bonnet/HAT, default) or 'active3' (triple-connector Active-3 board). Append '_bgr' (e.g. 'adafruit_bonnet_bgr') if red/blue are swapped. Selects both the piomatter pinout and the geometry/mapper — Active-3 uses the multilane mapper, the Adafruit bonnet a plain serpentine-chained geometry."
+    },
     "preview": {
       "anchor_x": 1.0,
       "anchor_y": 0.0,
@@ -344,7 +352,9 @@
     "_save_calibration_note": "Persist the chip's calibration profile to bno055_calib.bin (next to this file) so it survives reboots. Restored automatically at startup; saved on demand via Compass > Save IMU Calibration, and auto-saved once the chip first reaches full calibration (sys 3/3) if no file exists yet. Calibrate by rotating the head through several orientations + a figure-8 for the magnetometer until all four values read 3.",
     "transport": "i2c",
     "_transport_note": "'i2c' (default) or 'uart'. UART sidesteps the Pi's I2C clock-stretch problem entirely (Adafruit's recommended path on a Pi). UART setup: (1) solder the PS1 jumper to 3.3V so the chip boots in UART mode (SCL/SDA become RX/TX); (2) wire BNO SDA(TX)->Pi RXD, SCL(RX)->Pi TXD, PS1->3.3V; (3) free the serial port: add 'enable_uart=1' to /boot/firmware/config.txt, disable the serial login console (raspi-config > Interface > Serial > login shell No) and 'sudo systemctl disable serial-getty@ttyAMA0'. On CM5/Pi5, prefer a dedicated RP1 UART via dtoverlay so you don't fight Bluetooth; set uart_device to that port.",
+    "_uart_usb_note": "Easiest UART route: a USB-UART adapter (FTDI/CP2102/CH340) instead of the Pi's hardware UART — no enable_uart, no disabling the serial console. Still set PS1->3.3V on the BNO so it boots in UART mode, then wire BNO SDA(TX)->adapter RX, SCL(RX)->adapter TX, GND, 3.3V. The adapter enumerates as /dev/ttyUSB* — point uart_device at it (see _uart_device_note).",
     "uart_device": "/dev/ttyAMA0",
+    "_uart_device_note": "Serial port for transport:'uart'. Pi hardware UART = /dev/ttyAMA0 (or your RP1 dtoverlay port). USB-UART adapter = its /dev/ttyUSB* — but prefer the stable by-id path so it survives replug/enumeration order, e.g. /dev/serial/by-id/usb-Silicon_Labs_CP2102_USB_to_UART_Bridge_Controller_XXXX-if00-port0 (run `ls -l /dev/serial/by-id/` to find yours). A CP2102 adapter shares its USB VID:PID with the SmartKnob, so the by-id path (keyed on the adapter's serial) avoids a /dev/ttyUSBn mix-up.",
     "uart_baud": 115200
   },
   "post_process": {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -317,6 +317,21 @@ SUBSYSTEM=="tty", ATTRS{idVendor}=="239a", \
 SUBSYSTEM=="tty", ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="7523", \
     SYMLINK+="lora", MODE="0660", GROUP="dialout"
 
+# BNO055 IMU on a USB-UART adapter (optional) — for a stable /dev/bno055.
+# Most adapters are CP2102 (10c4:ea60), which COLLIDES with the SmartKnob rule
+# above (same VID:PID), so match the adapter's SERIAL instead. Find it with:
+#   udevadm info -a -n /dev/ttyUSB0 | grep '{serial}' | head -1
+# then uncomment + fill SERIAL below. If your SmartKnob is ALSO a CP2102, add the
+# same ATTRS{serial} guard to its rule so the two don't cross-link.
+# Simpler alternative (no udev): set bno055.uart_device in config.json to the
+# /dev/serial/by-id/usb-Silicon_Labs_CP2102_..._<serial>-if00-port0 path.
+#SUBSYSTEM=="tty", ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="ea60", \
+#    ATTRS{serial}=="REPLACE_WITH_BNO_ADAPTER_SERIAL", \
+#    SYMLINK+="bno055", MODE="0660", GROUP="dialout"
+# FTDI adapter (0403:6001) instead? It doesn't collide — use this:
+#SUBSYSTEM=="tty", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6001", \
+#    SYMLINK+="bno055", MODE="0660", GROUP="dialout"
+
 # USB cameras — readable by video group
 SUBSYSTEM=="video4linux", MODE="0660", GROUP="video"
 

--- a/scripts/panel_driver.py
+++ b/scripts/panel_driver.py
@@ -14,7 +14,7 @@ Shared-memory format (matches src/serial/shm_frame_reader.h / ShmPusherOutput):
 
 Usage: panel_driver.py [--canvas-w 128] [--canvas-h 32]
                        [--panel-w 64] [--panel-h 32] [--chain 2] [--parallel 1]
-                       [--shm /dev/shm/protoface_frame]
+                       [--pinout adafruit_bonnet] [--shm /dev/shm/protoface_frame]
 """
 
 import argparse
@@ -29,6 +29,17 @@ import adafruit_blinka_raspberry_pi5_piomatter as piomatter
 from adafruit_blinka_raspberry_pi5_piomatter.pixelmappers import simple_multilane_mapper
 
 
+# HUB75 bonnet wiring → piomatter pinout. "adafruit_bonnet" is the single-
+# connector Adafruit RGB Matrix Bonnet/HAT; "active3" is the triple-connector
+# Active-3 board. *_bgr swaps the panel's red/blue channel order.
+PINOUTS = {
+    'adafruit_bonnet':     piomatter.Pinout.AdafruitMatrixBonnet,
+    'adafruit_bonnet_bgr': piomatter.Pinout.AdafruitMatrixBonnetBGR,
+    'active3':             piomatter.Pinout.Active3,
+    'active3_bgr':         piomatter.Pinout.Active3BGR,
+}
+
+
 def addr_lines(panel_h: int) -> int:
     return (panel_h // 2).bit_length() - 1
 
@@ -41,6 +52,10 @@ def main():
     ap.add_argument('--panel-h', type=int, default=32)
     ap.add_argument('--chain', type=int, default=2)
     ap.add_argument('--parallel', type=int, default=1)
+    ap.add_argument('--pinout', default='adafruit_bonnet', choices=sorted(PINOUTS),
+                    help='HUB75 bonnet wiring: adafruit_bonnet (single-connector '
+                         'Adafruit bonnet/HAT, default) or active3 (triple-connector); '
+                         '*_bgr swaps red/blue')
     ap.add_argument('--shm', default='/dev/shm/protoface_frame')
     ap.add_argument('--fps', type=float, default=60.0, help='poll rate cap')
     args = ap.parse_args()
@@ -48,20 +63,33 @@ def main():
     W, H = args.canvas_w, args.canvas_h
     size = 1 + W * H * 3
     print(f"[panel_driver] starting: canvas {W}x{H}, panel {args.panel_w}x{args.panel_h}, "
-          f"chain {args.chain}, parallel {args.parallel}, shm {args.shm}", flush=True)
+          f"chain {args.chain}, parallel {args.parallel}, pinout {args.pinout}, "
+          f"shm {args.shm}", flush=True)
 
-    # Piomatter geometry — identical to Protoface's hub75.py.
+    # Piomatter geometry depends on the bonnet. The Active-3 board drives parallel
+    # chains that share address lines, so it needs the multilane mapper. The
+    # single-connector Adafruit bonnet has one output with the panels daisy-
+    # chained (serpentine for multi-row), so it uses a plain geometry whose
+    # width/height are the physical canvas dimensions.
     n_addr  = addr_lines(args.panel_h)
-    n_lanes = 2 * args.parallel
-    width   = args.panel_w * args.chain
-    height  = n_lanes << n_addr
-    pixelmap = simple_multilane_mapper(width, height, n_addr, n_lanes)
-    geometry = piomatter.Geometry(width=width, height=height, n_addr_lines=n_addr,
-                                  n_planes=10, n_temporal_planes=4,
-                                  map=pixelmap, n_lanes=n_lanes)
+    if args.pinout.startswith('active3'):
+        n_lanes  = 2 * args.parallel
+        width    = args.panel_w * args.chain
+        height   = n_lanes << n_addr
+        pixelmap = simple_multilane_mapper(width, height, n_addr, n_lanes)
+        geometry = piomatter.Geometry(width=width, height=height, n_addr_lines=n_addr,
+                                      n_planes=10, n_temporal_planes=4,
+                                      map=pixelmap, n_lanes=n_lanes)
+        chan = [1, 2, 0]    # Active-3 panels display R->G->B rotated; resend (G,B,R)
+    else:
+        width    = args.panel_w * args.chain
+        height   = args.panel_h * args.parallel
+        geometry = piomatter.Geometry(width=width, height=height, n_addr_lines=n_addr,
+                                      rotation=piomatter.Orientation.Normal)
+        chan = [0, 1, 2]    # straight RGB; switch to *_bgr pinout if red/blue swap
     fb = np.zeros((height, width, 3), dtype=np.uint8)
     matrix = piomatter.PioMatter(colorspace=piomatter.Colorspace.RGB888Packed,
-                                 pinout=piomatter.Pinout.Active3,
+                                 pinout=PINOUTS[args.pinout],
                                  framebuffer=fb, geometry=geometry)
     print("[panel_driver] piomatter ready", flush=True)
 
@@ -100,8 +128,9 @@ def main():
                 last_seq = seq
                 buf = np.frombuffer(mm, dtype=np.uint8, count=W * H * 3, offset=1)
                 frame = buf.reshape((H, W, 3))
-                # Panels display R->G->B rotated; resend as (G,B,R) to correct.
-                fb[:copy_h, :copy_w] = frame[:copy_h, :copy_w, [1, 2, 0]]
+                # Channel order is per-bonnet (see chan above): Active-3 needs a
+                # (G,B,R) rotate; the Adafruit bonnet takes straight RGB.
+                fb[:copy_h, :copy_w] = frame[:copy_h, :copy_w, chan]
                 matrix.show()
             time.sleep(period)
     finally:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -238,7 +238,8 @@ static float pick_imu_heading(const AppState& s, int64_t now_us) {
 static void pf_launch_panel_driver(const std::string& bin_dir,
                                    int canvas_w, int canvas_h,
                                    int panel_w = 64, int panel_h = 32,
-                                   int chain = 2, int parallel = 1) {
+                                   int chain = 2, int parallel = 1,
+                                   const std::string& pinout = "adafruit_bonnet") {
     std::string drv = bin_dir + "/../scripts/panel_driver.py";
     std::string cw  = std::to_string(canvas_w);
     std::string chh = std::to_string(canvas_h);
@@ -275,6 +276,7 @@ static void pf_launch_panel_driver(const std::string& bin_dir,
                "--canvas-w", cw.c_str(), "--canvas-h", chh.c_str(),
                "--panel-w", pw.c_str(), "--panel-h", ph.c_str(),
                "--chain", ch.c_str(), "--parallel", par.c_str(),
+               "--pinout", pinout.c_str(),
                static_cast<char*>(nullptr));
         _exit(127);
     }
@@ -316,6 +318,11 @@ struct PfHub75Layout {
     std::string panel_size      = "64x32";
     std::string arrangement     = "horizontal"; // horizontal / vertical / grid2x2
     int         panel_count     = 1;            // 1..4
+    // HUB75 bonnet wiring → piomatter pinout + geometry (scripts/panel_driver.py).
+    // "adafruit_bonnet" = the single-connector Adafruit RGB Matrix Bonnet/HAT
+    // (default; plain serpentine-chained geometry). "active3" = the triple-
+    // connector Active-3 board (multilane mapper). *_bgr variants swap R/B.
+    std::string pinout          = "adafruit_bonnet";
     std::string panel_size_per[4] = {"", "", "", ""};
     // Nudge stores each panel's CENTRE as an offset from the canvas centre
     // (in canvas pixels). Default = auto-placed by apply_defaults() per
@@ -11584,6 +11591,7 @@ int main(int argc, char* argv[]) {
             L.panel_size  = jh.value("panel_size",  L.panel_size);
             L.arrangement = jh.value("arrangement", L.arrangement);
             L.panel_count = jval(jh, "panel_count", L.panel_count);
+            L.pinout      = jh.value("pinout",      L.pinout);
             if (jh.contains("panel_size_per") && jh["panel_size_per"].is_array())
                 for (size_t i = 0; i < jh["panel_size_per"].size() && i < 4; ++i)
                     if (jh["panel_size_per"][i].is_string())
@@ -12713,7 +12721,7 @@ int main(int argc, char* argv[]) {
             int gpw = 64, gph = 32, gchain = 2, gpar = 1;
             pf_hub75_driver_geometry(pf_hub75, gpw, gph, gchain, gpar);
             pf_launch_panel_driver(bin_dir, rc.canvas_w, rc.canvas_h,
-                                   gpw, gph, gchain, gpar);
+                                   gpw, gph, gchain, gpar, pf_hub75.pinout);
         }
     } else {
         // Auto-start the Protoface daemon on boot (no-op if already running). The
@@ -12971,7 +12979,7 @@ int main(int argc, char* argv[]) {
             int gpw = 64, gph = 32, gchain = 2, gpar = 1;
             pf_hub75_driver_geometry(pf_hub75, gpw, gph, gchain, gpar);
             pf_launch_panel_driver(bin_dir, rc.canvas_w, rc.canvas_h,
-                                   gpw, gph, gchain, gpar);
+                                   gpw, gph, gchain, gpar, pf_hub75.pinout);
         }
     };
 
@@ -13468,7 +13476,7 @@ int main(int argc, char* argv[]) {
                                    // pf_launch_panel_driver now stops the old driver, waits for it
                                    // to release the PIO/DMA, then relaunches (see its comment).
                                    pf_launch_panel_driver(bin_dir, native_ctrl->canvas_width(),
-                                       native_ctrl->canvas_height(), gpw, gph, gchain, gpar);
+                                       native_ctrl->canvas_height(), gpw, gph, gchain, gpar, pf_hub75.pinout);
                                    Notification n; n.type = NotifType::App;
                                    n.title = "Panel driver restarted";
                                    n.body  = "If panels stay dark, check /tmp/panel_driver.log";
@@ -14284,6 +14292,7 @@ int main(int argc, char* argv[]) {
             jh["panel_size"]       = L.panel_size;
             jh["arrangement"]      = L.arrangement;
             jh["panel_count"]      = L.panel_count;
+            jh["pinout"]           = L.pinout;
             jh["panel_size_per"]   = json::array({L.panel_size_per[0], L.panel_size_per[1],
                                                   L.panel_size_per[2], L.panel_size_per[3]});
             jh["defaults_applied"] = L.defaults_applied;


### PR DESCRIPTION
two hardware updates, now that the BNO055 is on a USB-UART adapter and the
single-connector RGB Matrix Bonnet is in.

## BNO055 over USB-UART
the driver already speaks UART, so this is mostly the easy-setup path for a
USB-serial adapter (no `enable_uart` / serial-console disabling that the Pi's
hardware UART needs):
- README: a "Over a USB-UART adapter" section - PS1->3.3V, BNO TX/RX -> adapter
  RX/TX, point `uart_device` at it
- config notes: `_uart_usb_note` + `_uart_device_note`, recommending the stable
  `/dev/serial/by-id/...` path
- `install.sh`: a commented `/dev/bno055` udev template

⚠️ the adapter is a **CP2102 (`10c4:ea60`)**, which shares its USB id with the
SmartKnob rule - so a plain `/dev/ttyUSB0` can swap between them across reboots.
The by-id path keys on the adapter's serial and stays put; the udev template
matches `ATTRS{serial}` if you want a fixed `/dev/bno055`.

## Single-connector RGB Matrix Bonnet
`panel_driver.py` was hardcoded to `Pinout.Active3` (triple-connector) + the
multilane mapper. Made the bonnet configurable:
- `panel_driver.py`: new `--pinout` (`adafruit_bonnet` default, `active3`, + `_bgr`
  variants). The single bonnet uses a plain serpentine-chained geometry; active3
  keeps the multilane mapper. Channel order is per-bonnet (active3 needs the
  (G,B,R) rotate; the adafruit bonnet takes straight RGB - flip to `_bgr` if red
  and blue swap).
- `main.cpp`: `pinout` is a `PfHub75Layout` field, parsed + saved with the layout
  and passed through `pf_launch_panel_driver`. chain/parallel still come from the
  existing layout config.
- `config.example.json` + README: document the field + the geometry difference.

## not tested
not compiled - done on the windows box which can't build protohud. needs a
cmake/ninja build on the pi. `panel_driver.py` syntax + `config.example.json`
validated here.

## on-Pi steps
- BNO055: set `bno055.transport: "uart"` + `uart_device` (by-id path) in your
  config.json
- bonnet: `protoface.hub75.pinout: "adafruit_bonnet"` (default) - pick the layout
  in Face > HUB75 Layout as usual
