### PR TITLE
SmartKnob: share protocol via submodule, fix opcode collisions & port discovery

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,7 @@
 [submodule "Protoface"]
 	path = Protoface
 	url = https://github.com/brooksthemaker/ProtoFace.git
+[submodule "vendor/smart-knob"]
+	path = vendor/smart-knob
+	url = https://github.com/brooksthemaker/Smart-Knob-Redux.git
+	branch = claude/esp32-protohud-communication-ptpst6

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2701,10 +2701,14 @@ int main(int argc, char* argv[]) {
 
     // Auto-discover serial ports by USB VID:PID when configured paths are absent.
     // Teensy 4.1: VID=0x16C0, PID=0x0483.  LoRa CH340: VID=0x1A86, PID=0x7523.
-    // SmartKnob ESP32-S3 DevKitC-1 UART port: CH341 VID=0x1A86, PID=0x7522.
+    // SmartKnob: the firmware uses the ESP32-S3 NATIVE USB-CDC port (build flag
+    // ARDUINO_USB_MODE=1), so it enumerates as Espressif VID=0x303A, PID=0x1001
+    // on a /dev/ttyACM node — NOT the CH341 UART bridge (0x1A86) the board also
+    // exposes. If the PID varies by core version, set smartknob.port explicitly
+    // to a /dev/serial/by-id/... path instead.
     teensy_port = resolve_serial_port(teensy_port, 0x16C0, 0x0483);
     lora_port   = resolve_serial_port(lora_port,   0x1A86, 0x7523);
-    knob_port   = resolve_serial_port(knob_port,   0x1A86, 0x7522);
+    knob_port   = resolve_serial_port(knob_port,   0x303A, 0x1001);
 
     TeensyController     teensy  (teensy_port,   baud, state);
     ProtoFaceController  protoface_ctrl;
@@ -3775,6 +3779,10 @@ int main(int argc, char* argv[]) {
 
     menu.set_detent_callback([&knob, &menu](int count) {
         knob.set_detents(count);
+        // Menus wrap (MenuSystem::navigate uses % n), so the knob must stay
+        // free-spinning — keep it unbounded (max <= min). set_range() with real
+        // endstops is for non-wrapping ranges (e.g. a 0-100 slider), not menus.
+        knob.set_range(/*min*/0, /*max*/0, /*spacing_deg*/count ? 360 / count : 0);
         int depth = menu.menu_depth();
         uint8_t amp = 200, freq = 80, strength = 150;
         if      (depth >= 3) { amp = 150; freq = 60; strength = 100; }
@@ -3860,13 +3868,13 @@ int main(int argc, char* argv[]) {
     }); });
 
     knob.on_status([&state](uint8_t status, uint8_t param) {
-        if      (status == 0x01) {
+        if      (status == KnobStatus::READY) {
             std::lock_guard<std::mutex> lk(state.mtx);
             state.health.knob_ready = true;
             std::cout << "[knob] ready\n";
         }
-        else if (status == 0x02) std::cout << "[knob] entering sleep\n";
-        else if (status == 0x03) std::cout << "[knob] woke up reason=" << (int)param << "\n";
+        else if (status == KnobStatus::ENTERING_SLEEP) std::cout << "[knob] entering sleep\n";
+        else if (status == KnobStatus::WOKE_UP)        std::cout << "[knob] woke up reason=" << (int)param << "\n";
     });
 
     knob.on_button([&](uint8_t btn, uint8_t ev) { post_input([&, btn, ev]{

--- a/src/protocols.h
+++ b/src/protocols.h
@@ -4,38 +4,11 @@
 
 // ── Frame format ──────────────────────────────────────────────────────────────
 //   [SYNC_A][SYNC_B][CMD][LEN][...PAYLOAD...][CRC8]
-//   SYNC_A = 0xAA, SYNC_B = 0x55
-//   LEN = payload byte count (0-255)
-//   CRC8 covers CMD+LEN+PAYLOAD
-
-static constexpr uint8_t PROTO_SYNC_A = 0xAA;
-static constexpr uint8_t PROTO_SYNC_B = 0x55;
-static constexpr size_t  PROTO_HEADER_LEN = 4;  // SYNC_A SYNC_B CMD LEN
-static constexpr size_t  PROTO_MAX_PAYLOAD = 255;
-static constexpr size_t  PROTO_MAX_FRAME = PROTO_HEADER_LEN + PROTO_MAX_PAYLOAD + 1;
-
-inline uint8_t proto_crc8(const uint8_t* data, size_t len) {
-    uint8_t crc = 0;
-    for (size_t i = 0; i < len; i++) {
-        crc ^= data[i];
-        for (int b = 0; b < 8; b++)
-            crc = (crc & 0x80) ? ((crc << 1) ^ 0x07) : (crc << 1);
-    }
-    return crc;
-}
-
-// Build a frame into buf (must be >= PROTO_MAX_FRAME bytes).
-// Returns total frame length.
-inline size_t proto_build(uint8_t* buf, uint8_t cmd,
-                          const uint8_t* payload, uint8_t len) {
-    buf[0] = PROTO_SYNC_A;
-    buf[1] = PROTO_SYNC_B;
-    buf[2] = cmd;
-    buf[3] = len;
-    if (len && payload) __builtin_memcpy(buf + 4, payload, len);
-    buf[4 + len] = proto_crc8(buf + 2, 2 + len);
-    return 5 + len;
-}
+// The wire frame and its helpers (proto_crc8 / proto_build) are defined ONCE in
+// the shared protocol headers vendored from the Smart-Knob-Redux repo, so the
+// knob firmware and ProtoHUD can never disagree about the transport. Every
+// serial device here (Teensy/LoRa/SmartKnob/wireless) shares this same frame.
+#include "../vendor/smart-knob/include/proto_frame.h"
 
 // ── Teensy (Prototracer) ──────────────────────────────────────────────────────
 
@@ -118,53 +91,11 @@ struct LoRaNodeInfoHeader {
 #pragma pack(pop)
 
 // ── SmartKnob (ESP32-S3) ──────────────────────────────────────────────────────
-
-namespace KnobCmd {
-    // ESP32 → CM5 (legacy position/events)
-    static constexpr uint8_t POSITION_UPDATE = 0x01;  // see KnobPositionPayload
-    static constexpr uint8_t WAKE_EVENT      = 0x02;  // no payload
-    static constexpr uint8_t SLEEP_EVENT     = 0x03;  // no payload
-    static constexpr uint8_t BUTTON_EVENT    = 0x04;  // see KnobButtonPayload
-
-    // ESP32 → CM5 (status messages from binary protocol)
-    static constexpr uint8_t STATUS_READY         = 0x01;  // motor calibration complete
-    static constexpr uint8_t STATUS_ENTERING_SLEEP= 0x02;  // entering low-power mode
-    static constexpr uint8_t STATUS_WOKE_UP       = 0x03;  // woke from sleep (param: 0=rotation, 1=command)
-
-    // CM5 → ESP32
-    static constexpr uint8_t SET_DETENTS     = 0x81;  // count(1) positions[count*2 bytes, int16 each]
-    static constexpr uint8_t WAKE_DEVICE     = 0x82;  // no payload
-    static constexpr uint8_t SET_SLEEP_TMO   = 0x83;  // timeout_s(2, uint16)
-    static constexpr uint8_t SET_RANGE       = 0x84;  // spacing_deg(1) min_pos(2) max_pos(2) start_pos(2)
-    static constexpr uint8_t SET_HAPTIC      = 0x85;  // amplitude(1) frequency(1) detent_strength(1)
-}
-
-// Button IDs (matching firmware BTN_* constants)
-namespace KnobButton {
-    static constexpr uint8_t ENCODER = 0;  // encoder push-switch
-    static constexpr uint8_t BACK    = 1;  // dedicated back button
-    static constexpr uint8_t EXTRA   = 2;  // optional extra button
-}
-// Button event types
-namespace KnobButtonEvent {
-    static constexpr uint8_t PRESS      = 0;
-    static constexpr uint8_t LONG_PRESS = 1;
-    static constexpr uint8_t RELEASE    = 2;
-    static constexpr uint8_t DOUBLE_TAP = 3;
-}
-
-#pragma pack(push, 1)
-struct KnobPositionPayload {
-    int8_t   direction;      // -1, 0, +1
-    uint16_t velocity_rpm10; // RPM * 10
-    int16_t  detent_index;   // current selected detent (-1 if between)
-    int32_t  angle_milli;    // absolute angle in millidegrees
-};
-struct KnobButtonPayload {
-    uint8_t button_id;    // KnobButton:: constant
-    uint8_t event_type;   // KnobButtonEvent:: constant
-};
-#pragma pack(pop)
+// Opcodes (KnobCmd::*), button/status enums, and payload structs are the single
+// source of truth, vendored from the Smart-Knob-Redux firmware repo. Editing the
+// knob protocol means editing vendor/smart-knob/include/knob_protocol.h and
+// bumping the submodule — the two ends can no longer silently drift.
+#include "../vendor/smart-knob/include/knob_protocol.h"
 
 // ── Wireless Controller (ESP32-C3 USB-serial bridge + ESP-NOW peer) ───────────
 // Frame format: same as all other serial devices — [0xAA][0x55][CMD][LEN][...][CRC8]

--- a/src/serial/smartknob.cpp
+++ b/src/serial/smartknob.cpp
@@ -62,8 +62,14 @@ void SmartKnob::set_sleep_timeout(uint16_t seconds) {
 }
 
 void SmartKnob::set_haptic(uint8_t amplitude, uint8_t frequency, uint8_t detent_strength) {
-    uint8_t buf[3] = { amplitude, frequency, detent_strength };
-    port_.send(KnobCmd::SET_HAPTIC, buf, 3);
+    KnobSetHapticPayload h { amplitude, frequency, detent_strength };
+    port_.send(KnobCmd::SET_HAPTIC, reinterpret_cast<const uint8_t*>(&h), sizeof(h));
+}
+
+void SmartKnob::set_range(int16_t min_pos, int16_t max_pos,
+                          uint8_t spacing_deg, int16_t start_pos) {
+    KnobSetRangePayload r { spacing_deg, min_pos, max_pos, start_pos };
+    port_.send(KnobCmd::SET_RANGE, reinterpret_cast<const uint8_t*>(&r), sizeof(r));
 }
 
 float SmartKnob::event_age_ms() const {
@@ -124,18 +130,14 @@ void SmartKnob::on_frame(uint8_t cmd, const uint8_t* payload, uint8_t len) {
 
         if (button_cb_) button_cb_(p.button_id, p.event_type);
 
-    } else if (cmd == 0x01) {  // STATUS_READY (len=0, no position payload)
-        {
+    } else if (cmd == KnobCmd::STATUS && len >= sizeof(KnobStatusPayload)) {
+        KnobStatusPayload p {};
+        std::memcpy(&p, payload, sizeof(p));
+
+        if (p.code == KnobStatus::READY) {
             std::lock_guard<std::mutex> lk(state_.mtx);
             state_.health.knob_ready = true;
         }
-        if (status_cb_) status_cb_(0x01, 0);
-
-    } else if (cmd == 0x02) {  // STATUS_ENTERING_SLEEP
-        if (status_cb_) status_cb_(0x02, 0);
-
-    } else if (cmd == 0x03) {  // STATUS_WOKE_UP
-        uint8_t reason = (len >= 1) ? payload[0] : 0;
-        if (status_cb_) status_cb_(0x03, reason);
+        if (status_cb_) status_cb_(p.code, p.reason);
     }
 }

--- a/src/serial/smartknob.h
+++ b/src/serial/smartknob.h
@@ -29,6 +29,12 @@ public:
     void set_sleep_timeout(uint16_t seconds);
     void set_haptic(uint8_t amplitude, uint8_t frequency, uint8_t detent_strength);
 
+    // Configure detent-index endstops (Scott-style bounded rotation). The knob
+    // refuses to turn past [min_pos, max_pos]. Pass max_pos <= min_pos for
+    // free-spinning / unbounded rotation. spacing_deg/start_pos are advisory.
+    void set_range(int16_t min_pos, int16_t max_pos,
+                   uint8_t spacing_deg = 0, int16_t start_pos = 0);
+
     void on_move  (KnobMoveCallback cb)   { move_cb_   = std::move(cb); }
     void on_wake  (KnobWakeCallback cb)   { wake_cb_   = std::move(cb); }
     void on_status(KnobStatusCallback cb) { status_cb_ = std::move(cb); }


### PR DESCRIPTION
## What

Host side of the ESP32 ⇄ ProtoHUD serial-link cleanup. Pairs with **Smart-Knob-Redux#10**, which holds the now-canonical protocol headers.

## Changes

- **Single source of truth via submodule.** Adds `vendor/smart-knob` (Smart-Knob-Redux) and makes `src/protocols.h` `#include` `proto_frame.h` / `knob_protocol.h` instead of carrying duplicate definitions. The frame format and knob protocol are no longer hand-kept in two places.
- **De-collide opcodes.** Drops the `KnobCmd` status constants that reused `0x01/0x02/0x03` and the dead, length-disambiguated branches in `SmartKnob::on_frame`. The host now consumes the dedicated `KnobCmd::STATUS` (0x05) with `KnobStatusPayload`.
- **`SmartKnob::set_range()`** — exposes the firmware's bounded-rotation / endstop feature to the host (previously the firmware implemented `SET_RANGE` but nothing could send it). Menus wrap, so the detent callback deliberately keeps the knob unbounded and documents why; `set_range` is for non-wrapping ranges (e.g. a 0–100 slider).
- **Fix auto-discovery VID/PID.** The firmware talks over the ESP32-S3 **native** USB-CDC port (VID `0x303A`), not the CH341 UART bridge (`0x1A86`) the old IDs targeted.

## Notes for reviewers

- Build sources are listed explicitly in `CMakeLists.txt`, so the firmware under `vendor/smart-knob/` is **not** compiled into the host binary — only its headers are included.
- `.gitmodules` points at the canonical GitHub URL; after checkout run `git submodule update --init --recursive`.
- The submodule is pinned to Smart-Knob-Redux@`bf101dc`. The opcode change requires both ends to be updated together (not wire-compatible with old firmware).

## Testing

Header syntax-checked; full host build not run in this environment (needs ImGui/SDL/etc. toolchain). Needs an on-device pass with the paired firmware before merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01F5UPBa3pLD5Q5RUbFnLmKN)_