### PR TITLE
Per-camera resolution + full libcamera control set (AF/AE/WB/ISP/HDR)

### DIFF
--- a/config/config.example.json
+++ b/config/config.example.json
@@ -407,12 +407,7 @@
     "fourcc": "mp4v",
     "camera": "left"
   },
-  "resolution": {
-    "_note": "Persisted OWLsight resolution. Overrides cameras.owlsight_left/right width/height/fps on startup. fps set to match display.target_fps (90) for lowest latency; libcamera clamps to the sensor's achievable rate.",
-    "width":  1280,
-    "height":  800,
-    "fps":      90
-  },
+  "_resolution_note": "Capture resolution is per-camera — set cameras.owlsight_left/right width/height/fps independently (Menu > Cameras > Left/Right Camera > Resolution, populated live from the modes each sensor reports). fps is a best-effort target; libcamera clamps to the sensor's achievable rate at the chosen size. A legacy top-level 'resolution' block that forced both eyes equal is still honoured on load for old configs but is retired on the next save.",
   "qr": {
     "_note": "Persisted QR scan state. scan_main=OWLsight cameras, scan_usb=USB cameras.",
     "scan_main": false,

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -25,7 +25,15 @@
       "fps": 90,
       "rotation_deg": 0,
       "flip_h": false,
-      "flip_v": false
+      "flip_v": false,
+      "_controls_note": "Per-eye AF/AE/WB/ISP/HDR controls, set from Menu > Cameras > Left/Right Camera and saved here automatically. Values match libcamera enums. af_range:0 Normal/1 Macro/2 Full · af_speed:0 Normal/1 Fast · gain:0=auto else manual analogue gain · ae_metering:0 Centre/1 Spot/2 Matrix · ae_constraint:0 Normal/1 Highlight/2 Shadows · ae_exposure_mode:0 Normal/1 Short/2 Long · flicker:0 Off/1 Auto/2 50Hz/3 60Hz · awb_mode:0 Auto/1 Incandescent/2 Tungsten/3 Fluorescent/4 Indoor/5 Daylight/6 Cloudy · brightness:-1..1 · contrast/saturation/sharpness:0..2 · noise_reduction:0 Off/1 Fast/2 HQ/3 Minimal · hdr:0 Off/2 Multi/3 Single/4 Night (IMX708 + recent libcamera). Omit the block to keep neutral defaults.",
+      "controls": {
+        "af_range": 0, "af_speed": 0, "gain": 0.0,
+        "ae_metering": 0, "ae_constraint": 0, "ae_exposure_mode": 0, "flicker": 0,
+        "awb_mode": 0,
+        "brightness": 0.0, "contrast": 1.0, "saturation": 1.0, "sharpness": 1.0,
+        "noise_reduction": 0, "hdr": 0
+      }
     },
     "owlsight_right": {
       "libcamera_id": 1,
@@ -35,7 +43,14 @@
       "fps": 90,
       "rotation_deg": 0,
       "flip_h": false,
-      "flip_v": false
+      "flip_v": false,
+      "controls": {
+        "af_range": 0, "af_speed": 0, "gain": 0.0,
+        "ae_metering": 0, "ae_constraint": 0, "ae_exposure_mode": 0, "flicker": 0,
+        "awb_mode": 0,
+        "brightness": 0.0, "contrast": 1.0, "saturation": 1.0, "sharpness": 1.0,
+        "noise_reduction": 0, "hdr": 0
+      }
     },
     "usb_cam_1": {
       "device": "/dev/video17",

--- a/src/app_state.h
+++ b/src/app_state.h
@@ -239,6 +239,26 @@ struct CameraResolutionState {
     int fps    = 60;
 };
 
+// Per-CSI-camera libcamera control state, persisted to config and re-applied at
+// startup. Defaults are the libcamera/ISP neutral values. Mirrors the cur_*
+// values DmaCamera tracks; the menu writes to the camera, save reads them back.
+struct CameraControlsState {
+    int   af_range        = 0;     // 0 Normal, 1 Macro, 2 Full
+    int   af_speed        = 0;     // 0 Normal, 1 Fast
+    float gain            = 0.0f;  // manual AnalogueGain; 0 = auto
+    int   ae_metering     = 0;     // 0 Centre, 1 Spot, 2 Matrix
+    int   ae_constraint   = 0;     // 0 Normal, 1 Highlight, 2 Shadows
+    int   ae_exp_mode     = 0;     // 0 Normal, 1 Short, 2 Long
+    int   flicker         = 0;     // 0 Off, 1 Auto, 2 50 Hz, 3 60 Hz
+    int   awb_mode        = 0;     // 0 Auto … 6 Cloudy (libcamera AwbMode)
+    float brightness      = 0.0f;  // -1 .. 1
+    float contrast        = 1.0f;  //  0 .. 2
+    float saturation      = 1.0f;  //  0 .. 2
+    float sharpness       = 1.0f;  //  0 .. 2
+    int   noise_reduction = 0;     // 0 Off,1 Fast,2 HQ,3 Minimal
+    int   hdr             = 0;     // libcamera HdrMode (0 Off,2 Multi,3 Single,4 Night)
+};
+
 // Digital zoom / crop for OWLsight cameras.
 // zoom=1.0 → full frame (identity). zoom>1.0 → crops to 1/zoom of the frame.
 // center_x / center_y are normalized (0.0–1.0) screen-space coordinates.
@@ -868,6 +888,8 @@ struct AppState {
     ClockConfig          clock_cfg;
     CameraResolutionState camera_resolution;        // left / primary eye
     CameraResolutionState camera_resolution_right;   // right eye (set independently)
+    CameraControlsState   camera_controls_left;      // per-eye AF/AE/WB/ISP/HDR
+    CameraControlsState   camera_controls_right;
     ZoomCropState        zoom_left, zoom_right;
     MirrorCropState      mirror_crop;
     CamSingleState       cam_single;

--- a/src/app_state.h
+++ b/src/app_state.h
@@ -866,7 +866,8 @@ struct AppState {
     LightSquintConfig    light_squint;
     VoiceMouthConfig     voice_mouth;
     ClockConfig          clock_cfg;
-    CameraResolutionState camera_resolution;
+    CameraResolutionState camera_resolution;        // left / primary eye
+    CameraResolutionState camera_resolution_right;   // right eye (set independently)
     ZoomCropState        zoom_left, zoom_right;
     MirrorCropState      mirror_crop;
     CamSingleState       cam_single;

--- a/src/camera/dma_camera.cpp
+++ b/src/camera/dma_camera.cpp
@@ -8,6 +8,7 @@
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
 
+#include <algorithm>
 #include <iostream>
 #include <cstring>
 #include <chrono>
@@ -176,9 +177,34 @@ bool DmaCamera::configure_camera() {
     stream_ = sc.stream();
     stride_ = sc.stride;
 
+    // ── Enumerate the sensor's supported resolutions for this format ──────────
+    // Captured once so the menu can offer the camera's REAL modes instead of a
+    // fixed preset list (the cause of "pick 1440p, nothing changes" on sensors
+    // that don't support it). sizes() is the discrete set libcamera reports for
+    // the negotiated pixel format; sorted largest-area first for stable order.
+    // max_fps is left 0 here (the in-depth path can probe FrameDurationLimits
+    // per mode later); selecting a mode requests a target fps and libcamera
+    // clamps it to what the sensor can do at that size.
+    modes_.clear();
+    try {
+        for (const auto& s : sc.formats().sizes(sc.pixelFormat))
+            modes_.push_back({ static_cast<int>(s.width),
+                               static_cast<int>(s.height), 0 });
+        std::sort(modes_.begin(), modes_.end(),
+                  [](const Mode& a, const Mode& b){
+                      return static_cast<long>(a.width) * a.height
+                           > static_cast<long>(b.width) * b.height;
+                  });
+        modes_.erase(std::unique(modes_.begin(), modes_.end(),
+                     [](const Mode& a, const Mode& b){
+                         return a.width == b.width && a.height == b.height;
+                     }), modes_.end());
+    } catch (...) {}
+
     std::cout << "[dma] camera " << cfg_.libcamera_id
               << " configured: " << cfg_.width << "×" << cfg_.height
-              << " stride=" << stride_ << " fps=" << cfg_.fps << "\n";
+              << " stride=" << stride_ << " fps=" << cfg_.fps
+              << " (" << modes_.size() << " modes reported)\n";
     return true;
 }
 
@@ -381,6 +407,8 @@ void DmaCamera::on_request_complete(Request* req) {
             last_lens_pos_.store(meta.get(controls::LensPosition).value_or(0.0f));
         if (camCtrls.count(&controls::AnalogueGain))
             last_analogue_gain_.store(meta.get(controls::AnalogueGain).value_or(1.0f));
+        // Real per-frame duration (µs) → drives measured_fps() in the menu.
+        last_frame_dur_us_.store(meta.get(controls::FrameDuration).value_or(0));
     } catch (...) {}
 
     auto it = req_to_slot_.find(req);

--- a/src/camera/dma_camera.cpp
+++ b/src/camera/dma_camera.cpp
@@ -714,6 +714,68 @@ void DmaCamera::apply_pending_controls(ControlList& ctrls) {
         float gains[2] = { rg, bg };
         ctrls.set(controls::ColourGains, Span<const float, 2>(gains));
     }
+
+    // ── Extended controls ─────────────────────────────────────────────────────
+    // Menu values are chosen to match libcamera's enum numeric values, so each
+    // is forwarded straight through. count() guards mean a sensor that lacks a
+    // control silently ignores it rather than erroring.
+    const auto& cc = camera_->controls();
+
+    int afr = pending_af_range_.exchange(-1);
+    if (afr >= 0 && cc.count(&controls::AfRange)) ctrls.set(controls::AfRange, afr);
+
+    int afs = pending_af_speed_.exchange(-1);
+    if (afs >= 0 && cc.count(&controls::AfSpeed)) ctrls.set(controls::AfSpeed, afs);
+
+    float ag = pending_gain_.exchange(-1.0f);
+    if (ag > 0.0f && cc.count(&controls::AnalogueGain)) ctrls.set(controls::AnalogueGain, ag);
+
+    int aem = pending_ae_metering_.exchange(-1);
+    if (aem >= 0 && cc.count(&controls::AeMeteringMode)) ctrls.set(controls::AeMeteringMode, aem);
+
+    int aecn = pending_ae_constraint_.exchange(-1);
+    if (aecn >= 0 && cc.count(&controls::AeConstraintMode)) ctrls.set(controls::AeConstraintMode, aecn);
+
+    int aex = pending_ae_exp_mode_.exchange(-1);
+    if (aex >= 0 && cc.count(&controls::AeExposureMode)) ctrls.set(controls::AeExposureMode, aex);
+
+    int fl = pending_flicker_.exchange(-1);
+    if (fl >= 0 && cc.count(&controls::AeFlickerMode)) {
+        // libcamera AeFlickerMode: 0 Off, 1 Manual, 2 Auto. Menu: 0 Off, 1 Auto,
+        // 2 = 50 Hz, 3 = 60 Hz → Manual + an explicit period (µs).
+        if (fl == 0)      ctrls.set(controls::AeFlickerMode, 0);   // Off
+        else if (fl == 1) ctrls.set(controls::AeFlickerMode, 2);   // Auto
+        else {
+            ctrls.set(controls::AeFlickerMode, 1);                 // Manual
+            if (cc.count(&controls::AeFlickerPeriod))
+                ctrls.set(controls::AeFlickerPeriod, fl == 2 ? 10000 : 8333); // 50/60 Hz
+        }
+    }
+
+    int awbm = pending_awb_mode_.exchange(-1);
+    if (awbm >= 0 && cc.count(&controls::AwbMode)) {
+        if (cc.count(&controls::AwbEnable)) ctrls.set(controls::AwbEnable, true);
+        ctrls.set(controls::AwbMode, awbm);
+    }
+
+    float br = pending_brightness_.exchange(-9999.0f);
+    if (br > -9998.0f && cc.count(&controls::Brightness)) ctrls.set(controls::Brightness, br);
+
+    float ct = pending_contrast_.exchange(-1.0f);
+    if (ct >= 0.0f && cc.count(&controls::Contrast)) ctrls.set(controls::Contrast, ct);
+
+    float sa = pending_saturation_.exchange(-1.0f);
+    if (sa >= 0.0f && cc.count(&controls::Saturation)) ctrls.set(controls::Saturation, sa);
+
+    float sp = pending_sharpness_.exchange(-1.0f);
+    if (sp >= 0.0f && cc.count(&controls::Sharpness)) ctrls.set(controls::Sharpness, sp);
+
+    int nr = pending_nr_.exchange(-1);
+    if (nr >= 0 && cc.count(&controls::draft::NoiseReductionMode))
+        ctrls.set(controls::draft::NoiseReductionMode, nr);
+
+    int hdr = pending_hdr_.exchange(-1);
+    if (hdr >= 0 && cc.count(&controls::HdrMode)) ctrls.set(controls::HdrMode, hdr);
 }
 
 void DmaCamera::start_autofocus() {
@@ -810,4 +872,65 @@ void DmaCamera::set_colour_temp(int kelvin) {
             return;
         }
     }
+}
+
+// ── Extended controls ─────────────────────────────────────────────────────────
+// Each setter records the value for the menu (cur_*) and queues it for the next
+// request (pending_*). apply_pending_controls() guards each by controls().count()
+// so a sensor that lacks a given control simply ignores it.
+void DmaCamera::set_af_range(int range) {
+    if (!camera_) return;
+    cur_af_range_.store(range); pending_af_range_.store(range);
+}
+void DmaCamera::set_af_speed(int speed) {
+    if (!camera_) return;
+    cur_af_speed_.store(speed); pending_af_speed_.store(speed);
+}
+void DmaCamera::set_analogue_gain(float gain) {
+    if (!camera_) return;
+    cur_gain_.store(gain); pending_gain_.store(gain);
+}
+void DmaCamera::set_ae_metering(int mode) {
+    if (!camera_) return;
+    cur_ae_metering_.store(mode); pending_ae_metering_.store(mode);
+}
+void DmaCamera::set_ae_constraint(int mode) {
+    if (!camera_) return;
+    cur_ae_constraint_.store(mode); pending_ae_constraint_.store(mode);
+}
+void DmaCamera::set_ae_exposure_mode(int mode) {
+    if (!camera_) return;
+    cur_ae_exp_mode_.store(mode); pending_ae_exp_mode_.store(mode);
+}
+void DmaCamera::set_flicker_mode(int mode) {
+    if (!camera_) return;
+    cur_flicker_.store(mode); pending_flicker_.store(mode);
+}
+void DmaCamera::set_awb_mode(int mode) {
+    if (!camera_) return;
+    cur_awb_mode_.store(mode); pending_awb_mode_.store(mode);
+}
+void DmaCamera::set_brightness(float v) {
+    if (!camera_) return;
+    cur_brightness_.store(v); pending_brightness_.store(v);
+}
+void DmaCamera::set_contrast(float v) {
+    if (!camera_) return;
+    cur_contrast_.store(v); pending_contrast_.store(v);
+}
+void DmaCamera::set_saturation(float v) {
+    if (!camera_) return;
+    cur_saturation_.store(v); pending_saturation_.store(v);
+}
+void DmaCamera::set_sharpness(float v) {
+    if (!camera_) return;
+    cur_sharpness_.store(v); pending_sharpness_.store(v);
+}
+void DmaCamera::set_noise_reduction(int mode) {
+    if (!camera_) return;
+    cur_nr_.store(mode); pending_nr_.store(mode);
+}
+void DmaCamera::set_hdr_mode(int mode) {
+    if (!camera_) return;
+    cur_hdr_.store(mode); pending_hdr_.store(mode);
 }

--- a/src/camera/dma_camera.h
+++ b/src/camera/dma_camera.h
@@ -106,6 +106,47 @@ public:
     void set_colour_gains(float rg, float bg);     // raw ISP gains (typically 0.5–4.0)
     void set_colour_temp(int kelvin);              // maps 2800–7500 K → ColourGains LUT
 
+    // ── Autofocus tuning (PDAF sensors: IMX708 / Arducam 16MP / 64MP) ──────────
+    void set_af_range(int range);   // 0 Normal, 1 Macro, 2 Full
+    void set_af_speed(int speed);   // 0 Normal, 1 Fast
+    int  af_range() const { return cur_af_range_.load(); }
+    int  af_speed() const { return cur_af_speed_.load(); }
+
+    // ── Auto-exposure tuning ──────────────────────────────────────────────────
+    void  set_analogue_gain(float gain);   // manual sensor gain (>=1.0); <=0 → auto
+    void  set_ae_metering(int mode);       // 0 Centre-weighted, 1 Spot, 2 Matrix
+    void  set_ae_constraint(int mode);     // 0 Normal, 1 Highlight, 2 Shadows
+    void  set_ae_exposure_mode(int mode);  // 0 Normal, 1 Short, 2 Long
+    void  set_flicker_mode(int mode);      // 0 Off, 1 Auto, 2 50 Hz, 3 60 Hz
+    float analogue_gain_target() const { return cur_gain_.load(); }
+    int   ae_metering()    const { return cur_ae_metering_.load(); }
+    int   ae_constraint()  const { return cur_ae_constraint_.load(); }
+    int   ae_exposure_mode() const { return cur_ae_exp_mode_.load(); }
+    int   flicker_mode()   const { return cur_flicker_.load(); }
+
+    // ── White-balance preset modes (alternative to manual gains / Kelvin) ──────
+    void set_awb_mode(int mode);    // 0 Auto,1 Incandescent,2 Tungsten,3 Fluorescent,
+                                    // 4 Indoor,5 Daylight,6 Cloudy (matches libcamera)
+    int  awb_mode() const { return cur_awb_mode_.load(); }
+
+    // ── ISP image tuning ──────────────────────────────────────────────────────
+    void  set_brightness(float v);         // -1.0 .. 1.0  (0 = neutral)
+    void  set_contrast(float v);           //  0.0 .. 2.0  (1 = neutral)
+    void  set_saturation(float v);         //  0.0 .. 2.0  (1 = neutral, 0 = mono)
+    void  set_sharpness(float v);          //  0.0 .. 2.0  (1 = neutral)
+    void  set_noise_reduction(int mode);   // 0 Off,1 Fast,2 High Quality,3 Minimal
+    float brightness() const { return cur_brightness_.load(); }
+    float contrast()   const { return cur_contrast_.load(); }
+    float saturation() const { return cur_saturation_.load(); }
+    float sharpness()  const { return cur_sharpness_.load(); }
+    int   noise_reduction() const { return cur_nr_.load(); }
+
+    // ── On-sensor HDR (IMX708 — Camera Module 3 / Arducam Hawkeye) ─────────────
+    // Values match libcamera HdrMode: 0 Off, 2 MultiExposure, 3 SingleExposure,
+    // 4 Night. Needs a recent libcamera that exposes HdrMode as a runtime control.
+    void set_hdr_mode(int mode);
+    int  hdr_mode() const { return cur_hdr_.load(); }
+
     bool  is_ok()           const { return ok_; }
     int   width()           const { return cfg_.width; }
     int   height()          const { return cfg_.height; }
@@ -220,6 +261,43 @@ private:
     std::atomic<int>   pending_awb_enable_ { -1 };       // AwbEnable: 1=on 0=off -1=no-op
     std::atomic<float> pending_rg_gain_    { -1.0f };    // ColourGains R, -1 = no-op
     std::atomic<float> pending_bg_gain_    { -1.0f };    // ColourGains B, -1 = no-op
+
+    // Extended controls (AF tuning / AE tuning / WB mode / ISP image / HDR).
+    // pending_* sentinels: ints -1 = no-op; floats -1.0f (or -9999.0f where the
+    // valid range includes negatives, i.e. Brightness). Applied + reset in
+    // apply_pending_controls(); each is guarded there by controls().count().
+    std::atomic<int>   pending_af_range_     { -1 };
+    std::atomic<int>   pending_af_speed_     { -1 };
+    std::atomic<float> pending_gain_         { -1.0f };   // AnalogueGain, <=0 = no-op
+    std::atomic<int>   pending_ae_metering_  { -1 };
+    std::atomic<int>   pending_ae_constraint_{ -1 };
+    std::atomic<int>   pending_ae_exp_mode_  { -1 };
+    std::atomic<int>   pending_flicker_      { -1 };
+    std::atomic<int>   pending_awb_mode_     { -1 };
+    std::atomic<float> pending_brightness_   { -9999.0f }; // valid range incl. negatives
+    std::atomic<float> pending_contrast_     { -1.0f };
+    std::atomic<float> pending_saturation_   { -1.0f };
+    std::atomic<float> pending_sharpness_    { -1.0f };
+    std::atomic<int>   pending_nr_           { -1 };
+    std::atomic<int>   pending_hdr_          { -1 };
+
+    // Last-requested values, so the menu can show the active option / slider
+    // position (pending_* are one-shot and reset after apply). Seeded to the
+    // libcamera/ISP neutral defaults.
+    std::atomic<int>   cur_af_range_     { 0 };
+    std::atomic<int>   cur_af_speed_     { 0 };
+    std::atomic<float> cur_gain_         { 0.0f };   // 0 = auto
+    std::atomic<int>   cur_ae_metering_  { 0 };
+    std::atomic<int>   cur_ae_constraint_{ 0 };
+    std::atomic<int>   cur_ae_exp_mode_  { 0 };
+    std::atomic<int>   cur_flicker_      { 0 };
+    std::atomic<int>   cur_awb_mode_     { 0 };
+    std::atomic<float> cur_brightness_   { 0.0f };
+    std::atomic<float> cur_contrast_     { 1.0f };
+    std::atomic<float> cur_saturation_   { 1.0f };
+    std::atomic<float> cur_sharpness_    { 1.0f };
+    std::atomic<int>   cur_nr_           { 0 };
+    std::atomic<int>   cur_hdr_          { 0 };
 
     // ── Latest camera metadata (written by capture thread via atomics) ────────
     std::atomic<int>   last_af_state_      { 0 };        // AfState enum value

--- a/src/camera/dma_camera.h
+++ b/src/camera/dma_camera.h
@@ -20,6 +20,7 @@
 
 #include <atomic>
 #include <condition_variable>
+#include <cstdint>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -60,6 +61,16 @@ public:
         int         rotation_deg = 0;
     };
 
+    // A capture mode the sensor actually supports, as reported by libcamera.
+    // max_fps is 0 when unknown — the simple path leaves it 0 and lets libcamera
+    // clamp the requested rate; a future "probe each mode's FrameDurationLimits"
+    // pass can fill it in without changing this struct or supported_modes().
+    struct Mode {
+        int width   = 0;
+        int height  = 0;
+        int max_fps = 0;   // 0 = unknown (not yet probed)
+    };
+
     DmaCamera();
     ~DmaCamera();
 
@@ -98,8 +109,23 @@ public:
     bool  is_ok()           const { return ok_; }
     int   width()           const { return cfg_.width; }
     int   height()          const { return cfg_.height; }
+    int   fps()             const { return cfg_.fps; }
     const std::string& model_name() const { return cfg_.model_name; }
     float analogue_gain()   const { return last_analogue_gain_.load(); }
+
+    // Measured capture rate, derived from the per-frame FrameDuration metadata
+    // (0 until the first frame completes). Lets the menu show the real fps the
+    // sensor settled on rather than the requested target.
+    float measured_fps()    const {
+        int64_t us = last_frame_dur_us_.load();
+        return us > 0 ? 1.0e6f / static_cast<float>(us) : 0.0f;
+    }
+
+    // Resolutions this sensor reports for the negotiated pixel format, captured
+    // once during init(). Empty if init() hasn't run / the sensor reported none.
+    // Sorted largest-area first. Each DmaCamera is one physical sensor, so this
+    // is inherently per-camera.
+    const std::vector<Mode>& supported_modes() const { return modes_; }
 
     // Display rotation (0, 90, 180, 270 — snapped). Live-tunable from any
     // thread; the next draw() picks up the change via an atomic read.
@@ -199,6 +225,10 @@ private:
     std::atomic<int>   last_af_state_      { 0 };        // AfState enum value
     std::atomic<float> last_lens_pos_      { 0.0f };     // LensPosition diopters
     std::atomic<float> last_analogue_gain_ { 1.0f };     // AnalogueGain (1.0 = ISO100 equiv)
+    std::atomic<int64_t> last_frame_dur_us_ { 0 };       // FrameDuration µs (0 = no frame yet)
+
+    // Sensor-reported capture modes for the negotiated format (filled in init()).
+    std::vector<Mode> modes_;
 
     Config cfg_;
     bool   ok_ = false;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -228,6 +228,86 @@ static float pick_imu_heading(const AppState& s, int64_t now_us) {
     }
 }
 
+// ── Per-CSI-camera control persistence ────────────────────────────────────────
+// The menu writes AF/AE/WB/ISP/HDR controls straight onto the DmaCamera. These
+// helpers carry them through config: parse_* (config → state) and apply_* (state
+// → camera) run at startup; read_* (camera → state) + write_* (state → config)
+// run on save. State is the canonical persisted copy so a value survives even
+// when the camera is briefly absent.
+static void parse_cam_controls(const json& j, CameraControlsState& s) {
+    if (!j.is_object() || !j.contains("controls") || !j["controls"].is_object()) return;
+    const auto& c = j["controls"];
+    s.af_range        = c.value("af_range",         s.af_range);
+    s.af_speed        = c.value("af_speed",         s.af_speed);
+    s.gain            = c.value("gain",             s.gain);
+    s.ae_metering     = c.value("ae_metering",      s.ae_metering);
+    s.ae_constraint   = c.value("ae_constraint",    s.ae_constraint);
+    s.ae_exp_mode     = c.value("ae_exposure_mode", s.ae_exp_mode);
+    s.flicker         = c.value("flicker",          s.flicker);
+    s.awb_mode        = c.value("awb_mode",         s.awb_mode);
+    s.brightness      = c.value("brightness",       s.brightness);
+    s.contrast        = c.value("contrast",         s.contrast);
+    s.saturation      = c.value("saturation",       s.saturation);
+    s.sharpness       = c.value("sharpness",        s.sharpness);
+    s.noise_reduction = c.value("noise_reduction",  s.noise_reduction);
+    s.hdr             = c.value("hdr",              s.hdr);
+}
+
+static void write_cam_controls(json& j, const CameraControlsState& s) {
+    j["af_range"]         = s.af_range;
+    j["af_speed"]         = s.af_speed;
+    j["gain"]             = s.gain;
+    j["ae_metering"]      = s.ae_metering;
+    j["ae_constraint"]    = s.ae_constraint;
+    j["ae_exposure_mode"] = s.ae_exp_mode;
+    j["flicker"]          = s.flicker;
+    j["awb_mode"]         = s.awb_mode;
+    j["brightness"]       = s.brightness;
+    j["contrast"]         = s.contrast;
+    j["saturation"]       = s.saturation;
+    j["sharpness"]        = s.sharpness;
+    j["noise_reduction"]  = s.noise_reduction;
+    j["hdr"]              = s.hdr;
+}
+
+static void apply_cam_controls(DmaCamera* c, const CameraControlsState& s) {
+    if (!c) return;
+    c->set_af_range(s.af_range);
+    c->set_af_speed(s.af_speed);
+    if (s.gain > 0.0f) c->set_analogue_gain(s.gain);
+    c->set_ae_metering(s.ae_metering);
+    c->set_ae_constraint(s.ae_constraint);
+    c->set_ae_exposure_mode(s.ae_exp_mode);
+    c->set_flicker_mode(s.flicker);
+    // Only push a WB preset if one was actually chosen — set_awb_mode forces
+    // AWB on, which would override manual WB; default Auto (0) leaves it be.
+    if (s.awb_mode > 0) c->set_awb_mode(s.awb_mode);
+    c->set_brightness(s.brightness);
+    c->set_contrast(s.contrast);
+    c->set_saturation(s.saturation);
+    c->set_sharpness(s.sharpness);
+    c->set_noise_reduction(s.noise_reduction);
+    c->set_hdr_mode(s.hdr);
+}
+
+static void read_cam_controls(DmaCamera* c, CameraControlsState& s) {
+    if (!c) return;   // camera absent → keep the last-known (loaded) values
+    s.af_range        = c->af_range();
+    s.af_speed        = c->af_speed();
+    s.gain            = c->analogue_gain_target();
+    s.ae_metering     = c->ae_metering();
+    s.ae_constraint   = c->ae_constraint();
+    s.ae_exp_mode     = c->ae_exposure_mode();
+    s.flicker         = c->flicker_mode();
+    s.awb_mode        = c->awb_mode();
+    s.brightness      = c->brightness();
+    s.contrast        = c->contrast();
+    s.saturation      = c->saturation();
+    s.sharpness       = c->sharpness();
+    s.noise_reduction = c->noise_reduction();
+    s.hdr             = c->hdr_mode();
+}
+
 // Launch the panel_driver.py piomatter shim as a detached child. Used at
 // startup AND from the menu's backend hot-swap when switching back to HUB75.
 // fork()+setsid() (instead of `system("... &")`) so SIGINT to the parent
@@ -1308,6 +1388,7 @@ int main(int argc, char* argv[]) {
         owl_left.height       = jl.value("height",  800);
         owl_left.fps          = jl.value("fps",      60);
         owl_left.rotation_deg = jl.value("rotation_deg", 0);
+        parse_cam_controls(jl, state.camera_controls_left);
     }
     if (jcam.contains("owlsight_right")) {
         auto& jr               = jcam["owlsight_right"];
@@ -1317,6 +1398,7 @@ int main(int argc, char* argv[]) {
         owl_right.height       = jr.value("height",  800);
         owl_right.fps          = jr.value("fps",      60);
         owl_right.rotation_deg = jr.value("rotation_deg", 0);
+        parse_cam_controls(jr, state.camera_controls_right);
     }
     // Back-compat: older builds persisted a single top-level "resolution" block
     // that forced BOTH eyes to one value. Newer builds save per-eye under
@@ -2674,6 +2756,12 @@ int main(int argc, char* argv[]) {
         if (cameras.owl_right()) cameras.owl_right()->start_autofocus();
         std::cout << "[main] autofocus on startup\n";
     }
+
+    // Re-apply persisted per-eye AF/AE/WB/ISP/HDR controls now the cameras are
+    // running (the setters queue onto the next request). Done after the startup
+    // autofocus so a saved manual focus mode isn't immediately overridden.
+    apply_cam_controls(cameras.owl_left(),  state.camera_controls_left);
+    apply_cam_controls(cameras.owl_right(), state.camera_controls_right);
 
     // ── Beast built-in passthrough camera ────────────────────────────────────
 
@@ -4798,6 +4886,14 @@ int main(int argc, char* argv[]) {
         // block where the user already finds the rest of the per-eye config).
         cfg["cameras"]["owlsight_left"]["rotation_deg"]  = cameras.owl_left_rotation();
         cfg["cameras"]["owlsight_right"]["rotation_deg"] = cameras.owl_right_rotation();
+
+        // Per-eye AF/AE/WB/ISP/HDR controls. Refresh state from the live cameras
+        // (no-op if a camera is absent — the loaded values are kept), then write
+        // them under each camera's "controls" block.
+        read_cam_controls(cameras.owl_left(),  state.camera_controls_left);
+        read_cam_controls(cameras.owl_right(), state.camera_controls_right);
+        write_cam_controls(cfg["cameras"]["owlsight_left"]["controls"],  state.camera_controls_left);
+        write_cam_controls(cfg["cameras"]["owlsight_right"]["controls"], state.camera_controls_right);
 
         auto eye_src_str = [](EyeSource s) -> const char* {
             switch (s) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1318,7 +1318,10 @@ int main(int argc, char* argv[]) {
         owl_right.fps          = jr.value("fps",      60);
         owl_right.rotation_deg = jr.value("rotation_deg", 0);
     }
-    // Override both eyes from the persisted resolution section (set by in-app preset menu)
+    // Back-compat: older builds persisted a single top-level "resolution" block
+    // that forced BOTH eyes to one value. Newer builds save per-eye under
+    // owlsight_left/right and drop this block on save, so this only fires for
+    // configs written before per-camera resolution existed.
     if (cfg.contains("resolution")) {
         const auto& jres = cfg["resolution"];
         int w   = jres.value("width",  owl_left.width);
@@ -2118,10 +2121,13 @@ int main(int argc, char* argv[]) {
     if (!splash_cfg.image_path.empty() && splash_cfg.image_path[0] != '/')
         splash_cfg.image_path = res(splash_cfg.image_path);
 
-    // Seed resolution state from whatever the OWLsight config says
-    state.camera_resolution.width  = owl_left.width;
-    state.camera_resolution.height = owl_left.height;
-    state.camera_resolution.fps    = owl_left.fps;
+    // Seed per-eye resolution state from whatever each OWLsight config says
+    state.camera_resolution.width        = owl_left.width;
+    state.camera_resolution.height       = owl_left.height;
+    state.camera_resolution.fps          = owl_left.fps;
+    state.camera_resolution_right.width  = owl_right.width;
+    state.camera_resolution_right.height = owl_right.height;
+    state.camera_resolution_right.fps    = owl_right.fps;
 
     // ── Audio engine ──────────────────────────────────────────────────────────
 
@@ -4775,9 +4781,17 @@ int main(int argc, char* argv[]) {
             cfg["weather"]["interval_min"] = wc.interval_min;
         }
 
-        cfg["resolution"]["width"]  = state.camera_resolution.width;
-        cfg["resolution"]["height"] = state.camera_resolution.height;
-        cfg["resolution"]["fps"]    = state.camera_resolution.fps;
+        // Per-eye resolution lives under each camera's own block now. The legacy
+        // top-level "resolution" block (which forced BOTH eyes to one value) is
+        // retired on save so independent per-eye settings persist; the loader
+        // still honours it for back-compat with configs from older builds.
+        cfg["cameras"]["owlsight_left"]["width"]   = state.camera_resolution.width;
+        cfg["cameras"]["owlsight_left"]["height"]  = state.camera_resolution.height;
+        cfg["cameras"]["owlsight_left"]["fps"]     = state.camera_resolution.fps;
+        cfg["cameras"]["owlsight_right"]["width"]  = state.camera_resolution_right.width;
+        cfg["cameras"]["owlsight_right"]["height"] = state.camera_resolution_right.height;
+        cfg["cameras"]["owlsight_right"]["fps"]    = state.camera_resolution_right.fps;
+        cfg.erase("resolution");
 
         // Persist CSI display rotation so the in-app setting survives a
         // restart (rotation_deg lives next to the camera-id/width/height/fps
@@ -5712,6 +5726,7 @@ int main(int argc, char* argv[]) {
             snap.bt_devices         = state.bt_devices;
             snap.serial_metrics     = state.serial_metrics;
             snap.camera_resolution  = state.camera_resolution;
+            snap.camera_resolution_right = state.camera_resolution_right;
             snap.zoom_left          = state.zoom_left;
             snap.zoom_right         = state.zoom_right;
             snap.theater_mode       = state.theater_mode;
@@ -5898,8 +5913,11 @@ int main(int argc, char* argv[]) {
         // the camera's native aspect ratio. Black bars are filled by glClear().
         auto make_theater_vp = [&snap](int fw, int fh, bool right_eye) -> std::array<int,4> {
             using TA = AppState::TheaterAnchor;
-            float cam_ar  = (float)snap.camera_resolution.width
-                          / snap.camera_resolution.height;
+            // Each eye preserves its OWN camera aspect ratio (the eyes can run
+            // different resolutions now).
+            const auto& cam_res = right_eye ? snap.camera_resolution_right
+                                            : snap.camera_resolution;
+            float cam_ar  = (float)cam_res.width / cam_res.height;
             float disp_ar = (float)fw / fh;
             int vp_w, vp_h, vp_x, vp_y;
             if (cam_ar < disp_ar) {   // pillarbox: black left/right

--- a/src/menu/build_vision.cpp
+++ b/src/menu/build_vision.cpp
@@ -276,7 +276,9 @@ std::vector<MenuItem> build_vision_menu(MenuBuildContext& ctx)
                 if (!cameras) return;
                 if (cameras->set_resolution(w, h, fps)) {
                     std::lock_guard<std::mutex> lk(state.mtx);
-                    state.camera_resolution = { w, h, fps };
+                    // "Both eyes" shortcut — keep both per-eye states in sync.
+                    state.camera_resolution       = { w, h, fps };
+                    state.camera_resolution_right = { w, h, fps };
                 }
             },
             [&state, w = p.w, h = p.h]{ return state.camera_resolution.width == w && state.camera_resolution.height == h; }
@@ -324,7 +326,8 @@ std::vector<MenuItem> build_vision_menu(MenuBuildContext& ctx)
     auto make_cam_menu = [&](
         std::function<DmaCamera*()>     cam_ptr,
         CameraFocusState&               focus_st,
-        bool&                           awb_flag)
+        bool&                           awb_flag,
+        CameraResolutionState&          res_st)
     {
         std::vector<MenuItem> fm = {
             leaf_sel("Manual", [cameras, cam_ptr, &focus_st]{
@@ -377,19 +380,86 @@ std::vector<MenuItem> build_vision_menu(MenuBuildContext& ctx)
             rot_item("270\xc2\xb0 (Counterclockwise)", 270),
         };
 
+        // Resolution — built LIVE from this sensor's own reported modes, so any
+        // CSI camera shows valid options instead of a fixed preset list (the
+        // cause of "pick 1440p, nothing changes" on sensors that lack it).
+        // Selecting a mode requests the current target fps; libcamera clamps to
+        // what the sensor can do at that size, and the Current row shows the
+        // real measured fps. Per-camera, so each eye is set independently.
+        MenuItem res_status;
+        res_status.type     = MenuItemType::LEAF;
+        res_status.label    = "Current";
+        res_status.label_fn = [cam_ptr]{
+            auto* c = cam_ptr();
+            if (!c) return std::string("Current: (camera offline)");
+            char b[64];
+            snprintf(b, sizeof(b), "Current: %d x %d  @ %.0f fps",
+                     c->width(), c->height(), c->measured_fps());
+            return std::string(b);
+        };
+        res_status.action = []{};   // informational row
+
+        auto res_rows = make_dynamic_rows(16,
+            [cam_ptr]{ auto* c = cam_ptr();
+                       return c ? static_cast<int>(c->supported_modes().size()) : 0; },
+            [cam_ptr, &res_st, &state](int i) {
+                MenuItem m;
+                m.type     = MenuItemType::LEAF;
+                m.label    = "mode";
+                m.label_fn = [cam_ptr, i]{
+                    auto* c = cam_ptr(); if (!c) return std::string();
+                    const auto& ms = c->supported_modes();
+                    if (i >= static_cast<int>(ms.size())) return std::string();
+                    char b[32];
+                    snprintf(b, sizeof(b), "%d x %d", ms[i].width, ms[i].height);
+                    return std::string(b);
+                };
+                m.get_state = [cam_ptr, i]{
+                    auto* c = cam_ptr(); if (!c) return false;
+                    const auto& ms = c->supported_modes();
+                    return i < static_cast<int>(ms.size())
+                        && c->width()  == ms[i].width
+                        && c->height() == ms[i].height;
+                };
+                m.action = [cam_ptr, &res_st, &state, i]{
+                    auto* c = cam_ptr(); if (!c) return;
+                    const auto& ms = c->supported_modes();
+                    if (i >= static_cast<int>(ms.size())) return;
+                    // reconfigure() runs on the render thread (menu actions do),
+                    // matching how the global preset calls set_resolution().
+                    if (c->reconfigure(ms[i].width, ms[i].height, c->fps())) {
+                        std::lock_guard<std::mutex> lk(state.mtx);
+                        res_st.width  = c->width();
+                        res_st.height = c->height();
+                        res_st.fps    = c->fps();
+                    }
+                };
+                return m;
+            });
+
+        std::vector<MenuItem> resm;
+        resm.push_back(std::move(res_status));
+        for (auto& r : res_rows) resm.push_back(std::move(r));
+
         return std::vector<MenuItem>{
             submenu("Focus",          std::move(fm)),
             submenu("White Balance",  std::move(wbm)),
             submenu("Rotation",       std::move(rm)),
+            with_desc(submenu("Resolution", std::move(resm)),
+                "Set THIS camera's capture resolution from the modes the sensor "
+                "actually reports. fps follows the camera's limit at that size; "
+                "the Current row shows the real measured rate."),
         };
     };
 
     auto left_cam_menu  = make_cam_menu(
         [cameras]{ return cameras ? cameras->owl_left()  : nullptr; },
-        state.focus_left,  state.night_vision.csi_awb_left);
+        state.focus_left,  state.night_vision.csi_awb_left,
+        state.camera_resolution);
     auto right_cam_menu = make_cam_menu(
         [cameras]{ return cameras ? cameras->owl_right() : nullptr; },
-        state.focus_right, state.night_vision.csi_awb_right);
+        state.focus_right, state.night_vision.csi_awb_right,
+        state.camera_resolution_right);
 
     // ── Digital zoom presets (both eyes together) ─────────────────────────────
     struct ZoomPreset { const char* label; float zoom; };

--- a/src/menu/build_vision.cpp
+++ b/src/menu/build_vision.cpp
@@ -11,6 +11,8 @@
 #include <set>
 #include <string>
 #include <thread>
+#include <utility>
+#include <vector>
 #include <chrono>
 #include <cfloat>
 #include <cmath>
@@ -329,6 +331,30 @@ std::vector<MenuItem> build_vision_menu(MenuBuildContext& ctx)
         bool&                           awb_flag,
         CameraResolutionState&          res_st)
     {
+        // Helpers for the extended controls: a radio-list submenu bound to a
+        // DmaCamera int setter/getter, and a slider bound to a float one. Menu
+        // values match libcamera's enum numbers so they pass straight through.
+        auto enum_sub = [cam_ptr](std::vector<std::pair<std::string,int>> opts,
+                                  std::function<void(DmaCamera*,int)> set,
+                                  std::function<int(DmaCamera*)>      get) {
+            std::vector<MenuItem> v;
+            for (auto& o : opts) {
+                int val = o.second;
+                v.push_back(leaf_sel(o.first,
+                    [cam_ptr, set, val]{ if (auto* c = cam_ptr()) set(c, val); },
+                    [cam_ptr, get, val]{ auto* c = cam_ptr(); return c && get(c) == val; }));
+            }
+            return v;
+        };
+        auto fslider = [cam_ptr](std::string lbl, float mn, float mx, float st,
+                                 std::string unit,
+                                 std::function<void(DmaCamera*,float)> set,
+                                 std::function<float(DmaCamera*)>      get) {
+            return slider(std::move(lbl), mn, mx, st, std::move(unit),
+                [cam_ptr, get]{ auto* c = cam_ptr(); return c ? get(c) : 0.f; },
+                [cam_ptr, set](float v){ if (auto* c = cam_ptr()) set(c, v); });
+        };
+
         std::vector<MenuItem> fm = {
             leaf_sel("Manual", [cameras, cam_ptr, &focus_st]{
                 focus_st.mode = CameraFocusState::Mode::MANUAL;
@@ -353,6 +379,16 @@ std::vector<MenuItem> build_vision_menu(MenuBuildContext& ctx)
                 }),
         };
 
+        // AF range/speed live alongside the focus mode (PDAF sensors only).
+        fm.push_back(submenu("AF Range", enum_sub(
+            {{"Normal", 0}, {"Macro", 1}, {"Full", 2}},
+            [](DmaCamera* c, int v){ c->set_af_range(v); },
+            [](DmaCamera* c){ return c->af_range(); })));
+        fm.push_back(submenu("AF Speed", enum_sub(
+            {{"Normal", 0}, {"Fast", 1}},
+            [](DmaCamera* c, int v){ c->set_af_speed(v); },
+            [](DmaCamera* c){ return c->af_speed(); })));
+
         std::vector<MenuItem> wbm;
         wbm.push_back(toggle("Auto WB",
             [&awb_flag]{ return awb_flag; },
@@ -360,6 +396,13 @@ std::vector<MenuItem> build_vision_menu(MenuBuildContext& ctx)
                 awb_flag = v;
                 if (auto* c = cam_ptr()) c->set_awb_enable(v);
             }));
+        // Preset illuminant modes (ISP picks the gains) — alt to the manual
+        // Kelvin presets below.
+        wbm.push_back(submenu("AWB Mode", enum_sub(
+            {{"Auto", 0}, {"Daylight", 5}, {"Cloudy", 6}, {"Incandescent", 1},
+             {"Tungsten", 2}, {"Fluorescent", 3}, {"Indoor", 4}},
+            [](DmaCamera* c, int v){ c->set_awb_mode(v); },
+            [](DmaCamera* c){ return c->awb_mode(); })));
         for (const auto& p : WB_PRESETS)
             wbm.push_back(leaf(p.label, [cam_ptr, k = p.k]{
                 if (auto* c = cam_ptr()) c->set_colour_temp(k);
@@ -441,9 +484,66 @@ std::vector<MenuItem> build_vision_menu(MenuBuildContext& ctx)
         resm.push_back(std::move(res_status));
         for (auto& r : res_rows) resm.push_back(std::move(r));
 
+        // ── Exposure (AE tuning + manual gain) ────────────────────────────────
+        std::vector<MenuItem> expm = {
+            submenu("Metering", enum_sub(
+                {{"Centre-Weighted", 0}, {"Spot", 1}, {"Matrix", 2}},
+                [](DmaCamera* c, int v){ c->set_ae_metering(v); },
+                [](DmaCamera* c){ return c->ae_metering(); })),
+            submenu("Constraint", enum_sub(
+                {{"Normal", 0}, {"Highlight", 1}, {"Shadows", 2}},
+                [](DmaCamera* c, int v){ c->set_ae_constraint(v); },
+                [](DmaCamera* c){ return c->ae_constraint(); })),
+            submenu("Exposure Profile", enum_sub(
+                {{"Normal", 0}, {"Short", 1}, {"Long", 2}},
+                [](DmaCamera* c, int v){ c->set_ae_exposure_mode(v); },
+                [](DmaCamera* c){ return c->ae_exposure_mode(); })),
+            submenu("Anti-Flicker", enum_sub(
+                {{"Off", 0}, {"Auto", 1}, {"50 Hz", 2}, {"60 Hz", 3}},
+                [](DmaCamera* c, int v){ c->set_flicker_mode(v); },
+                [](DmaCamera* c){ return c->flicker_mode(); })),
+            with_desc(fslider("Manual Gain", 0.f, 16.f, 0.5f, "x",
+                [](DmaCamera* c, float v){ c->set_analogue_gain(v); },
+                [](DmaCamera* c){ return c->analogue_gain_target(); }),
+                "Manual sensor (analogue) gain. 0 = leave on auto. Takes effect "
+                "with auto-exposure off (set a manual Shutter Speed)."),
+        };
+
+        // ── Image (ISP tuning) ────────────────────────────────────────────────
+        std::vector<MenuItem> imgm = {
+            fslider("Brightness", -1.f, 1.f, 0.1f, "",
+                [](DmaCamera* c, float v){ c->set_brightness(v); },
+                [](DmaCamera* c){ return c->brightness(); }),
+            fslider("Contrast", 0.f, 2.f, 0.1f, "",
+                [](DmaCamera* c, float v){ c->set_contrast(v); },
+                [](DmaCamera* c){ return c->contrast(); }),
+            fslider("Saturation", 0.f, 2.f, 0.1f, "",
+                [](DmaCamera* c, float v){ c->set_saturation(v); },
+                [](DmaCamera* c){ return c->saturation(); }),
+            fslider("Sharpness", 0.f, 2.f, 0.1f, "",
+                [](DmaCamera* c, float v){ c->set_sharpness(v); },
+                [](DmaCamera* c){ return c->sharpness(); }),
+            submenu("Noise Reduction", enum_sub(
+                {{"Off", 0}, {"Fast", 1}, {"High Quality", 2}, {"Minimal", 3}},
+                [](DmaCamera* c, int v){ c->set_noise_reduction(v); },
+                [](DmaCamera* c){ return c->noise_reduction(); })),
+        };
+
+        // ── HDR (on-sensor; IMX708 / Camera Module 3) ─────────────────────────
+        auto hdrm = enum_sub(
+            {{"Off", 0}, {"Single Exposure", 3}, {"Multi Exposure", 2}, {"Night", 4}},
+            [](DmaCamera* c, int v){ c->set_hdr_mode(v); },
+            [](DmaCamera* c){ return c->hdr_mode(); });
+
         return std::vector<MenuItem>{
             submenu("Focus",          std::move(fm)),
+            submenu("Exposure",       std::move(expm)),
             submenu("White Balance",  std::move(wbm)),
+            submenu("Image",          std::move(imgm)),
+            with_desc(submenu("HDR",  std::move(hdrm)),
+                "On-sensor HDR (IMX708 / Camera Module 3). Needs a recent "
+                "libcamera that exposes HdrMode at runtime; on sensors that "
+                "don't, the options are a no-op."),
             submenu("Rotation",       std::move(rm)),
             with_desc(submenu("Resolution", std::move(resm)),
                 "Set THIS camera's capture resolution from the modes the sensor "


### PR DESCRIPTION
## Summary

Makes the CSI camera controls work with any sensor (not just the OWLsight defaults) and exposes the full libcamera control surface, per eye, with persistence. Motivated by testing on an Arducam Camera Module 3 Wide NoIR (IMX708).

### 1. Per-camera resolution from the sensor's real modes
The resolution menu offered a fixed preset list and libcamera silently clamps anything the sensor can't do — so on a different CSI camera you'd pick a mode and nothing changed.
- `DmaCamera` now enumerates the sensor's actual supported sizes during configure (`formats().sizes()` for the negotiated pixel format), cached in `supported_modes()`. Adds `fps()` and `measured_fps()` (from per-frame `FrameDuration`).
- `Cameras → Left/Right Camera → Resolution` is built live from each camera's own modes, with a **Current** row showing the real measured fps. Each eye is independent; the global "both eyes" preset stays as a shortcut. `make_theater_vp` uses each eye's own aspect ratio.
- Resolution persists per-eye under `cameras.owlsight_left/right`; the legacy top-level `resolution` block (forced both eyes equal) is retired on save and still honored on load.

### 2. Full control set
All follow the existing `pending_*`/`apply_pending_controls` atomic pattern, each guarded by `controls().count()` so unsupported controls are silent no-ops.
- **AF:** Range (Normal/Macro/Full), Speed (Normal/Fast)
- **AE:** manual AnalogueGain, Metering, Constraint, Exposure mode, Anti-Flicker (Off/Auto/50/60 Hz)
- **WB:** preset illuminant modes (alongside manual gains/Kelvin)
- **ISP:** Brightness, Contrast, Saturation, Sharpness, Noise Reduction
- **HDR:** Off / Single / Multi / Night (IMX708 / Camera Module 3)

Menu gains Exposure, Image, and HDR submenus, plus AF Range/Speed under Focus and AWB Mode under White Balance. Menu enum values match libcamera's numeric enums so they pass straight through.

### 3. Persistence
All ~14 controls round-trip per eye through `cameras.owlsight_left/right.controls`: parsed on load, applied once the cameras are capturing, read back from the live cameras on save. `config.example.json` documents the block and enum meanings.

## Notes / caveats
- **Not yet compiled** — developed without libcamera available, so verified by review (JSON validates, braces/parens balance, helpers defined before use). Needs a build on the CM5.
- `HdrMode` / `AeFlickerMode` require **libcamera ≥ 0.1** (Bookworm 2023+); on older headers those identifiers won't exist.
- Manual gain only takes effect with auto-exposure off; HDR may only engage on certain sensor modes.

## Test plan
- [ ] Build on the CM5 (flag any errors around `HdrMode`/`AeFlickerMode`/`controls::` names).
- [ ] Verify the per-eye Resolution list reflects the actual sensor modes and the Current row shows real fps.
- [ ] Exercise each control on the IMX708 and confirm it survives a restart.

## Follow-up
- `Mode` carries a `max_fps` field (0 = unknown) so the in-depth option — probing each mode's `FrameDurationLimits` to offer only achievable rates per size — can be added without changing the struct or menu shape.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lqn4JdAw8cF61zQTZdbrVM)_