### PR TITLE
Pin-in-space (head-locked) Android overlay

### DIFF
--- a/src/app_state.h
+++ b/src/app_state.h
@@ -52,6 +52,18 @@ struct OverlayConfig {
     float    size     = 0.25f;  // fraction of screen height
     enum class Rotation { Landscape = 0, Portrait, LandscapeFlipped, PortraitFlipped };
     Rotation rotation = Rotation::Landscape;
+
+    // World-lock ("pin in space"): when enabled the overlay is positioned by the
+    // head IMU (AppState::imu_pose) instead of anchor_x/anchor_y, so it appears
+    // fixed in space as you look around. lock_yaw/lock_pitch are the forward
+    // direction captured when pinned; recenter_request asks the render loop to
+    // re-capture the current head pose. lock_invert_* correct a mirrored IMU axis.
+    bool  world_locked       = false;
+    bool  recenter_request   = false;
+    float lock_yaw           = 0.f;
+    float lock_pitch         = 0.f;
+    bool  lock_invert_yaw    = false;
+    bool  lock_invert_pitch  = false;
 };
 
 // ── Sub-states ────────────────────────────────────────────────────────────────

--- a/src/hud/head_lock.h
+++ b/src/hud/head_lock.h
@@ -1,0 +1,47 @@
+#pragma once
+// ── head_lock.h ───────────────────────────────────────────────────────────────
+// World-locking ("pin in space") math for HUD overlays, driven by the VITURE
+// glasses' built-in head IMU (AppState::imu_pose). A point pinned to a forward
+// direction (anchor_yaw, anchor_pitch) is re-projected to a screen-pixel offset
+// each frame as the head turns, so the overlay appears fixed in space.
+//
+// Uses the same pinhole model as the timewarp reprojection: a ray at angle θ
+// from the optical axis lands at fx·tan(θ) pixels. fx/fy are the display focal
+// lengths in pixels (the timewarp CameraIntrinsics — fx = fy = 1920 on VITURE).
+
+#include "../app_state.h"   // ImuPose, ImVec2 (via imgui.h)
+#include <cmath>
+
+namespace headlock {
+
+// Wrap a degree delta into [-180, 180] so yaw wrap-around (359°→1°) is smooth.
+inline float wrap180(float d) {
+    d = std::fmod(d + 180.f, 360.f);
+    if (d < 0.f) d += 360.f;
+    return d - 180.f;
+}
+
+// Pixel offset (from screen centre) at which a point world-locked to
+// (anchor_yaw, anchor_pitch) should be drawn for the current head pose.
+// invert_* flips the axis if the IMU sign is mirrored relative to the display
+// (tunable from the menu so it can be corrected without a recompile).
+inline ImVec2 screen_offset(float cur_yaw,   float cur_pitch,
+                            float anchor_yaw, float anchor_pitch,
+                            float fx, float fy,
+                            bool invert_yaw = false, bool invert_pitch = false) {
+    float dyaw   = wrap180(anchor_yaw   - cur_yaw);
+    float dpitch = wrap180(anchor_pitch - cur_pitch);
+    if (invert_yaw)   dyaw   = -dyaw;
+    if (invert_pitch) dpitch = -dpitch;
+
+    // Clamp near ±90° so tan() can't explode when looking far off-axis.
+    const float lim = 85.f;
+    if (dyaw   >  lim) dyaw   =  lim; else if (dyaw   < -lim) dyaw   = -lim;
+    if (dpitch >  lim) dpitch =  lim; else if (dpitch < -lim) dpitch = -lim;
+
+    const float r = 3.14159265358979f / 180.f;
+    return ImVec2( fx * std::tan(dyaw   * r),     // turn head right → point slides left
+                  -fy * std::tan(dpitch * r) );   // look up → point slides down
+}
+
+}  // namespace headlock

--- a/src/hud/hud_renderer.cpp
+++ b/src/hud/hud_renderer.cpp
@@ -1,5 +1,6 @@
 #include "hud_renderer.h"
 #include "../serial/shm_frame_reader.h"
+#include "head_lock.h"
 
 #include <imgui.h>
 #include <imgui_impl_glfw.h>
@@ -2051,7 +2052,9 @@ void HudRenderer::draw_pip(unsigned int /*tex*/, const char* /*label*/,
 void HudRenderer::draw_android_overlay(unsigned int tex, int w, int h,
                                         bool active, bool connecting,
                                         const OverlayConfig& cfg,
-                                        float frame_aspect) {
+                                        float frame_aspect,
+                                        const ImuPose& head_pose,
+                                        float fx, float fy) {
     if (!active) return;
 
     ImGui::SetCurrentContext(ctx_);
@@ -2061,7 +2064,17 @@ void HudRenderer::draw_android_overlay(unsigned int tex, int w, int h,
     const float ov_h   = sh * cfg.size;
     const float ov_w   = ov_h * frame_aspect;
     const float margin = static_cast<float>(cfg_.compass_height);
-    const auto  pos    = overlay_origin(cfg, sw, sh, ov_w, ov_h, margin);
+    ImVec2 pos;
+    if (cfg.world_locked) {
+        // Pinned in space: position by the head IMU instead of the screen anchor.
+        const ImVec2 off = headlock::screen_offset(
+            head_pose.yaw, head_pose.pitch, cfg.lock_yaw, cfg.lock_pitch,
+            fx, fy, cfg.lock_invert_yaw, cfg.lock_invert_pitch);
+        pos = ImVec2(sw * 0.5f - ov_w * 0.5f + off.x,
+                     sh * 0.5f - ov_h * 0.5f + off.y);
+    } else {
+        pos = overlay_origin(cfg, sw, sh, ov_w, ov_h, margin);
+    }
 
     ImGui::SetNextWindowPos ({0.f, 0.f});
     ImGui::SetNextWindowSize({sw,  sh });

--- a/src/hud/hud_renderer.h
+++ b/src/hud/hud_renderer.h
@@ -142,7 +142,9 @@ public:
     // Build Android mirror overlay (ImGui pass).
     void draw_android_overlay(unsigned int tex, int w, int h,
                               bool active, bool connecting, const OverlayConfig& cfg,
-                              float frame_aspect = 9.f / 16.f);
+                              float frame_aspect = 9.f / 16.f,
+                              const ImuPose& head_pose = {}, float fx = 1920.f,
+                              float fy = 1920.f);
 
     // Draw floating panel preview (ImGui pass). Positioned like the camera PiPs:
     // anchor_x/anchor_y are screen fractions (0=left/top .. 1=right/bottom),

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6423,12 +6423,21 @@ int main(int argc, char* argv[]) {
             menu_dup = true;
         }
 
+        // Pinned-in-space ("world-lock") overlay: when a recenter is requested,
+        // capture the current head pose as the forward anchor. Then feed the live
+        // head pose + display focal lengths so the overlay tracks as you look around.
+        if (android_overlay_cfg.recenter_request) {
+            android_overlay_cfg.lock_yaw   = snap.imu_pose.yaw;
+            android_overlay_cfg.lock_pitch = snap.imu_pose.pitch;
+            android_overlay_cfg.recenter_request = false;
+        }
         hud.draw_android_overlay(tex_android,
                                   xr.eye_width(), xr.eye_height(),
                                   android_overlay_active,
                                   android_mirror.is_running() && !android_mirror.is_connected(),
                                   android_overlay_cfg,
-                                  android_mirror.frame_aspect());
+                                  android_mirror.frame_aspect(),
+                                  snap.imu_pose, K.fx, K.fy);
 
         // Protoface LED preview (top-right corner, above popups). Source
         // depends on backend: HUB75 + daemon mode go through the shm reader

--- a/src/menu/build_vision.cpp
+++ b/src/menu/build_vision.cpp
@@ -1570,6 +1570,24 @@ std::vector<MenuItem> build_vision_menu(MenuBuildContext& ctx)
             [android_overlay](bool v){ *android_overlay = v; }),
         submenu("Position", make_position_items(android_cfg)),
         make_size_slider("Size", android_cfg),
+        // Pin the overlay in space (head-locked): it stays fixed in the world as
+        // you look around, driven by the VITURE head IMU. Enabling also recenters
+        // it in front of you. Invert toggles fix a mirrored IMU axis on-device.
+        submenu("Pin In Space", std::vector<MenuItem>{
+            toggle("Pinned",
+                [android_cfg]{ return android_cfg->world_locked; },
+                [android_cfg](bool v){
+                    android_cfg->world_locked = v;
+                    if (v) android_cfg->recenter_request = true;
+                }),
+            leaf("Recenter Here", [android_cfg]{ android_cfg->recenter_request = true; }),
+            toggle("Invert Yaw",
+                [android_cfg]{ return android_cfg->lock_invert_yaw; },
+                [android_cfg](bool v){ android_cfg->lock_invert_yaw = v; }),
+            toggle("Invert Pitch",
+                [android_cfg]{ return android_cfg->lock_invert_pitch; },
+                [android_cfg](bool v){ android_cfg->lock_invert_pitch = v; }),
+        }),
     };
 
     // ── Vision Assist (post-processing depth cues) ────────────────────────────


### PR DESCRIPTION
Stage 1 of head tracking: the Android mirror overlay can be **pinned in world space**, driven by the VITURE glasses' built-in head IMU (`imu_pose`). When pinned, it stays fixed in space as you look around instead of being glued to the screen.

## How it works
A point pinned to a forward direction is reprojected to a screen-pixel offset each frame using the same pinhole intrinsics as the timewarp reprojection (`fx`/`fy` ≈ 1920 px): `offset = fx·tan(Δyaw)`, `−fy·tan(Δpitch)`. No new hardware — reuses the head IMU already feeding timewarp.

## Changes
- **`head_lock.h`** — pure angle→pixel reprojection helper, with yaw wrap-around, ±85° clamping, and per-axis invert.
- **`OverlayConfig`** — `world_locked`, `lock_yaw`, `lock_pitch`, `recenter_request`, `lock_invert_yaw`, `lock_invert_pitch`.
- **`draw_android_overlay`** — positions from the head pose when pinned, screen anchor otherwise; render loop captures the head pose on recenter and feeds `fx`/`fy`.
- **Menu** — Vision → Android → **Pin In Space**: `Pinned` / `Recenter Here` / `Invert Yaw` / `Invert Pitch`.

## Testing notes (on-device)
- The IMU yaw/pitch sign convention isn't verified against the display; if the overlay tracks the wrong way, flip **Invert Yaw**/**Invert Pitch** from the menu (no recompile).
- Pin/invert state is runtime-only (not persisted) for now.

## Not in this PR (Stage 2)
Head-gaze reticle + selection (controller button / dwell / boop sensor) — best tuned on the glasses.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lqn4JdAw8cF61zQTZdbrVM)_