### PR TITLE
Star field effects + configurable glitch post-effect

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -319,6 +319,7 @@ add_library(protoface_native STATIC EXCLUDE_FROM_ALL
     src/face/renderer.cpp
     src/face/face_loader.cpp
     src/face/particles.cpp
+    src/face/glitch.cpp
     src/face/gif_player.cpp
     src/face/eye_animations.cpp
     src/face/shm_pusher_output.cpp

--- a/src/face/glitch.cpp
+++ b/src/face/glitch.cpp
@@ -1,0 +1,213 @@
+#include "glitch.h"
+
+#include <opencv2/imgproc.hpp>
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <vector>
+
+namespace face {
+namespace {
+
+constexpr double kPi = 3.14159265358979323846;
+
+// Shift a horizontal band [y0,y1) of an RGB image sideways by dx, filling the
+// vacated edge with black (signal-loss feel). Self-overlap safe (clones first).
+void shift_rows(cv::Mat& img, int y0, int y1, int dx) {
+    y0 = std::max(0, y0);
+    y1 = std::min(img.rows, y1);
+    if (y1 <= y0 || dx == 0) return;
+    const int W = img.cols;
+    if (std::abs(dx) >= W) { img.rowRange(y0, y1).setTo(cv::Scalar(0, 0, 0)); return; }
+    cv::Mat band = img.rowRange(y0, y1).clone();
+    cv::Mat dst  = img.rowRange(y0, y1);
+    dst.setTo(cv::Scalar(0, 0, 0));
+    if (dx > 0) band.colRange(0, W - dx).copyTo(dst.colRange(dx, W));
+    else        band.colRange(-dx, W).copyTo(dst.colRange(0, W + dx));
+}
+
+// Horizontally shift a single-channel image by dx into a fresh black image.
+cv::Mat hshift(const cv::Mat& src, int dx) {
+    if (dx == 0) return src.clone();
+    cv::Mat out = cv::Mat::zeros(src.size(), src.type());
+    const int W = src.cols;
+    if (std::abs(dx) >= W) return out;
+    if (dx > 0) src.colRange(0, W - dx).copyTo(out.colRange(dx, W));
+    else        src.colRange(-dx, W).copyTo(out.colRange(0, W + dx));
+    return out;
+}
+
+} // namespace
+
+nlohmann::json GlitchConfig::to_json() const {
+    return nlohmann::json{
+        {"enabled", enabled}, {"intensity", intensity},
+        {"burst_rate", burst_rate}, {"burst_min", burst_min}, {"burst_max", burst_max},
+        {"chromatic", chromatic}, {"tearing", tearing}, {"blocks", blocks},
+        {"bitcrush", bitcrush}, {"dropout", dropout}, {"datamosh", datamosh},
+        {"region_desync", region_desync}, {"expr_flicker", expr_flicker},
+    };
+}
+
+GlitchConfig GlitchConfig::from_json(const nlohmann::json& j) {
+    GlitchConfig c;
+    if (!j.is_object()) return c;
+    c.enabled       = j.value("enabled",       c.enabled);
+    c.intensity     = j.value("intensity",     c.intensity);
+    c.burst_rate    = j.value("burst_rate",    c.burst_rate);
+    c.burst_min     = j.value("burst_min",     c.burst_min);
+    c.burst_max     = j.value("burst_max",     c.burst_max);
+    c.chromatic     = j.value("chromatic",     c.chromatic);
+    c.tearing       = j.value("tearing",       c.tearing);
+    c.blocks        = j.value("blocks",        c.blocks);
+    c.bitcrush      = j.value("bitcrush",      c.bitcrush);
+    c.dropout       = j.value("dropout",       c.dropout);
+    c.datamosh      = j.value("datamosh",      c.datamosh);
+    c.region_desync = j.value("region_desync", c.region_desync);
+    c.expr_flicker  = j.value("expr_flicker",  c.expr_flicker);
+    return c;
+}
+
+GlitchEffect::GlitchEffect()
+    : rng_(static_cast<uint32_t>(
+          std::chrono::steady_clock::now().time_since_epoch().count())) {}
+
+double GlitchEffect::rnd(double lo, double hi) {
+    std::uniform_real_distribution<double> d(lo, hi);
+    return d(rng_);
+}
+
+void GlitchEffect::tick(double dt, const GlitchConfig& cfg) {
+    flicker_expr_ = false;
+    if (!cfg.enabled || cfg.intensity <= 0.0) { env_ = 0.0; return; }
+
+    if (cfg.burst_rate <= 0.0) {
+        env_ = 1.0;                                  // constant-on
+    } else if (burst_left_ > 0.0) {
+        burst_left_ -= dt;
+        // Smooth 0→1→0 over the burst so corruption ramps in and out.
+        const double t = 1.0 - std::clamp(burst_left_ / std::max(1e-3, burst_len_), 0.0, 1.0);
+        env_ = std::sin(t * kPi);
+        if (burst_left_ <= 0.0) { env_ = 0.0; burst_left_ = 0.0; }
+    } else {
+        env_ = 0.0;
+        next_in_ -= dt;
+        if (next_in_ <= 0.0) {
+            burst_len_  = rnd(cfg.burst_min, std::max(cfg.burst_min, cfg.burst_max));
+            burst_left_ = burst_len_;
+            // Poisson-style gap: -ln(u)/rate, plus the burst's own length.
+            const double u = std::max(1e-4, rnd(0.0, 1.0));
+            next_in_ = burst_len_ - std::log(u) / std::max(1e-3, cfg.burst_rate);
+        }
+    }
+
+    // Expression flicker: sample only well inside an active burst.
+    if (env_ > 0.2 && cfg.expr_flicker > 0.0 &&
+        rnd(0.0, 1.0) < cfg.expr_flicker * env_ * 0.4) {
+        flicker_expr_ = true;
+        flicker_pick_ = rnd(0.0, 1.0);
+    }
+}
+
+void GlitchEffect::apply(cv::Mat& rgb, const GlitchConfig& cfg) {
+    if (rgb.empty() || rgb.type() != CV_8UC3) return;
+    const double s = env_ * cfg.intensity;
+    if (s <= 1e-3) { rgb.copyTo(prev_); return; }
+
+    const int W = rgb.cols, H = rgb.rows;
+
+    // datamosh smears the *clean* previous frame, so stash a clean copy first.
+    cv::Mat clean;
+    if (cfg.datamosh > 0.0) rgb.copyTo(clean);
+
+    // 1. Region desync — split into eyes(top) / mouth(bottom) and slip each
+    //    band independently. Eyes sit in the upper ~60% of these faces.
+    if (cfg.region_desync > 0.0) {
+        const int amp = static_cast<int>(std::round(cfg.region_desync * s * W * 0.12));
+        if (amp > 0) {
+            const int split = std::max(1, static_cast<int>(std::round(H * 0.62)));
+            shift_rows(rgb, 0, split, static_cast<int>(std::round(rnd(-amp, amp))));
+            shift_rows(rgb, split, H, static_cast<int>(std::round(rnd(-amp, amp))));
+        }
+    }
+
+    // 2. Tearing — a handful of horizontal bands shoved sideways.
+    if (cfg.tearing > 0.0) {
+        const int bands = 1 + static_cast<int>(cfg.tearing * s * 6.0);
+        const int amp   = std::max(1, static_cast<int>(std::round(cfg.tearing * s * W * 0.18)));
+        for (int i = 0; i < bands; ++i) {
+            const int y0 = static_cast<int>(rnd(0, H - 1));
+            const int bh = 1 + static_cast<int>(rnd(1, std::max(2.0, H * 0.18)));
+            shift_rows(rgb, y0, y0 + bh, static_cast<int>(std::round(rnd(-amp, amp))));
+        }
+    }
+
+    // 3. Block shuffle — copy random source blocks over destination blocks.
+    if (cfg.blocks > 0.0) {
+        const int n = 1 + static_cast<int>(cfg.blocks * s * 8.0);
+        const int jit = std::max(1, static_cast<int>(std::round(cfg.blocks * s * W * 0.15)));
+        for (int i = 0; i < n; ++i) {
+            const int bw = std::max(2, static_cast<int>(rnd(3, std::max(4.0, W * 0.2))));
+            const int bh = std::max(2, static_cast<int>(rnd(2, std::max(3.0, H * 0.5))));
+            const int dx = static_cast<int>(rnd(0, std::max(1, W - bw)));
+            const int dy = static_cast<int>(rnd(0, std::max(1, H - bh)));
+            const int sx = std::clamp(dx + static_cast<int>(std::round(rnd(-jit, jit))),
+                                      0, std::max(0, W - bw));
+            const int sy = std::clamp(dy + static_cast<int>(std::round(rnd(-2.0, 2.0))),
+                                      0, std::max(0, H - bh));
+            cv::Mat blk = rgb(cv::Rect(sx, sy, bw, bh)).clone();
+            blk.copyTo(rgb(cv::Rect(dx, dy, bw, bh)));
+        }
+    }
+
+    // 4. Chromatic split — shove the R and B planes apart (canvas is RGB, so
+    //    channel 0 = R, channel 2 = B).
+    if (cfg.chromatic > 0.0) {
+        const int off = std::max(1, static_cast<int>(std::round(cfg.chromatic * s * 4.0)));
+        std::vector<cv::Mat> ch;
+        cv::split(rgb, ch);
+        ch[0] = hshift(ch[0],  off);
+        ch[2] = hshift(ch[2], -off);
+        cv::merge(ch, rgb);
+    }
+
+    // 5. Bitcrush — posterise colour depth (8 levels → 2 as the amount rises).
+    if (cfg.bitcrush > 0.0) {
+        const int levels = std::clamp(static_cast<int>(std::round(8.0 - cfg.bitcrush * s * 6.0)), 2, 8);
+        const double q = 255.0 / (levels - 1);
+        rgb.forEach<cv::Vec3b>([q](cv::Vec3b& p, const int*) {
+            for (int k = 0; k < 3; ++k)
+                p[k] = static_cast<uchar>(std::clamp(
+                    static_cast<int>(std::round(std::round(p[k] / q) * q)), 0, 255));
+        });
+    }
+
+    // 6. Dropout — random horizontal bars go black or full static.
+    if (cfg.dropout > 0.0) {
+        const int n = static_cast<int>(cfg.dropout * s * 4.0);
+        for (int i = 0; i < n; ++i) {
+            const int y0 = static_cast<int>(rnd(0, H - 1));
+            const int bh = 1 + static_cast<int>(rnd(1, std::max(2.0, H * 0.12)));
+            cv::Mat band = rgb.rowRange(y0, std::min(H, y0 + bh));
+            if (rnd(0.0, 1.0) < 0.5) {
+                band.setTo(cv::Scalar(0, 0, 0));
+            } else {
+                cv::Mat noise(band.size(), CV_8UC3);
+                cv::randu(noise, cv::Scalar(0, 0, 0), cv::Scalar(255, 255, 255));
+                noise.copyTo(band);
+            }
+        }
+    }
+
+    // 7. Datamosh — blend in a ghost of the previous clean frame.
+    if (cfg.datamosh > 0.0 && !prev_.empty() &&
+        prev_.size() == rgb.size() && prev_.type() == rgb.type()) {
+        const double a = std::clamp(cfg.datamosh * s * 0.8, 0.0, 0.95);
+        cv::addWeighted(prev_, a, rgb, 1.0 - a, 0.0, rgb);
+    }
+    if (cfg.datamosh > 0.0) clean.copyTo(prev_);
+    else                    rgb.copyTo(prev_);
+}
+
+} // namespace face

--- a/src/face/glitch.h
+++ b/src/face/glitch.h
@@ -1,0 +1,81 @@
+#pragma once
+// ── glitch.h ───────────────────────────────────────────────────────────────────
+// CPU "glitch" post-effect for the native face. ONE overall effect whose
+// individual looks are exposed as independent 0..1 variables, wrapped by a
+// master `intensity` and a burst (on/off) envelope so the corruption stutters
+// in bursts rather than running flat.
+//
+// Most components run frame-level on the composited RGB canvas (chromatic
+// split, band tearing, block shuffle, bitcrush, dropout bars, datamosh smear,
+// eyes/mouth region desync). One component — expression flicker — can't be
+// faked from pixels, so tick() raises a flag the controller reads at the face
+// stage to flash a different expression image for that frame.
+//
+// Threading: a single GlitchEffect instance is owned and driven by the
+// NativeFaceController render thread; only its config is set from other
+// threads (copied under the controller's mutex).
+
+#include <cstdint>
+#include <random>
+
+#include <opencv2/core.hpp>
+#include <nlohmann/json.hpp>
+
+namespace face {
+
+struct GlitchConfig {
+    bool   enabled    = false;
+    double intensity  = 1.0;   // master scale over every component (0..2)
+
+    // Burst timing. burst_rate <= 0 => always-on (constant glitch).
+    double burst_rate = 0.4;   // average bursts per second
+    double burst_min  = 0.08;  // burst length seconds
+    double burst_max  = 0.30;
+
+    // Per-component amounts (0 = off, 1 = full).
+    double chromatic     = 0.5;  // RGB channel split / chromatic aberration
+    double tearing       = 0.6;  // horizontal band displacement (VHS tracking)
+    double blocks        = 0.3;  // rectangular block shuffle (macroblock rot)
+    double bitcrush      = 0.0;  // colour-depth posterise
+    double dropout       = 0.0;  // signal-loss bars (black / static)
+    double datamosh      = 0.0;  // frame freeze / smear (ghost of prev frame)
+    double region_desync = 0.3;  // eyes(top) vs mouth(bottom) band slip
+    double expr_flicker  = 0.0;  // chance to flash a wrong expression
+
+    nlohmann::json to_json() const;
+    static GlitchConfig from_json(const nlohmann::json& j);
+};
+
+class GlitchEffect {
+public:
+    GlitchEffect();
+
+    // Advance the burst envelope once per frame (call before the panel loop).
+    void tick(double dt, const GlitchConfig& cfg);
+
+    double envelope() const { return env_; }      // 0..1 current burst strength
+    bool   active()   const { return env_ > 1e-3; }
+
+    // True this frame when a wrong-expression flash should be shown (sampled in
+    // tick from cfg.expr_flicker). flicker_pick() is a stable [0,1) selector so
+    // every panel flashes the SAME alternate expression in a given frame.
+    bool   flicker_expr() const { return flicker_expr_; }
+    double flicker_pick() const { return flicker_pick_; }
+
+    // Apply the frame-level glitch to an 8UC3 RGB image, in place.
+    void apply(cv::Mat& rgb, const GlitchConfig& cfg);
+
+private:
+    double rnd(double lo, double hi);
+
+    std::mt19937 rng_;
+    double env_          = 0.0;   // current burst envelope 0..1
+    double burst_left_   = 0.0;   // seconds remaining in the active burst
+    double burst_len_    = 0.0;   // total length of the active burst
+    double next_in_      = 0.0;   // seconds until the next burst starts
+    bool   flicker_expr_ = false;
+    double flicker_pick_ = 0.0;
+    cv::Mat prev_;                // previous clean frame, for datamosh smear
+};
+
+} // namespace face

--- a/src/face/native_face_controller.cpp
+++ b/src/face/native_face_controller.cpp
@@ -42,6 +42,11 @@ nlohmann::json effect_cfg_for_id(int id) {
         case 15: return nlohmann::json{{"preset", "party"}};
         case 16: return std::string("clouds");
         case 17: return nlohmann::json{{"preset", "nebula"}};
+        case 18: return nlohmann::json{{"preset", "starfield"}};
+        case 19: return nlohmann::json{{"preset", "warp"}};
+        case 20: return nlohmann::json{{"preset", "constellation"}};
+        case 21: return nlohmann::json{{"preset", "shooting_stars"}};
+        case 22: return nlohmann::json{{"preset", "night_sky"}};
         default: return std::string("none");
     }
 }

--- a/src/face/native_face_controller.cpp
+++ b/src/face/native_face_controller.cpp
@@ -197,6 +197,10 @@ void NativeFaceController::render_thread() {
             const bool eye_active = eye_anim_timer_ > 0.0;
             if (eye_active) { eye_anim_timer_ -= dt; eye_anim_t_ += dt; }
 
+            // Advance the glitch burst envelope once per frame so every panel
+            // (and both eyes) corrupts identically this tick.
+            glitch_.tick(dt, glitch_cfg_);
+
             // Expire any transient face overlays whose deadline has passed —
             // restore the original expression image to the loader and drop
             // the record. Done before render so this tick uses the restored
@@ -218,6 +222,21 @@ void NativeFaceController::render_thread() {
                     }
                 }
             }
+
+            // When the glitch fires an expression flash this frame, swap the
+            // rendered face for a different expression's raw image — same pick
+            // for every panel so both eyes flash the same wrong expression.
+            auto glitch_flicker = [&](FaceLoader* loader, FaceState* st, cv::Mat& face) {
+                if (!glitch_cfg_.enabled || !glitch_.flicker_expr() || !loader || !st) return;
+                const auto& names = loader->expression_names();
+                if (names.size() < 2) return;
+                int idx = std::min<int>(static_cast<int>(names.size()) - 1,
+                                        static_cast<int>(glitch_.flicker_pick() * names.size()));
+                if (names[idx] == st->expression())
+                    idx = (idx + 1) % static_cast<int>(names.size());
+                cv::Mat alt = loader->get_expression_image(names[idx]);
+                if (!alt.empty() && alt.size() == face.size()) face = alt;
+            };
 
             // Render each self-rendering panel into its region.
             for (auto& pn : panels_) {
@@ -277,9 +296,11 @@ void NativeFaceController::render_thread() {
                     }
                 } else if (!cfg_.effects_enabled || !pn.material) {
                     face_layer = pn.loader->get_frame(*pn.state);
+                    glitch_flicker(pn.loader.get(), pn.state.get(), face_layer);
                 } else {
                     cv::Mat mat = pn.material->get_frame();
                     cv::Mat face_rgba = pn.loader->get_frame(*pn.state);
+                    glitch_flicker(pn.loader.get(), pn.state.get(), face_rgba);
                     face_layer = apply_material(face_rgba, mat);
                 }
 
@@ -349,6 +370,10 @@ void NativeFaceController::render_thread() {
                 cv::flip(region, flipped, code);
                 flipped.copyTo(region);
             }
+
+            // Glitch post-effect: corrupt the fully-composited face canvas in a
+            // single pass so it reads as one signal glitch across the whole face.
+            if (glitch_cfg_.enabled) glitch_.apply(canvas, glitch_cfg_);
         }
 
         {
@@ -896,6 +921,11 @@ void NativeFaceController::set_wiggle(const WiggleCfg& w) {
     std::lock_guard<std::mutex> lk(state_mtx_);
     for (auto& pn : panels_)
         if (pn.state) pn.state->set_wiggle(w);
+}
+
+void NativeFaceController::set_glitch(const GlitchConfig& cfg) {
+    std::lock_guard<std::mutex> lk(state_mtx_);
+    glitch_cfg_ = cfg;
 }
 
 void NativeFaceController::set_audio_drive(double volume, double mouth_open) {

--- a/src/face/native_face_controller.h
+++ b/src/face/native_face_controller.h
@@ -23,6 +23,7 @@
 #include "../serial/face_controller.h"
 #include "eye_anim.h"
 #include "face_config.h"
+#include "glitch.h"         // GlitchEffect + GlitchConfig
 #include "panel_output.h"   // PanelOutput + NamedRegion
 
 namespace face {
@@ -136,6 +137,10 @@ public:
     // to every self-rendered panel and persist it. Used by the Material Color
     // gradient editor for live preview.
     void set_material_spec(const std::string& spec);
+    // Live "glitch" post-effect config — corrupts the composited face (chromatic
+    // split, tearing, blocks, bitcrush, dropout, datamosh, region desync, and an
+    // occasional wrong-expression flash). Read by the render thread each frame.
+    void set_glitch(const GlitchConfig& cfg);
 
     // Push a "transient" image for the named expression onto every panel
     // for duration_s seconds. The current image is stashed and restored
@@ -201,6 +206,11 @@ private:
     EyeAnimParams      eye_anim_;
     double             eye_anim_timer_ = 0.0;   // seconds remaining
     double             eye_anim_t_     = 0.0;   // elapsed seconds (animation phase)
+
+    // Glitch post-effect. glitch_ (sim state) is touched only by the render
+    // thread; glitch_cfg_ is written by set_glitch() under state_mtx_.
+    GlitchEffect       glitch_;
+    GlitchConfig       glitch_cfg_;
 
     // Expression → mood-preset coupling (off by default). expr_effects_ gates
     // it; current_expression_ tracks the latest set face so toggling re-applies

--- a/src/face/particles.cpp
+++ b/src/face/particles.cpp
@@ -1204,6 +1204,232 @@ private:
     std::vector<Particle> bubbles_;
 };
 
+// ── Star field (3-D parallax) ────────────────────────────────────────────────
+// Stars stream outward from the full-canvas centre (the origin) toward the
+// panel edges (the far plane). Each star has a fixed world direction (vx/vy in
+// [-1,1]) and a depth z in `extra`; depth shrinks each frame so the projection
+// screen = centre + dir * fov / z pushes it out, brightening and growing as it
+// "approaches". The centre uses cw_/ch_ (full canvas) so the origin stays put
+// even when the canvas is split across panels; positions convert to panel-local
+// via -ox_/-oy_. Stars recycle to the far depth once they leave the canvas.
+
+class StarfieldEffect : public BaseEffect {
+public:
+    using BaseEffect::BaseEffect;
+    void update(double dt) override {
+        const double cx = cw_ * 0.5, cy = ch_ * 0.5;
+        const double fov = jnum(cfg_, "fov", cw_ * 0.5);
+        const int size_max = jint(cfg_, "size_max", 2);
+        const double zfar = kZFar, znear = znear_();
+        const double span = std::max(1e-3, zfar - znear);
+        for (auto& p : particles_) {
+            p.extra -= p.max_life * dt;          // approach: depth shrinks
+            bool recycle = p.extra <= znear;
+            double gx = 0, gy = 0;
+            if (!recycle) {
+                const double f = fov / p.extra;
+                gx = cx + p.vx * f;
+                gy = cy + p.vy * f;
+                if (gx < -2 || gx > cw_ + 1 || gy < -2 || gy > ch_ + 1) recycle = true;
+            }
+            if (recycle) {
+                respawn(p);
+                const double f = fov / p.extra;
+                gx = cx + p.vx * f;
+                gy = cy + p.vy * f;
+            }
+            p.x = gx - ox_;                      // full-canvas → panel-local
+            p.y = gy - oy_;
+            const double near = std::clamp((zfar - p.extra) / span, 0.0, 1.0);
+            p.life = near;
+            p.size = (size_max > 1 && near > 0.75) ? size_max : 1;
+        }
+        while ((int)particles_.size() < count(70)) particles_.push_back(spawn());
+    }
+    cv::Mat render() override {
+        cv::Mat c = blank();
+        for (const auto& p : particles_)
+            draw_dot(c, p.x, p.y, (int)p.r, (int)p.g, (int)p.b, 0.2 + 0.8 * p.life, p.size);
+        return c;
+    }
+
+protected:
+    static constexpr double kZFar = 8.0;
+    virtual double znear_() const { return 0.55; }
+    virtual void speed_range(double& lo, double& hi) const { lo = 1.2; hi = 3.0; }
+
+    Color pick() {
+        if (has_colors(cfg_)) return pick_color(cfg_, rng_);
+        static const Color pool[4] = {{255,255,255},{200,220,255},{255,240,210},{210,235,255}};
+        return pool[irand(rng_, 0, 3)];
+    }
+    void respawn(Particle& p) {
+        double wx = frand(rng_, -1, 1), wy = frand(rng_, -1, 1);
+        while (std::fabs(wx) < 0.05 && std::fabs(wy) < 0.05) {   // avoid dead centre
+            wx = frand(rng_, -1, 1); wy = frand(rng_, -1, 1);
+        }
+        p.vx = wx; p.vy = wy; p.extra = kZFar;
+        double lo, hi; speed_range(lo, hi);
+        p.max_life = pick_speed(cfg_, lo, hi, rng_);
+        Color col = pick(); p.r = col.r; p.g = col.g; p.b = col.b;
+        p.life = 0;
+    }
+    Particle spawn() {
+        Particle p; respawn(p);
+        p.extra = frand(rng_, znear_() + 0.5, kZFar);   // spread depths on first fill
+        return p;
+    }
+};
+
+// ── Warp (hyperspace) ────────────────────────────────────────────────────────
+// The star field cranked to "jump to lightspeed": faster stars smeared into
+// radial streaks that point back to the centre and lengthen as they near the
+// edge. Reuses the star field's projection/update via inheritance.
+
+class WarpEffect : public StarfieldEffect {
+public:
+    using StarfieldEffect::StarfieldEffect;
+    cv::Mat render() override {
+        cv::Mat c = blank();
+        const double cx = cw_ * 0.5 - ox_, cy = ch_ * 0.5 - oy_;   // panel-local centre
+        const double gain = jnum(cfg_, "streak", 1.0);
+        for (const auto& p : particles_) {
+            const double alpha = 0.25 + 0.75 * p.life;
+            double dx = p.x - cx, dy = p.y - cy;
+            double dist = std::hypot(dx, dy); if (dist < 1e-6) dist = 1.0;
+            const double ux = dx / dist, uy = dy / dist;           // outward unit
+            const double length = (1.0 + p.life * 6.0) * gain;     // longer near edge
+            const int n = std::max(1, (int)length);
+            for (int i = 0; i <= n; ++i) {                         // streak toward centre
+                const double t = (double)i / n;
+                const double a = alpha * (1.0 - t);
+                if (a <= 0) break;
+                draw_dot(c, p.x - ux * length * t, p.y - uy * length * t,
+                         (int)p.r, (int)p.g, (int)p.b, a, i == 0 ? p.size : 1);
+            }
+        }
+        return c;
+    }
+protected:
+    double znear_() const override { return 0.4; }
+    void speed_range(double& lo, double& hi) const override { lo = 2.5; hi = 5.5; }
+};
+
+// ── Constellation (still twinkling sky) ──────────────────────────────────────
+// Fixed stars that breathe brightness on independent phases/rates; a fraction
+// are "bright" and grow a soft cross glint at their peak. Nothing moves off
+// screen, so no centre/edge geometry — stars fill the panel like sparkle.
+
+class ConstellationEffect : public BaseEffect {
+public:
+    using BaseEffect::BaseEffect;
+    void update(double dt) override {
+        // vx = twinkle rate, vy = base brightness, extra = phase, size 2 = bright.
+        for (auto& p : particles_) {
+            p.extra += p.vx * dt;
+            p.life = p.vy * (0.45 + 0.55 * (0.5 + 0.5 * std::sin(p.extra)));
+        }
+        while ((int)particles_.size() < count(50)) {
+            Color col = has_colors(cfg_) ? pick_color(cfg_, rng_) : default_pick();
+            const bool bright = frand(rng_, 0, 1) < jnum(cfg_, "bright_frac", 0.15);
+            Particle p;
+            p.x = frand(rng_, 0, w_ - 1); p.y = frand(rng_, 0, h_ - 1);
+            p.vx = frand(rng_, jnum(cfg_, "twinkle_min", 0.8), jnum(cfg_, "twinkle_max", 3.0));
+            p.vy = bright ? 1.0 : frand(rng_, 0.4, 0.85);
+            p.r = col.r; p.g = col.g; p.b = col.b;
+            p.size = bright ? 2 : 1; p.max_life = 9999; p.life = 1;
+            p.extra = frand(rng_, 0, kTau);
+            particles_.push_back(p);
+        }
+    }
+    cv::Mat render() override {
+        cv::Mat c = blank();
+        for (const auto& p : particles_) {
+            const double alpha = std::clamp(p.life, 0.0, 1.0);
+            const int r = (int)p.r, g = (int)p.g, b = (int)p.b;
+            draw_dot(c, p.x, p.y, r, g, b, alpha, 1);
+            if (p.size >= 2 && alpha > 0.55) {                 // soft cross glint at peak
+                const double a2 = (alpha - 0.55) * 1.5;
+                draw_dot(c, p.x + 1, p.y, r, g, b, a2, 1);
+                draw_dot(c, p.x - 1, p.y, r, g, b, a2, 1);
+                draw_dot(c, p.x, p.y + 1, r, g, b, a2, 1);
+                draw_dot(c, p.x, p.y - 1, r, g, b, a2, 1);
+            }
+        }
+        return c;
+    }
+private:
+    Color default_pick() {
+        static const Color pool[4] = {{255,255,255},{200,220,255},{255,240,210},{255,255,235}};
+        return pool[irand(rng_, 0, 3)];
+    }
+};
+
+// ── Shooting stars (meteors from centre) ─────────────────────────────────────
+// Sparse meteors that launch from the full-canvas centre (the origin) out to a
+// panel edge with a fading tail. Distinct from MeteorEffect, which streaks all
+// meteors in one shared direction; here each flies radially from the centre.
+
+class ShootingStarsEffect : public BaseEffect {
+public:
+    using BaseEffect::BaseEffect;
+    void update(double dt) override {
+        const double cx = cw_ * 0.5, cy = ch_ * 0.5;
+        const double tail = jnum(cfg_, "tail", 8.0);
+        for (auto& p : particles_) {
+            p.x += p.vx * dt; p.y += p.vy * dt; p.life -= dt / p.max_life;
+        }
+        particles_.erase(std::remove_if(particles_.begin(), particles_.end(),
+            [&](const Particle& p){
+                const double gx = p.x + ox_, gy = p.y + oy_;       // back to full canvas
+                return !(p.life > 0 && gx >= -tail && gx <= cw_ + tail
+                         && gy >= -tail && gy <= ch_ + tail);
+            }), particles_.end());
+        const double rate = jnum(cfg_, "rate", 0.8) * intensity_;
+        acc_ += dt * rate;
+        const int cap = count(3);
+        while (acc_ >= 1.0) {
+            acc_ -= 1.0;
+            if ((int)particles_.size() < cap) particles_.push_back(spawn(cx, cy));
+        }
+    }
+    cv::Mat render() override {
+        cv::Mat c = blank();
+        const int tail = (int)jnum(cfg_, "tail", 8.0);
+        for (const auto& p : particles_) {
+            const double sp = std::hypot(p.vx, p.vy);
+            if (sp < 1e-3) continue;
+            const double ux = p.vx / sp, uy = p.vy / sp;
+            const double head = std::clamp(p.life * 1.5, 0.0, 1.0);
+            for (int i = 0; i < tail; ++i) {
+                const double a = (1.0 - (double)i / tail) * head;
+                if (a <= 0) break;
+                draw_dot(c, p.x - ux * i, p.y - uy * i, (int)p.r, (int)p.g, (int)p.b, a, 1);
+            }
+        }
+        return c;
+    }
+private:
+    double acc_ = 0.0;
+    Particle spawn(double cx, double cy) {
+        const double ang = frand(rng_, 0, kTau);
+        const double spd = pick_speed(cfg_, 55, 90, rng_);
+        Color col;
+        if (has_colors(cfg_)) col = pick_color(cfg_, rng_);
+        else { static const Color pool[3] = {{255,255,255},{200,225,255},{255,240,220}};
+               col = pool[irand(rng_, 0, 2)]; }
+        const double r0 = frand(rng_, 0, 6);                       // nudge off-centre
+        Particle p;
+        p.x = cx + std::cos(ang) * r0 - ox_;
+        p.y = cy + std::sin(ang) * r0 - oy_;
+        p.vx = std::cos(ang) * spd; p.vy = std::sin(ang) * spd;
+        p.r = col.r; p.g = col.g; p.b = col.b;
+        p.size = pick_size(cfg_, 1, 1, rng_);
+        p.max_life = 2.5; p.life = 1; p.extra = ang;
+        return p;
+    }
+};
+
 // ── Effect factory ───────────────────────────────────────────────────────────
 
 std::unique_ptr<BaseEffect> make_effect(const std::string& name, int w, int h, const json& cfg) {
@@ -1221,6 +1447,10 @@ std::unique_ptr<BaseEffect> make_effect(const std::string& name, int w, int h, c
     if (name == "fireworks") return std::make_unique<FireworksEffect>(w, h, cfg);
     if (name == "vortex")    return std::make_unique<VortexEffect>(w, h, cfg);
     if (name == "water")     return std::make_unique<WaterEffect>(w, h, cfg);
+    if (name == "starfield")     return std::make_unique<StarfieldEffect>(w, h, cfg);
+    if (name == "warp")          return std::make_unique<WarpEffect>(w, h, cfg);
+    if (name == "constellation") return std::make_unique<ConstellationEffect>(w, h, cfg);
+    if (name == "shootingstars") return std::make_unique<ShootingStarsEffect>(w, h, cfg);
     return nullptr;
 }
 
@@ -1289,7 +1519,14 @@ const std::map<std::string, json>& presets() {
           "nebula": {"layers":[
             {"effect":"clouds","count":4,"size_min":10,"size_max":18,"lobes_min":3,"lobes_max":6,"turbulence":0.55,"churn":0.3,"alpha_min":0.18,"alpha_max":0.4,"speed_min":0.5,"speed_max":1.8,"colors":[[150,40,140],[90,60,200],[40,90,200]],"blend":"add"},
             {"effect":"clouds","count":5,"size_min":5,"size_max":9,"lobes_min":2,"lobes_max":4,"turbulence":0.8,"churn":0.5,"alpha_min":0.15,"alpha_max":0.4,"speed_min":1.5,"speed_max":4.0,"colors":[[220,80,170],[60,160,200],[120,80,210]],"blend":"add"},
-            {"effect":"sparkle","count":10,"colors":[[255,255,255],[200,220,255]],"life_min":0.4,"life_max":1.2,"blend":"add"}]}
+            {"effect":"sparkle","count":10,"colors":[[255,255,255],[200,220,255]],"life_min":0.4,"life_max":1.2,"blend":"add"}]},
+          "starfield": {"effect":"starfield","count":80,"colors":[[255,255,255],[200,220,255],[255,240,210],[210,235,255]],"speed_min":1.2,"speed_max":3.2,"size_max":2,"blend":"add"},
+          "warp": {"effect":"warp","count":70,"colors":[[255,255,255],[200,225,255],[180,210,255]],"speed_min":3.0,"speed_max":6.0,"streak":1.2,"blend":"add"},
+          "constellation": {"effect":"constellation","count":55,"colors":[[255,255,255],[200,220,255],[255,240,210],[255,255,235]],"twinkle_min":0.7,"twinkle_max":3.0,"bright_frac":0.18,"blend":"add"},
+          "shooting_stars": {"effect":"shootingstars","count":3,"colors":[[255,255,255],[200,225,255],[255,240,220]],"speed_min":55,"speed_max":95,"rate":0.8,"tail":9,"blend":"add"},
+          "night_sky": {"layers":[
+            {"effect":"constellation","count":55,"colors":[[255,255,255],[200,220,255],[255,240,210],[255,255,235]],"twinkle_min":0.6,"twinkle_max":2.6,"bright_frac":0.18,"blend":"add"},
+            {"effect":"shootingstars","count":2,"colors":[[255,255,255],[210,230,255]],"speed_min":55,"speed_max":95,"rate":0.5,"tail":10,"blend":"add"}]}
         })JSON";
         std::map<std::string, json> m;
         json all = json::parse(kJson);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4154,6 +4154,7 @@ static std::vector<MenuItem> build_menu(
         "none", "sparkle", "embers", "rain", "snow",
         "confetti", "rings", "fireflies", "clouds",
         "lightning", "meteor", "bubbles", "fireworks", "vortex", "water",
+        "starfield", "warp", "constellation", "shootingstars",
     };
     static const char* const kBlendModes[] = {
         "add", "normal", "multiply", "screen",
@@ -4725,6 +4726,11 @@ static std::vector<MenuItem> build_menu(
         {"vortex_rose","comet vortex (pink/violet)"},
         {"vortex_rainbow","comet vortex (rainbow)"},
         {"nebula","clouds x2 + sparkle"},
+        {"starfield","parallax stars from centre"},
+        {"warp","hyperspace streaks"},
+        {"constellation","still twinkling sky"},
+        {"shooting_stars","meteors from centre"},
+        {"night_sky","twinkle + shooting stars"},
         {"water","liquid — cyan, bubbles"}, {"lava","liquid — lava, thick"},
         {"toxic","liquid — green, bubbles"}, {"ocean","liquid — teal"},
         {"plasma_fluid","liquid — magenta"}, {"mercury","liquid — silver, thick"},
@@ -4780,7 +4786,8 @@ static std::vector<MenuItem> build_menu(
             static std::mt19937 rng(std::random_device{}());
             static const char* const fx[] = {
                 "sparkle","embers","rain","snow","confetti","rings","fireflies",
-                "clouds","lightning","meteor","bubbles","fireworks","vortex"};
+                "clouds","lightning","meteor","bubbles","fireworks","vortex",
+                "starfield","constellation"};
             static const int pal[][3] = {
                 {0,220,180},{255,80,80},{80,180,255},{255,200,40},
                 {180,80,255},{80,255,160},{255,120,20},{255,255,255}};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11564,6 +11564,11 @@ int main(int argc, char* argv[]) {
     std::string pf_hub75_active = "Default";
     // Custom Gradient material editor state (Protoface > Material Color).
     PfGradient pf_gradient;
+    // Glitch post-effect config — forwarded to the native controller live and
+    // persisted to cfg["protoface"]["glitch"]. Tunable via the settings JSON;
+    // every option (chromatic, tearing, blocks, bitcrush, dropout, datamosh,
+    // region_desync, expr_flicker) is an independent variable.
+    face::GlitchConfig pf_glitch;
     // Face animation tunables — forwarded to every panel's FaceState live
     // and persisted to cfg["protoface"]["animation"] on save.
     bool   pf_blink_enabled   = true;
@@ -11634,6 +11639,8 @@ int main(int argc, char* argv[]) {
             pf_preview_duration_s =
                 jval(ja, "preview_duration_s", pf_preview_duration_s);
         }
+        if (jpf.contains("glitch") && jpf["glitch"].is_object())
+            pf_glitch = face::GlitchConfig::from_json(jpf["glitch"]);
         if (jpf.contains("gradient") && jpf["gradient"].is_object()) {
             auto& jg = jpf["gradient"];
             pf_gradient.count     = std::clamp(jval(jg, "count", pf_gradient.count), 2, 6);
@@ -12704,6 +12711,7 @@ int main(int argc, char* argv[]) {
         native_ctrl->set_blink_enabled(pf_blink_enabled);
         native_ctrl->set_blink_timing(pf_blink_min, pf_blink_max, pf_blink_duration);
         native_ctrl->set_expression_fade(pf_expr_fade);
+        native_ctrl->set_glitch(pf_glitch);
         native_ctrl->set_active_layout_name(pf_hub75_active);
         protoface_ctrl.start();   // shm reader only — feeds the in-HUD preview
         std::cout << "[main] Protoface: native in-process renderer\n";
@@ -12966,6 +12974,7 @@ int main(int argc, char* argv[]) {
         native_ctrl->set_blink_enabled(pf_blink_enabled);
         native_ctrl->set_blink_timing(pf_blink_min, pf_blink_max, pf_blink_duration);
         native_ctrl->set_expression_fade(pf_expr_fade);
+        native_ctrl->set_glitch(pf_glitch);
         native_ctrl->set_active_layout_name(pf_hub75_active);
 
         // panel_driver.py choreography. The Python shim is only needed for
@@ -14365,6 +14374,7 @@ int main(int argc, char* argv[]) {
         cfg["protoface"]["animation"]["blink_duration"]  = pf_blink_duration;
         cfg["protoface"]["animation"]["expression_fade"] = pf_expr_fade;
         cfg["protoface"]["animation"]["preview_duration_s"] = pf_preview_duration_s;
+        cfg["protoface"]["glitch"] = pf_glitch.to_json();
         {
             auto& jg = cfg["protoface"]["gradient"];
             jg["count"]     = std::clamp(pf_gradient.count, 2, 6);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1509,7 +1509,10 @@ static std::vector<MenuItem> build_menu(
         // has no coprocessor support wired.
         bool* coproc_enabled_p = nullptr,
         std::shared_ptr<std::function<void()>> coproc_reload = nullptr,
-        std::shared_ptr<std::function<std::string()>> coproc_status = nullptr)
+        std::shared_ptr<std::function<std::string()>> coproc_status = nullptr,
+        // Glitch post-effect config (null on non-native backends). The menu
+        // mutates it in place and re-pushes via pf_anim_push().
+        face::GlitchConfig* pf_glitch_p = nullptr)
 {
     (void)lora; (void)knob;
 
@@ -5708,6 +5711,45 @@ static std::vector<MenuItem> build_menu(
                 "Idle-face animation tuning: blink cadence, blink duration, "
                 "and the crossfade time between expressions. Applies to the "
                 "native (MAX7219 / RGB matrix) renderer.");
+        })(),
+        // Glitch post-effect — one effect, every look an independent variable.
+        ([&]() -> MenuItem {
+            if (!pf_glitch_p) { MenuItem e; e.visible_fn = []{ return false; }; return e; }
+            face::GlitchConfig* G = pf_glitch_p;
+            std::vector<MenuItem> gi;
+            gi.push_back(toggle("Glitch",
+                [G]{ return G->enabled; },
+                [G, pf_anim_push](bool v){ G->enabled = v; if (pf_anim_push) pf_anim_push(); }));
+            gi.push_back(slider("Intensity", 0.f, 200.f, 5.f, "%",
+                [G]{ return static_cast<float>(G->intensity * 100.0); },
+                [G, pf_anim_push](float v){ G->intensity = v / 100.0; if (pf_anim_push) pf_anim_push(); }));
+            gi.push_back(slider("Burst Rate", 0.f, 3.f, 0.1f, "/s",
+                [G]{ return static_cast<float>(G->burst_rate); },
+                [G, pf_anim_push](float v){ G->burst_rate = v; if (pf_anim_push) pf_anim_push(); }));
+            gi.push_back(slider("Burst Min", 0.02f, 1.f, 0.02f, "s",
+                [G]{ return static_cast<float>(G->burst_min); },
+                [G, pf_anim_push](float v){ G->burst_min = v; if (pf_anim_push) pf_anim_push(); }));
+            gi.push_back(slider("Burst Max", 0.05f, 2.f, 0.05f, "s",
+                [G]{ return static_cast<float>(G->burst_max); },
+                [G, pf_anim_push](float v){ G->burst_max = v; if (pf_anim_push) pf_anim_push(); }));
+            // Per-component amounts (0 = off). Each is an independent variable.
+            auto comp = [&](const char* name, double face::GlitchConfig::* member) {
+                gi.push_back(slider(name, 0.f, 100.f, 5.f, "%",
+                    [G, member]{ return static_cast<float>((G->*member) * 100.0); },
+                    [G, member, pf_anim_push](float v){ G->*member = v / 100.0; if (pf_anim_push) pf_anim_push(); }));
+            };
+            comp("Chromatic Split",    &face::GlitchConfig::chromatic);
+            comp("Band Tearing",       &face::GlitchConfig::tearing);
+            comp("Block Shuffle",      &face::GlitchConfig::blocks);
+            comp("Bitcrush",           &face::GlitchConfig::bitcrush);
+            comp("Dropout Bars",       &face::GlitchConfig::dropout);
+            comp("Datamosh",           &face::GlitchConfig::datamosh);
+            comp("Eyes/Mouth Desync",  &face::GlitchConfig::region_desync);
+            comp("Expression Flicker", &face::GlitchConfig::expr_flicker);
+            return with_desc(submenu("Glitch", std::move(gi)),
+                "Digital glitch corruption of the face. Master Intensity and Burst "
+                "Rate gate the look (Burst Rate 0 = constant); each component below "
+                "is an independent amount.");
         })(),
         gated(with_panel(submenu("GIFs", std::move(pf_gifs)),
                          "GIF Preview", draw_gif_preview), visible_for_hub75),
@@ -13453,6 +13495,7 @@ int main(int argc, char* argv[]) {
                                                                  pf_blink_max,
                                                                  pf_blink_duration);
                                    native_ctrl->set_expression_fade(pf_expr_fade);
+                                   native_ctrl->set_glitch(pf_glitch);
                                },
                                /* pf_set_effect_json */ [&](const nlohmann::json& spec){
                                    if (native_ctrl) native_ctrl->set_effect_json(spec);
@@ -13495,7 +13538,8 @@ int main(int argc, char* argv[]) {
                                /* gpio_pins */ gpio_pins.data(), kGpioSlots,
                                &gpio_inputs_enabled, gpio_reload, kdc_menu_ptr,
                                &kdc_ignore, &kdc_msgapps,
-                               &coproc_cfg.enabled, coproc_reload, coproc_status));
+                               &coproc_cfg.enabled, coproc_reload, coproc_status,
+                               /* pf_glitch_p */ &pf_glitch));
     menu_ptr = &menu;
     menu.set_quick_items(std::move(quick_items));
 


### PR DESCRIPTION
Two face features on this branch (kept together per the active branch policy `claude/protoface-star-field-3ztww9`). Happy to split the glitch into its own PR if you'd like a separate branch.

---

## 1. Star field particle effects (ports ProtoFace#3)

Four effects ported into ProtoHUD's native C++ particle system: `starfield` (parallax), `warp` (hyperspace streaks), `constellation` (still twinkling sky), `shootingstars` (center-radial meteors, distinct from the existing directional `meteor`). Registered in `make_effect()`, with presets `starfield`/`warp`/`constellation`/`shooting_stars`/`night_sky`, menu + numeric-id (18–22) wiring. Centre-origin effects use full-canvas geometry so the origin stays at canvas centre across split panels. Verified against the Python impl (near-identical lit-pixel counts; ~9× busier near canvas-centre on a split panel).

## 2. Configurable glitch post-effect (new)

One **overall** glitch effect whose individual looks are independent variables, wrapped by a master `intensity` and a **burst** on/off envelope so corruption stutters in bursts rather than running flat. Runs CPU-side (OpenCV) on the composited face canvas — it actually corrupts the **face**, not just an overlay.

| Variable | Effect |
|---|---|
| `chromatic` | RGB channel split / chromatic aberration |
| `tearing` | horizontal band displacement (VHS tracking) |
| `blocks` | rectangular block shuffle (macroblock rot) |
| `bitcrush` | colour-depth posterise |
| `dropout` | signal-loss bars (black / static) |
| `datamosh` | ghost-smear of the previous frame |
| `region_desync` | eyes(top) vs mouth(bottom) bands slip independently |
| `expr_flicker` | flash a *different expression* for a frame (face-aware) |

Plus `enabled`, `intensity`, `burst_rate`/`burst_min`/`burst_max`.

**Design:** `GlitchEffect`/`GlitchConfig` in `src/face/glitch.{h,cpp}` with JSON round-trip. The controller ticks the burst envelope once per frame (both eyes corrupt identically), flashes a shared alternate expression at the face stage via `FaceLoader::get_expression_image()`, and applies the frame-level pass to the whole canvas after compositing. Config persists under `cfg["protoface"]["glitch"]` and pushes live through `set_glitch()`.

**UI:** a **Protoface → Glitch** submenu with live controls — enable toggle, master Intensity, Burst Rate/Min/Max, and a per-component percentage slider for each variable above. Edits push to the controller instantly via the existing `pf_anim_push` callback and persist on save. Hidden on non-native backends.

**Scope per request:** ProtoHUD first, **face-only (CPU)** — the GPU `postprocess.fs` shader (whole-HUD glitch) is a deliberate, separable follow-up since the face texture doesn't flow through that pass.

**Verification:** built and ran the engine against OpenCV in isolation — each component produces a measurable change in isolation, datamosh ghosts on motion, bursts stay idle most of the time and fire intermittently, expr-flicker flag samples correctly, disabled is a true no-op. The controller passes `-fsyntax-only`, and the menu's pointer-to-member slider idiom was compile+run validated against the real `GlitchConfig`. The `main.cpp` wiring (config persistence, controller push, and the menu) mirrors the existing `pf_*` animation pattern but is **not compiled here** (needs GLFW/ImGui) — worth a local build check since this repo has no CI.

https://claude.ai/code/session_014QLXvqqjdENEC19ep3vCKP